### PR TITLE
Add proper logging for unknown base types in profile generation

### DIFF
--- a/fit_tool/gen/profile.py
+++ b/fit_tool/gen/profile.py
@@ -5,6 +5,7 @@ from openpyxl import load_workbook
 from fit_tool import SDK_VERSION
 from fit_tool.base_type import FieldType, BaseType
 from fit_tool.field import Field, ArrayType
+from fit_tool.utils.logging import logger
 
 
 class Message:
@@ -138,9 +139,8 @@ class Profile:
                 # it.
                 type_base_type = BaseType.from_name(type_base_type_name)
                 if not type_base_type:
-                    # TODO: add proper logging
-                    print(
-                        'Warning: Unknown base_type {}'.format(type_base_type))
+                    logger.warning(
+                        'Unknown base_type {}'.format(type_base_type_name))
                     continue
                 current_type = FieldType(type_name, type_base_type)
                 profile.add_type(current_type)

--- a/fit_tool/gen/profile.py
+++ b/fit_tool/gen/profile.py
@@ -139,8 +139,7 @@ class Profile:
                 # it.
                 type_base_type = BaseType.from_name(type_base_type_name)
                 if not type_base_type:
-                    logger.warning(
-                        'Unknown base_type {}'.format(type_base_type_name))
+                    logger.warning(f'Unknown base_type {type_base_type_name}')
                     continue
                 current_type = FieldType(type_name, type_base_type)
                 profile.add_type(current_type)


### PR DESCRIPTION
Replaced a `print` statement with `logger.warning` in `fit_tool/gen/profile.py` when encountering an unknown base type. The original code was printing `type_base_type` which was guaranteed to be `None` in that block. The new implementation logs `type_base_type_name` instead, providing useful information.

Verified the change with a temporary test case that mocked `openpyxl.load_workbook` to inject an unknown base type and asserted that the correct warning was logged. Ran all existing tests to ensure no regressions.


---
*PR created automatically by Jules for task [13827787556981614391](https://jules.google.com/task/13827787556981614391) started by @shaonianche*