### PR TITLE
SHA-3: fix P0 local_id and FLOAT encoding

### DIFF
--- a/fit_tool/field.py
+++ b/fit_tool/field.py
@@ -227,11 +227,15 @@ class Field:
         if index < 0:
             return
 
-        # None is the public representation of a FIT invalid value for floating-point fields.
-        if check_validity and self.base_type != BaseType.STRING and encoded_value is not None:
-            if not self.base_type.is_valid(encoded_value):
+        # None is only a valid encoded form for floating-point fields (FIT invalid bit pattern).
+        # Integer/enum fields must keep rejecting None at the setter so they cannot enter an
+        # unserializable state that only fails later in to_bytes().
+        if check_validity and self.base_type != BaseType.STRING:
+            is_float_invalid = encoded_value is None and self.base_type.is_float()
+            if not is_float_invalid and not self.base_type.is_valid(encoded_value):
                 raise ValueError(
-                    f'{self.name} encoded value {encoded_value} is not in valid range [{self.base_type.min}, {self.base_type.max}]')
+                    f'{self.name} encoded value {encoded_value} is not in valid range '
+                    f'[{self.base_type.min}, {self.base_type.max}]')
 
         size_changed = False
         while index >= self.length:

--- a/fit_tool/field.py
+++ b/fit_tool/field.py
@@ -227,7 +227,8 @@ class Field:
         if index < 0:
             return
 
-        if check_validity and self.base_type != BaseType.STRING:
+        # None is the public representation of a FIT invalid value for floating-point fields.
+        if check_validity and self.base_type != BaseType.STRING and encoded_value is not None:
             if not self.base_type.is_valid(encoded_value):
                 raise ValueError(
                     f'{self.name} encoded value {encoded_value} is not in valid range [{self.base_type.min}, {self.base_type.max}]')
@@ -254,17 +255,28 @@ class Field:
             return value
 
         if value is None:
-            encoded_value = self.base_type.invalid_raw_value()
-        else:
-            scale = self.get_scale(sub_field=sub_field)
-            offset = self.get_offset(sub_field=sub_field)
-            if isinstance(value, Enum):
-                encoded_value = value.value
-            elif (scale is None or scale == 1.0) and (offset is None or offset == 0.0):
-                encoded_value = int(value)
-            else:
-                encoded_value = self.scale_offset_value(value, scale, offset)
-        return encoded_value
+            # Float invalid values are represented as None until packed to the FIT bit pattern.
+            # Integer/enum types keep the protocol invalid raw integer for encoding.
+            if self.base_type.is_float():
+                return None
+            return self.base_type.invalid_raw_value()
+
+        scale = self.get_scale(sub_field=sub_field)
+        offset = self.get_offset(sub_field=sub_field)
+        if isinstance(value, Enum):
+            return value.value
+
+        if self.base_type.is_float():
+            if (scale is None or scale == 1.0) and (offset is None or offset == 0.0):
+                return float(value)
+            scale = scale if scale is not None else 1.0
+            offset = offset if offset is not None else 0.0
+            return (float(value) + offset) * scale
+
+        if (scale is None or scale == 1.0) and (offset is None or offset == 0.0):
+            return int(value)
+
+        return self.scale_offset_value(value, scale, offset)
 
     def read_all_from_bytes(self, bytes_buffer: bytes, endian: Endian = Endian.LITTLE, offset: int = 0):
         if self.base_type == BaseType.STRING:
@@ -323,19 +335,55 @@ class Field:
             return value.decode('utf-8')
 
         endian_symbol = '<' if endian == Endian.LITTLE else '>'
+
+        # FIT float invalid values are a specific all-ones bit pattern, not an ordinary NaN.
+        if self.base_type.is_float():
+            unsigned_format = 'I' if self.base_type == BaseType.FLOAT32 else 'Q'
+            raw_bits, = struct.unpack_from(f'{endian_symbol}{unsigned_format}', bytes_buffer, offset)
+            if raw_bits == self.base_type.invalid_raw_value():
+                return None
+            value, = struct.unpack_from(f'{endian_symbol}{self.base_type.struct_format}', bytes_buffer, offset)
+            return value
+
         value, = struct.unpack_from(f'{endian_symbol}{self.base_type.struct_format}', bytes_buffer, offset)
 
         return value
 
     def encoded_value_to_bytes(self, encoded_value, endian: Endian = Endian.LITTLE) -> bytes:
-        if encoded_value is None:
-            raise ValueError('Value cannot be None')
-
         if self.base_type == BaseType.STRING:
+            if encoded_value is None:
+                raise ValueError('Value cannot be None')
             return encoded_value.encode('utf-8') + b'\0'
 
         endian_symbol = '<' if endian == Endian.LITTLE else '>'
         bytes_buffer = bytearray(b'\0' * self.base_type.size)
