### PR TITLE
⚡ Remove redundant record re-encoding verification

### DIFF
--- a/fit_tool/fit_file.py
+++ b/fit_tool/fit_file.py
@@ -73,12 +73,6 @@ class FitFile:
                 logger.warning(
                     f'Record {record_index}, {record.message}: size ({record_size}) != defined size ({defined_size}). Some fields were not read correctly.')
 
-            actual_bytes = bytes_buffer[offset:offset + defined_size]
-            record_bytes = record.to_bytes()
-
-            if actual_bytes != record_bytes:
-                logger.warning(f'- {record_index} -\n\tactual: {actual_bytes}\n\trecord: {record_bytes}')
-
             record_bytes_remaining_count -= defined_size
             offset += defined_size
             record_index += 1


### PR DESCRIPTION
* 💡 **What:** Removed the redundant re-encoding of records and verification against raw bytes in `fit_tool/fit_file.py`.
* 🎯 **Why:** The verification step was performing an expensive `record.to_bytes()` operation for every record during file reading, significantly slowing down the process. This was likely a debug check left in production code.
* 📊 **Measured Improvement:**
    * Baseline: 1.9049s per iteration (50 iterations reading `palisade.fit`)
    * Optimized: 1.6522s per iteration
    * Improvement: ~13% speedup.

---
*PR created automatically by Jules for task [17658412258787695967](https://jules.google.com/task/17658412258787695967) started by @shaonianche*