### PR TITLE
SHA-5: converge stable public API exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,12 +114,54 @@ See [Capability boundary](#capability-boundary) for what works today. The
 strict-conformance roadmap (target architecture, not current guarantees) is in
 [`docs/FIT_CONFORMANCE_DESIGN.md`](docs/FIT_CONFORMANCE_DESIGN.md).
 
+### Public API
+
+Application code should import the stable surface from the package root:
+
+```python
+from fit_tool import (
+    FitFile,
+    FitFileBuilder,
+    FitError,
+    FitParseError,
+    FitCRCError,
+    FitValidationError,
+    PROTOCOL_VERSION,
+    SDK_VERSION,
+)
+```
+
+| Symbol | Role |
+| --- | --- |
+| `FitFile` | Load, inspect, stream, and serialize FIT files |
+| `FitFileBuilder` | Build FIT files from messages |
+| `FitError` and subclasses | Typed errors for parse, CRC, encode, and validation failures |
+| `PROTOCOL_VERSION`, `SDK_VERSION`, `FIT_DATA_TYPE` | Bundled protocol/profile version metadata |
+
+The same symbols are defined in `fit_tool.api` and re-exported by `fit_tool`.
+
+**Profile messages** (generated types such as `RecordMessage`, `FileIdMessage`) are
+not re-exported at the package root. Import them by module path:
+
+```python
+from fit_tool.profile.messages.file_id_message import FileIdMessage
+from fit_tool.profile.messages.record_message import RecordMessage
+from fit_tool.profile.profile_type import FileType, Sport
+```
+
+Naming convention: message module is the snake_case form of the class
+(`record_message` → `RecordMessage`), under `fit_tool.profile.messages`.
+
+**Compatibility:** deep imports such as `from fit_tool.fit_file import FitFile`
+remain supported. Prefer the package-root form for new code. No deep-import paths
+are removed in this release; future deprecations will be announced in the changelog.
+
 ### Minimal read/convert example
 
 ```python
 from pathlib import Path
 
-from fit_tool.fit_file import FitFile
+from fit_tool import FitFile
 
 root = Path.cwd()
 in_file = root / "fit_tool" / "tests" / "data" / "sdk" / "Activity.fit"
@@ -136,7 +178,7 @@ fit_file.to_csv(str(out_file))
 record-by-record processing, use the streaming iterator to keep memory usage bounded:
 
 ```python
-from fit_tool.fit_file import FitFile
+from fit_tool import FitFile
 
 for record in FitFile.iter_file("activity.fit"):
     process(record)
@@ -152,7 +194,7 @@ Use strict mode to additionally validate Developer Field declarations, `file_id`
 cardinality before bytes are produced:
 
 ```python
-from fit_tool.fit_file_builder import FitFileBuilder
+from fit_tool import FitFileBuilder
 
 builder = FitFileBuilder(strict=True)
 builder.add_all(messages)

--- a/fit_tool/__init__.py
+++ b/fit_tool/__init__.py
@@ -1,3 +1,44 @@
+"""fit-tool: a library for reading and writing Garmin FIT files.
+
+The stable application-facing surface is defined in :mod:`fit_tool.api` and
+re-exported from this package. Prefer::
+
+    from fit_tool import FitFile, FitFileBuilder, FitCRCError, SDK_VERSION
+
+Existing deep imports (for example ``from fit_tool.fit_file import FitFile``)
+continue to work; no modules are moved or removed in this change.
+"""
+
+# Version and format constants must be defined before re-exports so modules that
+# import ``from fit_tool import SDK_VERSION`` during package initialization
+# (e.g. fit_file_header) see a fully assigned name.
 PROTOCOL_VERSION = '2.4'
 SDK_VERSION = '21.205.0'
 FIT_DATA_TYPE = b'.FIT'
+
+from fit_tool.api import (  # noqa: E402
+    FitCRCError,
+    FitEncodingError,
+    FitError,
+    FitFile,
+    FitFileBuilder,
+    FitHeaderError,
+    FitParseError,
+    FitRecordError,
+    FitValidationError,
+)
+
+__all__ = [
+    'PROTOCOL_VERSION',
+    'SDK_VERSION',
+    'FIT_DATA_TYPE',
+    'FitFile',
+    'FitFileBuilder',
+    'FitError',
+    'FitParseError',
+    'FitHeaderError',
+    'FitRecordError',
+    'FitCRCError',
+    'FitEncodingError',
+    'FitValidationError',
+]

--- a/fit_tool/api.py
+++ b/fit_tool/api.py
@@ -1,0 +1,41 @@
+"""Stable public API for application users.
+
+Prefer importing symbols from the package root::
+
+    from fit_tool import FitFile, FitFileBuilder, FitCRCError
+
+Deep imports such as ``from fit_tool.fit_file import FitFile`` remain supported
+for backward compatibility; the package root is the documented entry point.
+
+Profile message classes are generated and live under
+``fit_tool.profile.messages``. They are intentionally not re-exported here so
+that package import stays light and each message stays discoverable by name.
+Import them by module path, for example::
+
+    from fit_tool.profile.messages.record_message import RecordMessage
+    from fit_tool.profile.profile_type import Sport, FileType
+"""
+
+from fit_tool.exceptions import (
+    FitCRCError,
+    FitEncodingError,
+    FitError,
+    FitHeaderError,
+    FitParseError,
+    FitRecordError,
+    FitValidationError,
+)
+from fit_tool.fit_file import FitFile
+from fit_tool.fit_file_builder import FitFileBuilder
+
+__all__ = [
+    'FitFile',
+    'FitFileBuilder',
+    'FitError',
+    'FitParseError',
+    'FitHeaderError',
+    'FitRecordError',
+    'FitCRCError',
+    'FitEncodingError',
+    'FitValidationError',
+]

--- a/fit_tool/tests/test_public_api.py
+++ b/fit_tool/tests/test_public_api.py
@@ -47,10 +47,10 @@ class TestPublicApi(unittest.TestCase):
             self.assertTrue(hasattr(fit_tool, name))
 
     def test_deep_imports_remain_supported(self) -> None:
+        from fit_tool import FitCRCError, FitFile, FitFileBuilder
         from fit_tool.exceptions import FitCRCError as DeepFitCRCError
         from fit_tool.fit_file import FitFile as DeepFitFile
         from fit_tool.fit_file_builder import FitFileBuilder as DeepFitFileBuilder
-        from fit_tool import FitCRCError, FitFile, FitFileBuilder
 
         self.assertIs(FitFile, DeepFitFile)
         self.assertIs(FitFileBuilder, DeepFitFileBuilder)

--- a/fit_tool/tests/test_public_api.py
+++ b/fit_tool/tests/test_public_api.py
@@ -1,0 +1,67 @@
+"""Tests for the stable package-level public API."""
+
+from __future__ import annotations
+
+import unittest
+
+
+class TestPublicApi(unittest.TestCase):
+    def test_core_symbols_importable_from_package_root(self) -> None:
+        from fit_tool import (  # noqa: PLC0415
+            FIT_DATA_TYPE,
+            PROTOCOL_VERSION,
+            SDK_VERSION,
+            FitCRCError,
+            FitEncodingError,
+            FitError,
+            FitFile,
+            FitFileBuilder,
+            FitHeaderError,
+            FitParseError,
+            FitRecordError,
+            FitValidationError,
+        )
+
+        self.assertEqual(SDK_VERSION, '21.205.0')
+        self.assertEqual(PROTOCOL_VERSION, '2.4')
+        self.assertEqual(FIT_DATA_TYPE, b'.FIT')
+        self.assertTrue(issubclass(FitCRCError, FitParseError))
+        self.assertTrue(issubclass(FitParseError, FitError))
+        self.assertTrue(issubclass(FitValidationError, FitEncodingError))
+        self.assertTrue(issubclass(FitEncodingError, FitError))
+        self.assertTrue(issubclass(FitHeaderError, FitParseError))
+        self.assertTrue(issubclass(FitRecordError, FitParseError))
+        self.assertTrue(callable(FitFile.from_file))
+        self.assertTrue(callable(FitFileBuilder))
+
+    def test_package_all_matches_api_surface(self) -> None:
+        import fit_tool
+        from fit_tool import api
+
+        for name in api.__all__:
+            self.assertIn(name, fit_tool.__all__)
+            self.assertIs(getattr(fit_tool, name), getattr(api, name))
+
+        for name in ('PROTOCOL_VERSION', 'SDK_VERSION', 'FIT_DATA_TYPE'):
+            self.assertIn(name, fit_tool.__all__)
+            self.assertTrue(hasattr(fit_tool, name))
+
+    def test_deep_imports_remain_supported(self) -> None:
+        from fit_tool.exceptions import FitCRCError as DeepFitCRCError
+        from fit_tool.fit_file import FitFile as DeepFitFile
+        from fit_tool.fit_file_builder import FitFileBuilder as DeepFitFileBuilder
+        from fit_tool import FitCRCError, FitFile, FitFileBuilder
+
+        self.assertIs(FitFile, DeepFitFile)
+        self.assertIs(FitFileBuilder, DeepFitFileBuilder)
+        self.assertIs(FitCRCError, DeepFitCRCError)
+
+    def test_message_import_convention(self) -> None:
+        from fit_tool.profile.messages.file_id_message import FileIdMessage
+        from fit_tool.profile.messages.record_message import RecordMessage
+        from fit_tool.profile.profile_type import FileType, Sport
+
+        self.assertEqual(FileIdMessage.__name__, 'FileIdMessage')
+        self.assertEqual(RecordMessage.__name__, 'RecordMessage')
+        self.assertIsNotNone(FileType)
+        self.assertIsNotNone(Sport)

--- a/news/SHA-5.feature
+++ b/news/SHA-5.feature
@@ -1,0 +1,2 @@
+Expose a stable package-level public API (`FitFile`, `FitFileBuilder`, exceptions, version constants)
+via `from fit_tool import ...`, documented in the README. Existing deep imports remain supported.


### PR DESCRIPTION
## Summary

- Define a curated public surface in `fit_tool/api.py` and re-export it from `fit_tool/__init__.py`: `FitFile`, `FitFileBuilder`, exception types (`FitError`, `FitParseError`, `FitHeaderError`, `FitRecordError`, `FitCRCError`, `FitEncodingError`, `FitValidationError`), plus existing version constants.
- Document the recommended package-root import style and profile message path convention in the README.
- Add tests that lock the package-root surface, identity with deep imports, and message import convention.
- Additive only: existing deep imports continue to work; no modules moved or removed.

Closes SHA-5

## Test plan

- [x] `PYTHONPATH=. python -m pytest fit_tool/tests/test_public_api.py -q` (4 passed)
- [x] Full suite (excluding live Garmin JS interop): `226 passed`
- [ ] CI green on the PR