### PR TITLE
Refactor Field class to accept type_ in constructor

### DIFF
--- a/fit_tool/field.py
+++ b/fit_tool/field.py
@@ -4,7 +4,7 @@ from typing import Dict as dict
 from typing import List as list
 from typing import Optional
 
-from fit_tool.base_type import BaseType
+from fit_tool.base_type import BaseType, FieldType
 from fit_tool.endian import Endian
 from fit_tool.field_component import FieldComponent
 from fit_tool.field_definition import FieldDefinition
@@ -32,7 +32,8 @@ class Field:
                  type_name: str = '',
                  ref_field_map: dict = None,
                  array_type: ArrayType = None,
-                 array_fixed_length: int = None):
+                 array_fixed_length: int = None,
+                 field_type: FieldType = None):
 
         self.field_id = field_id
         self.name = name
@@ -50,6 +51,7 @@ class Field:
         self.ref_field_map = ref_field_map
         self.array_type = array_type
         self.array_fixed_length = array_fixed_length
+        self.type_ = field_type
 
         self.encoded_values = [None for _ in range(Field.get_length_from_size(base_type, size))]
 
@@ -59,7 +61,8 @@ class Field:
                       scale=other.scale, units=other.units, is_accumulated=other.is_accumulated,
                       is_expanded_field=other.is_expanded_field, sub_fields=other.sub_fields,
                       components=other.components,
-                      size=other.size, growable=other.growable, type_name=other.type_name)
+                      size=other.size, growable=other.growable, type_name=other.type_name,
+                      field_type=getattr(other, 'type_', None))
         field.encoded_values = other.encoded_values
         return field
 

--- a/fit_tool/field.py
+++ b/fit_tool/field.py
@@ -33,7 +33,7 @@ class Field:
                  ref_field_map: dict = None,
                  array_type: ArrayType = None,
                  array_fixed_length: int = None,
-                 field_type: FieldType = None):
+                 type_: FieldType = None):
 
         self.field_id = field_id
         self.name = name
@@ -51,7 +51,7 @@ class Field:
         self.ref_field_map = ref_field_map
         self.array_type = array_type
         self.array_fixed_length = array_fixed_length
-        self.type_ = field_type
+        self.type_ = type_
 
         self.encoded_values = [None for _ in range(Field.get_length_from_size(base_type, size))]
 
@@ -62,7 +62,7 @@ class Field:
                       is_expanded_field=other.is_expanded_field, sub_fields=other.sub_fields,
                       components=other.components,
                       size=other.size, growable=other.growable, type_name=other.type_name,
-                      field_type=getattr(other, 'type_', None))
+                      type_=getattr(other, 'type_', None))
         field.encoded_values = other.encoded_values
         return field
 

--- a/fit_tool/gen/profile.py
+++ b/fit_tool/gen/profile.py
@@ -268,11 +268,9 @@ class Profile:
                                               ref_field_map=ref_field_map,
                                               type_name=field_type_name,
                                               array_type=array_type,
-                                              array_fixed_length=array_fixed_length
+                                              array_fixed_length=array_fixed_length,
+                                              field_type=type_
                                               )
-
-                    # todo: hack for now, should add to class
-                    field_or_subfield.type_ = type_
 
                     is_field = field_id is not None
 

--- a/fit_tool/gen/profile.py
+++ b/fit_tool/gen/profile.py
@@ -269,7 +269,7 @@ class Profile:
                                               type_name=field_type_name,
                                               array_type=array_type,
                                               array_fixed_length=array_fixed_length,
-                                              field_type=type_
+                                              type_=type_
                                               )
 
                     is_field = field_id is not None


### PR DESCRIPTION
Moved `type_` assignment to `Field` constructor to cleanup technical debt.

---
*PR created automatically by Jules for task [16951162587970221993](https://jules.google.com/task/16951162587970221993) started by @shaonianche*