+
+        if self.base_type.is_float():
+            # None (and legacy integer invalid markers) encode to the FIT invalid bit pattern.
+            if encoded_value is None or (
+                isinstance(encoded_value, int)
+                and encoded_value == self.base_type.invalid_raw_value()
+            ):
+                unsigned_format = 'I' if self.base_type == BaseType.FLOAT32 else 'Q'
+                struct.pack_into(
+                    f'{endian_symbol}{unsigned_format}',
+                    bytes_buffer,
+                    0,
+                    self.base_type.invalid_raw_value(),
+                )
+                return bytes_buffer
+
+            struct.pack_into(
+                f'{endian_symbol}{self.base_type.struct_format}',
+                bytes_buffer,
+                0,
+                float(encoded_value),
+            )
+            return bytes_buffer
+
+        if encoded_value is None:
+            raise ValueError('Value cannot be None')
+
         struct.pack_into(f'{endian_symbol}{self.base_type.struct_format}', bytes_buffer, 0, encoded_value)
 
         return bytes_buffer

--- a/fit_tool/record.py
+++ b/fit_tool/record.py
@@ -140,6 +140,10 @@ class Record:
                 developer_fields = []
             message = DataMessage.from_bytes(definition_message, developer_fields, bytes_buffer, offset=offset)
 
+        # Local message type lives only in the record header on the wire; copy it onto the
+        # message so callers and rebuild paths see the same local_id as the header.
+        message.local_id = header.local_id
+
         return cls(header, message)
 
     def to_bytes(self):

--- a/fit_tool/tests/test_field.py
+++ b/fit_tool/tests/test_field.py
@@ -66,6 +66,40 @@ class TestField(unittest.TestCase):
         self.assertAlmostEqual(value, value_from_bytes, 3)
         self.assertEqual(bytes2, bytes_buffer)
 
+    def test_float_set_value_preserves_fractional_component(self):
+        """FLOAT fields must not truncate via int() when scale/offset are identity (P0)."""
+        field = Field(name='grit', base_type=BaseType.FLOAT32, size=4, scale=1.0, offset=0.0)
+        field.set_value(0, 3.14)
+
+        self.assertIsInstance(field.encoded_values[0], float)
+        self.assertAlmostEqual(field.get_value(), 3.14, places=5)
+
+    def test_float_invalid_value_uses_all_ones_bit_pattern(self):
+        """FIT invalid floats are all-ones bits, represented as None in Python (P0)."""
+        for base_type, expected_bytes in (
+            (BaseType.FLOAT32, b'\xff\xff\xff\xff'),
+            (BaseType.FLOAT64, b'\xff\xff\xff\xff\xff\xff\xff\xff'),
+        ):
+            field = Field(name='x', base_type=base_type, size=base_type.size)
+            field.set_value(0, None)
+
+            self.assertIsNone(field.encoded_values[0])
+            self.assertEqual(field.to_bytes(), expected_bytes)
+
+            decoded = Field(name='x', base_type=base_type, size=base_type.size)
+            decoded.read_all_from_bytes(expected_bytes)
+            self.assertIsNone(decoded.get_value())
+            self.assertEqual(decoded.to_bytes(), expected_bytes)
+
+    def test_float_set_value_round_trips_through_bytes(self):
+        field = Field(name='flow', base_type=BaseType.FLOAT32, size=4, scale=1.0)
+        field.set_value(0, 2.5)
+        wire = field.to_bytes()
+
+        restored = Field(name='flow', base_type=BaseType.FLOAT32, size=4, scale=1.0)
+        restored.read_all_from_bytes(wire)
+        self.assertAlmostEqual(restored.get_value(), 2.5, places=5)
+
     def test_field_string_to_row(self):
         field = Field(name='title', base_type=BaseType.STRING, growable=True)
         value = 'test12345'

--- a/fit_tool/tests/test_field.py
+++ b/fit_tool/tests/test_field.py
@@ -100,6 +100,33 @@ class TestField(unittest.TestCase):
         restored.read_all_from_bytes(wire)
         self.assertAlmostEqual(restored.get_value(), 2.5, places=5)
 
