### PR TITLE
Add logging for unknown base types

### DIFF
--- a/fit_tool/gen/profile.py
+++ b/fit_tool/gen/profile.py
@@ -1,3 +1,4 @@
+import logging
 import os.path
 
 from openpyxl import load_workbook
@@ -5,6 +6,8 @@ from openpyxl import load_workbook
 from fit_tool import SDK_VERSION
 from fit_tool.base_type import FieldType, BaseType
 from fit_tool.field import Field, ArrayType
+
+logger = logging.getLogger(__name__)
 
 
 class Message:
@@ -138,9 +141,7 @@ class Profile:
                 # it.
                 type_base_type = BaseType.from_name(type_base_type_name)
                 if not type_base_type:
-                    # TODO: add proper logging
-                    print(
-                        'Warning: Unknown base_type {}'.format(type_base_type))
+                    logger.warning('Unknown base_type: %s', type_base_type_name)
                     continue
                 current_type = FieldType(type_name, type_base_type)
                 profile.add_type(current_type)


### PR DESCRIPTION
Replaced the `print` statement with `logger.warning` in `fit_tool/gen/profile.py` to properly log unknown base types.
Corrected the logged variable to `type_base_type_name` to provide useful information instead of `None`.
Implemented standard logging pattern using `logging.getLogger(__name__)`.

---
*PR created automatically by Jules for task [12499612174913297084](https://jules.google.com/task/12499612174913297084) started by @shaonianche*