+    def test_set_encoded_value_rejects_none_for_integer_fields(self):
+        """Codex P2: integer fields must not silently accept None as an encoded value."""
+        field = Field(name='heart_rate', base_type=BaseType.UINT8, size=1)
+        with self.assertRaises(ValueError):
+            field.set_encoded_value(0, None)
+
+        enum_field = Field(name='sport', base_type=BaseType.ENUM, size=1)
+        with self.assertRaises(ValueError):
+            enum_field.set_encoded_value(0, None)
+
+    def test_set_encoded_value_allows_none_for_float_fields(self):
+        field = Field(name='grit', base_type=BaseType.FLOAT32, size=4)
+        field.set_encoded_value(0, None)
+        self.assertIsNone(field.encoded_values[0])
+        self.assertEqual(field.to_bytes(), b'\xff\xff\xff\xff')
+
+    def test_float_encode_value_applies_scale_and_offset(self):
+        field = Field(name='scaled', base_type=BaseType.FLOAT32, size=4, scale=2.0, offset=1.0)
+        field.set_value(0, 3.0)  # (3 + 1) * 2 = 8
+        self.assertAlmostEqual(field.encoded_values[0], 8.0, places=5)
+
+    def test_float_legacy_invalid_raw_int_still_packs_all_ones(self):
+        """Integer invalid markers left from pre-fix code still encode correctly."""
+        field = Field(name='x', base_type=BaseType.FLOAT32, size=4)
+        field.set_encoded_value(0, BaseType.FLOAT32.invalid_raw_value(), check_validity=False)
+        self.assertEqual(field.to_bytes(), b'\xff\xff\xff\xff')
+
     def test_field_string_to_row(self):
         field = Field(name='title', base_type=BaseType.STRING, growable=True)
         value = 'test12345'

--- a/fit_tool/tests/test_fit_file.py
+++ b/fit_tool/tests/test_fit_file.py
@@ -57,6 +57,22 @@ class TestFitFile(unittest.TestCase):
 
         self.assertEqual(len(fit_file.records), 3)
 
+    def test_from_bytes_preserves_non_zero_local_id_on_messages(self):
+        """Parsed messages must keep the local_id from the record header (P0)."""
+        local_id = 5
+        mesg = WorkoutStepMessage(local_id=local_id)
+        mesg.workout_step_name = '1st step'
+        mesg.duration_type = WorkoutStepDuration.DISTANCE
+
+        builder = FitFileBuilder(auto_define=True)
+        builder.add(mesg)
+        fit_bytes = builder.build().to_bytes()
+
+        fit_file = FitFile.from_bytes(fit_bytes)
+        for record in fit_file.records:
+            self.assertEqual(record.header.local_id, local_id)
+            self.assertEqual(record.message.local_id, local_id)
+
     def test_from_bytes_invalid_crc_raises_value_error(self):
         mesg = WorkoutStepMessage(local_id=0)
         mesg.workout_step_name = '1st step'

--- a/fit_tool/tests/test_record.py
+++ b/fit_tool/tests/test_record.py
@@ -76,3 +76,27 @@ class TestRecord(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             Record.from_bytes(definition_messages={}, bytes_buffer=record.to_bytes())
+
+    def test_from_bytes_preserves_local_id_on_definition_and_data_messages(self):
+        """Record header local_id must be copied onto parsed messages (P0)."""
+        local_id = 5
+        data_message = WorkoutStepMessage(local_id=local_id)
+        data_message.workout_step_name = 'step'
+        definition_message = DefinitionMessage.from_data_message(data_message)
+
+        definition_record = Record.from_message(definition_message)
+        data_record = Record.from_message(data_message)
+
+        parsed_definition = Record.from_bytes(
+            definition_messages={},
+            bytes_buffer=definition_record.to_bytes(),
+        )
+        self.assertEqual(parsed_definition.header.local_id, local_id)
+        self.assertEqual(parsed_definition.message.local_id, local_id)
+
+        parsed_data = Record.from_bytes(
+            definition_messages={local_id: parsed_definition.message},
+            bytes_buffer=data_record.to_bytes(),
+        )
+        self.assertEqual(parsed_data.header.local_id, local_id)
+        self.assertEqual(parsed_data.message.local_id, local_id)

--- a/news/sha3.bugfix
+++ b/news/sha3.bugfix
@@ -1,0 +1,1 @@
+Copy record-header `local_id` onto parsed definition and data messages, and fix FLOAT field encoding so fractional values are preserved and FIT invalid all-ones bit patterns round-trip as `None`.


### PR DESCRIPTION
## Summary
Fixes the P0 findings from the SHA-3 code review:

1. **local_id backfill** — `Record.from_bytes` now copies the record-header local message type onto definition and data messages (previously always `0` after parse).
2. **FLOAT encoding** — `Field.encode_value` no longer truncates floats via `int()` when scale/offset are identity; invalid values pack/unpack as the FIT all-ones bit pattern (`None` in Python).

## Test plan
- [x] `UV_PYTHON=3.12 uv run pytest` — 229 passed, 1 skipped
- [x] New unit tests for local_id preservation and FLOAT invalid/fractional encoding
- [x] Manual sanity: `RecordMessage.grit = 3.14` keeps 3.14; invalid float bytes `ffffffff`