### PR TITLE
SHA-6: split runtime and gen optional dependencies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,12 @@ uv run pytest --cov=fit_tool --cov-report=term
 uv build
 ```
 
+Runtime install of `fit-tool` has no third-party dependencies. Profile generation
+uses the optional `[gen]` extra (`openpyxl`, `inflection`, `jinja2`). The `dev`
+dependency group already includes those packages so `uv sync --group dev` supports
+the full suite and `uv run gen-profile`. For a published package, install with
+`pip install 'fit-tool[gen]'` or `uv add 'fit-tool[gen]'`.
+
 The CI baseline is a package build plus the full test suite on Python 3.9 through 3.14. Before finishing a normal code change, run the narrowest relevant tests and then the full suite when practical. Run `uv build` for packaging, entry-point, dependency, or metadata changes.
 
 Ruff and mypy settings live in `pyproject.toml`, but those tools are not part of the locked development dependency group and are not currently CI gates. If they are already available in the development environment, useful checks are:
@@ -54,6 +60,10 @@ Change the generator inputs or templates under `fit_tool/gen/`, update `fit_tool
 ```bash
 uv run gen-profile
 ```
+
+`gen-profile` requires the gen extra (or an equivalent `uv sync --group dev`).
+Without those packages it exits with a clear install hint rather than a raw
+import traceback.
 
 The generator deletes and rebuilds the entire `fit_tool/profile/` directory. Before running it, make sure the intended spreadsheet is present in `fit_tool/gen/` and the working tree contains no uncommitted manual work in the generated directory. Review the complete generated diff and run at least `fit_tool/tests/test_profile.py` followed by the full test suite.
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ this package against the matrix above, not against full protocol conformance.
 Installation
 ==================
 
+The runtime library and `fit-tool` CLI have no third-party dependencies.
+Optional packages are only needed for profile generation (maintainers regenerating
+code from the Garmin Profile spreadsheet).
+
 ### Using uv (recommended)
 
 ```bash
@@ -46,6 +50,33 @@ uv add fit-tool
 python3 -m pip install --upgrade pip
 python3 -m pip install --upgrade fit-tool
 ```
+
+### Profile generation tooling (optional)
+
+Regenerating `fit_tool/profile/` from the Garmin Profile spreadsheet requires the
+`gen` extra (`openpyxl`, `inflection`, `jinja2`):
+
+```bash
+# pip
+python3 -m pip install 'fit-tool[gen]'
+
+# uv (published package)
+uv add 'fit-tool[gen]'
+
+# local checkout (dev group already includes gen deps for the full test suite)
+uv sync --group dev
+# or, without the full dev toolchain:
+uv sync --extra gen
+```
+
+Then run:
+
+```bash
+uv run gen-profile
+```
+
+Without the gen extra, `gen-profile` exits with an install hint. End users who
+only read/write FIT files do not need these packages.
 
 Command line interface
 =======================

--- a/fit_tool/gen/gen_profile.py
+++ b/fit_tool/gen/gen_profile.py
@@ -1,10 +1,8 @@
 import argparse
 import os
 import shutil
+import sys
 from pathlib import Path
-
-import inflection
-import jinja2
 
 from fit_tool import SDK_VERSION
 from fit_tool.base_type import BaseType
@@ -12,6 +10,40 @@ from fit_tool.field import Field
 from fit_tool.gen.profile import Message, Profile
 
 DEFAULT_BUILD_PATH = str(Path(__file__).resolve().parents[1])
+
+_GEN_INSTALL_HINT = (
+    "gen-profile requires the optional gen dependencies "
+    "(openpyxl, inflection, jinja2).\n"
+    "Install with: pip install 'fit-tool[gen]'  or  uv sync --extra gen --group dev"
+)
+
+try:
+    import inflection
+    import jinja2
+except ImportError:
+    # Allow the module (and console entry point) to load without gen extras;
+    # main() exits with a clear install hint.
+    inflection = None  # type: ignore[assignment]
+    jinja2 = None  # type: ignore[assignment]
+
+
+def _require_gen_dependencies():
+    """Exit with a clear install hint if gen-only deps are missing."""
+    missing = []
+    for module_name, module in (
+        ("inflection", inflection),
+        ("jinja2", jinja2),
+    ):
+        if module is None:
+            missing.append(module_name)
+    try:
+        import openpyxl  # noqa: F401
+    except ImportError:
+        missing.append("openpyxl")
+    if missing:
+        print(_GEN_INSTALL_HINT, file=sys.stderr)
+        print(f"Missing: {', '.join(missing)}", file=sys.stderr)
+        raise SystemExit(1)
 
 
 def parse_args():
@@ -176,6 +208,8 @@ def get_field_property_type_name(profile: Profile, field: Field) -> str:
 
 
 def main():
+    _require_gen_dependencies()
+
     build_path = DEFAULT_BUILD_PATH
     profile_path = os.path.join(build_path, 'profile')
     messages_path = os.path.join(profile_path, 'messages')

--- a/fit_tool/gen/profile.py
+++ b/fit_tool/gen/profile.py
@@ -1,12 +1,22 @@
 import os.path
 import re
 
-from openpyxl import load_workbook
-
 from fit_tool import SDK_VERSION
 from fit_tool.base_type import BaseType, FieldType
 from fit_tool.field import ArrayType, Field
 from fit_tool.utils.logging import logger
+
+
+def _load_workbook(filename):
+    """Load a profile spreadsheet; requires the optional [gen] extra."""
+    try:
+        from openpyxl import load_workbook
+    except ImportError as exc:
+        raise ImportError(
+            "Reading Garmin Profile spreadsheets requires the optional gen dependencies. "
+            "Install with: pip install 'fit-tool[gen]'  or  uv sync --extra gen --group dev"
+        ) from exc
+    return load_workbook(filename=filename, read_only=True, data_only=True)
 
 
 class Message:
@@ -142,7 +152,7 @@ class Profile:
     @classmethod
     def load(cls, filename):
         profile = cls()
-        wb = load_workbook(filename=filename, read_only=True, data_only=True)
+        wb = _load_workbook(filename)
 
         def is_blank(value):
             return value is None or (isinstance(value, str) and value.strip() == '')

--- a/fit_tool/tests/test_profile.py
+++ b/fit_tool/tests/test_profile.py
@@ -5,6 +5,8 @@ import sys
 import unittest
 from pathlib import Path
 
+import pytest
+
 from fit_tool import SDK_VERSION
 from fit_tool.field import ArrayType
 from fit_tool.gen import profile as profile_module
@@ -16,6 +18,9 @@ from fit_tool.profile.messages.record_message import RecordMessage
 class TestFitFile(unittest.TestCase):
 
     def test_profile(self):
+        # Spreadsheet loading needs openpyxl from the optional [gen] extra.
+        pytest.importorskip("openpyxl")
+
         gen_dir = Path(profile_module.__file__).resolve().parent
         expected = gen_dir / f'Profile_{SDK_VERSION}.xlsx'
         self.assertTrue(

--- a/news/sha6.dep
+++ b/news/sha6.dep
@@ -1,0 +1,1 @@
+Move profile-generation packages (`openpyxl`, `inflection`, plus `jinja2`) to an optional `[gen]` extra and drop unused `bitstruct` from the runtime install.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,13 +26,16 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 requires-python = ">=3.8"
-dependencies = [
-    "openpyxl>=2.5.12",
-    "bitstruct>=8.11.1",
-    "inflection>=0.5.1",
-]
+# Runtime library and fit-tool CLI need no third-party packages.
+# Profile generation tooling lives under the optional [gen] extra.
+dependencies = []
 
 [project.optional-dependencies]
+gen = [
+    "openpyxl>=2.5.12",
+    "inflection>=0.5.1",
+    "jinja2>=3.0",
+]
 test = [
     "pytest>=7.0",
     "pytest-cov>=4.0",
@@ -69,6 +72,10 @@ dev = [
     "pytest-cov>=4.0",
     "ruff>=0.15.22",
     "towncrier>=24.8.0",
+    # Gen tooling (also published as the [gen] extra) so full suite / gen-profile work.
+    "openpyxl>=2.5.12",
+    "inflection>=0.5.1",
+    "jinja2>=3.0",
 ]
 
 [tool.coverage.run]

--- a/uv.lock
+++ b/uv.lock
@@ -50,132 +50,6 @@ wheels = [
 ]
 
 [[package]]
-name = "bitstruct"
-version = "8.20.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.9'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/37/b7/cc0edea9ed9d8fad97820cb3d38992d5631e5f06d10d1e394148aeaa7797/bitstruct-8.20.0.tar.gz", hash = "sha256:f6b16a93097313f2a6c146640c93e5f988a39c33364f8c20a4286ac1c5ed5dae", size = 35637, upload-time = "2025-02-22T12:11:12.26Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/37/d1/881fcc068acc24007458197372dd392a430b4f398f60b7577c3ab12e49db/bitstruct-8.20.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:7a33169c25eef4f923f8a396ef362098216f527e83e44c7e726c126c084944ab", size = 38255, upload-time = "2025-02-22T12:09:59.469Z" },
-    { url = "https://files.pythonhosted.org/packages/04/95/b538b7283d607f8d4d2016fbcf015178c6028f101d8a3bb5203e7f24838f/bitstruct-8.20.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b7fec9cff575cdd9dafba9083fa8446203f32c7112af7a6748f315f974dcd418", size = 81061, upload-time = "2025-02-22T12:10:01.551Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/5a/037ff150904923612477411c88b7e07380bd0fbbab31389eb11aaa6e7b48/bitstruct-8.20.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:08835ebed9142babc39885fc0301f45fae9de7b1f3e78c1e3b4b5c2e20ff8d38", size = 75573, upload-time = "2025-02-22T12:10:03.433Z" },
-    { url = "https://files.pythonhosted.org/packages/14/ae/8855346326aea3c0a27c113c3dfc962affa789da4bfe3cf25589aff35e30/bitstruct-8.20.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:2b1735a9ae5ff82304b9f416051e986e3bffa76bc416811d598ee3e8e9b1f26c", size = 74172, upload-time = "2025-02-22T12:10:05.389Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/cf/c5df5eb10b7d8529b676738728f567355c9cb70e033809d75b2d9c217e2a/bitstruct-8.20.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:9962bccebee15ec895fa8363ad4391e5314ef499b3e96af7d8ef6bf6e2f146ce", size = 78959, upload-time = "2025-02-22T12:10:07.172Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/7b/e604da0ade67ce6e5629da196f6936867235b3d9d513b700b875aff66763/bitstruct-8.20.0-cp310-cp310-win32.whl", hash = "sha256:5f3c88ae5d4e329cefecc66b18269dc27cd77f2537a8d506b31f8b874225a5cc", size = 34817, upload-time = "2025-02-22T12:10:09.015Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/52/3d6c1b7abc7f33b7bf348038dd8d4915de93cf03e8a1b0333f92e5179d61/bitstruct-8.20.0-cp310-cp310-win_amd64.whl", hash = "sha256:98640aeb709b67dcea79da7553668b96e9320ee7a11639c3fe422592727b1705", size = 36816, upload-time = "2025-02-22T12:10:10.865Z" },
-    { url = "https://files.pythonhosted.org/packages/60/0d/5115ee2459ce8d6afb5fa02ae41a1a2b04f0efdd56e7dca79f8f05b99582/bitstruct-8.20.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:3be9192bff6accb6c2eb4edd355901fed1e64cc50de437015ee1469faab436a4", size = 38254, upload-time = "2025-02-22T12:10:12.714Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/91/25cafb8a91bb62965d438872f6370811f4296829cac1a54544e1f17d868f/bitstruct-8.20.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f9a2634563ed9c7229b0c6938a332b718e654f0494c2df87ee07f8074026ee68", size = 82777, upload-time = "2025-02-22T12:10:13.673Z" },
-    { url = "https://files.pythonhosted.org/packages/db/c6/165fa6cedfe0779cf3b6513a0408d5dbba3789e55b212b5714c84bf66894/bitstruct-8.20.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4cf892b3c95393772eea4ab2a0e4ea2d7ec45742557488727bd6bfdd1d1e5007", size = 77495, upload-time = "2025-02-22T12:10:15.547Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/d0/63b41eb8abb6d31d0c3a6d7be077882fee0046e6b5c0294c1b08374e639e/bitstruct-8.20.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:fc4a841126e2d89fd3ef579c2d8b02f8af31b5973b947afb91450ae8adf5caa4", size = 75660, upload-time = "2025-02-22T12:10:17.575Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/2d/50a543c70823547d26fc20641edcfdc005eaa9aa4e29354ce21409228b21/bitstruct-8.20.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0fbf434f70f827318f2aaa68c6cf2fde58ab34a5ab1c6d9f0f4b9f953f058584", size = 80673, upload-time = "2025-02-22T12:10:19.438Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/45/fc2d648cb357b7283f11d6f3275a7e2689d353f9a343dbefd83436264752/bitstruct-8.20.0-cp311-cp311-win32.whl", hash = "sha256:0b0444a713f4f7e13927427e9ff5ed73bb4223c8074141adfc3e0bfbe63e092d", size = 34807, upload-time = "2025-02-22T12:10:20.435Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/de/c446c5a96a4b612558827a71a373760c06af104e02a974fadbb9287ce548/bitstruct-8.20.0-cp311-cp311-win_amd64.whl", hash = "sha256:8271b3851657fe1066cb04ddc30e14a8492bdd18fa287514506af0801babd494", size = 36803, upload-time = "2025-02-22T12:10:21.367Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/f6/9598c50c432bd56eb301cbf2ef69941141bc5519c728176648a4b3dc54cd/bitstruct-8.20.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5df3ce5f4dd517be68e4b2d8ab37a564e12d5e24ec29039a3535281174a75284", size = 38313, upload-time = "2025-02-22T12:10:22.287Z" },
-    { url = "https://files.pythonhosted.org/packages/90/43/0eae530142d0e65cb74e83de79d6c6c55e3c57de0a2d1ec9b7459d1c9afd/bitstruct-8.20.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ac0bb940fa9238c05796d45fb957ddf2e10d82ee8fd8cd43c5e367a9c380b24c", size = 83575, upload-time = "2025-02-22T12:10:24.116Z" },
-    { url = "https://files.pythonhosted.org/packages/40/30/cb048fa88c276d156a2a7af7f6ec2820c7391f8f7ecec43b945127abf116/bitstruct-8.20.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:73eb7f0b6031c7819c12412c71af07cfac036da22a9245b7a1669a1f11fe1220", size = 77902, upload-time = "2025-02-22T12:10:25.937Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/e3/6904e2f80c89efeee473bf3539e1f3904c422f7cab0bb86d28124e732fc5/bitstruct-8.20.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:ea7b64a444bf592712593a9f3bf1cb37588fae257aeb40d2ea427e17ef3d690c", size = 76142, upload-time = "2025-02-22T12:10:26.94Z" },
-    { url = "https://files.pythonhosted.org/packages/17/6a/a1cb10a564bcf522211101c3b023f8a859bda2e1a552d7694935ad208106/bitstruct-8.20.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c4dad0231810bc3ef4e5154d6d6f7d62cc3efe2b9e9e6126002f105297284af3", size = 81160, upload-time = "2025-02-22T12:10:28.743Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/18/1b6f22b19e6fb87ed08760576fac092f8a20ff8a2ac2f9eab7e60ae82a38/bitstruct-8.20.0-cp312-cp312-win32.whl", hash = "sha256:8ca1cc21ae72bbefee4471054e6a993b74f4571716eded73c3d3b6280dc831fd", size = 34783, upload-time = "2025-02-22T12:10:30.64Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/83/37c741d02133ed2e18db015aaa3849bf24946b7903d8b4af3645cfb9233c/bitstruct-8.20.0-cp312-cp312-win_amd64.whl", hash = "sha256:b3732bed3c8b190dee071c2222304ef668f665fbdbeef19c9aeed50fbe1a3d48", size = 36843, upload-time = "2025-02-22T12:10:31.585Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/a0/45821219ffa1c4d86ec9056d67f9fd4a3226d8b239a55ff0fe06d8e532f1/bitstruct-8.20.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:b62fab3f38c09f5d61c83559cfc495b56de6dc424c3ccb1ff9f93457975b8c25", size = 38293, upload-time = "2025-02-22T12:10:32.486Z" },
-    { url = "https://files.pythonhosted.org/packages/20/cb/d7c5e919594fbdca797f3e2e227b95c3f70513513c181d405bb641c053f1/bitstruct-8.20.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c4df55aea3bf5c1970174191f04f575d657515b2ff26582e7a6475937b4e8176", size = 83490, upload-time = "2025-02-22T12:10:33.389Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/15/ccbd6b54c3afd474dbebb9ea7bf02031068fb30c7949bc3134f01d55a937/bitstruct-8.20.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f44afbce27ca0bd3fa96630c7a240bff167a7b66c05ac12ba9147ec001eee531", size = 77849, upload-time = "2025-02-22T12:10:37.029Z" },
-    { url = "https://files.pythonhosted.org/packages/44/8c/fa70b395703e155e2b4e1d70310c2b987e8ea388b85ecbb2dbbb80c6dda4/bitstruct-8.20.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:3c3d19f85935613a7db42f0e848e278d33ed2b18629dd5cc0e391d0ee8ddb54b", size = 76195, upload-time = "2025-02-22T12:10:38.155Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/88/69db802731e023bbc0dd5443b3aeff7266470c51fbcb969936015bc7252d/bitstruct-8.20.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:d3f29bb701916a8bb885ccc0de77c6c4b3eaf81652916b3d0bcd7dd9ebdab799", size = 81220, upload-time = "2025-02-22T12:10:39.081Z" },
-    { url = "https://files.pythonhosted.org/packages/67/72/611a63dea63bdd0a1d15eb2b8cdee0cb089f010f0a7bb4ba839618316f2b/bitstruct-8.20.0-cp313-cp313-win32.whl", hash = "sha256:a09f81cdeec264349a6e65597329a1cee461218b870f8113848126c2c6729025", size = 34785, upload-time = "2025-02-22T12:10:40.942Z" },
-    { url = "https://files.pythonhosted.org/packages/66/0a/73564b78aaff494e3bdaf5e4946cabbc41d957d386d92af2123fd2b705f5/bitstruct-8.20.0-cp313-cp313-win_amd64.whl", hash = "sha256:31e33cc7db403cd2441d4d1968c57334b2489ffe123cfc30d26eedf11063288e", size = 36843, upload-time = "2025-02-22T12:10:42.068Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/a8/08c4a76948e5eb43cd68b25a08a9741188eca567c37cb314adf20ba48bc0/bitstruct-8.20.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:9dcbccadba78c9b3170db967a8559500e3eca821cd9f101a76c087cf01e1cdbd", size = 38256, upload-time = "2025-02-22T12:10:54Z" },
-    { url = "https://files.pythonhosted.org/packages/db/17/0362f8469adb2eaf09ab2cb198d20acfe7f3ce774ab0227880d6e646f2da/bitstruct-8.20.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c6232fdf18689406369810a448181e9a2936f9d22707918394fc0cf5334c9fc1", size = 80957, upload-time = "2025-02-22T12:10:54.914Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/e1/0dc2926d0b4bb558b5fe9717b1995fa7c525a6c8dfed8ffa127502ab4687/bitstruct-8.20.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7fe8c959beb3b9471bedc3af01467cedede72f2cf65614aa69a6651684926c4e", size = 75589, upload-time = "2025-02-22T12:10:56.573Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/da/5fb7e00e7548e230f4173e4956597011acbbb10553aa1d590b53328f0d85/bitstruct-8.20.0-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:2adcd545a8f8a90a2e84a21edc5763f3d3832ebddb7cc687b7650221cddfc19a", size = 73548, upload-time = "2025-02-22T12:10:57.498Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/88/b9cec4afa4b708ee10df707badc151200954c17149d7a4516d6dc3c80098/bitstruct-8.20.0-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:b3a4f0e443a9b4171b648b52c3003064cf31113f6203e08dc4ac225601d9249b", size = 78306, upload-time = "2025-02-22T12:10:59.333Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/25/cfdc5b43cf815164750403b6d6f50e896701d60b9dce2584f99dfbe93771/bitstruct-8.20.0-cp38-cp38-win32.whl", hash = "sha256:5618eaab857db6dafa26751af5b8c926541ce578f36608e50fa687127682af3c", size = 34828, upload-time = "2025-02-22T12:11:02.892Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/58/6c5ad5959bcf28eb675aab2b56bea4fb0212a265ce08acdfe51352ceb414/bitstruct-8.20.0-cp38-cp38-win_amd64.whl", hash = "sha256:3eb8de0ad891b716ed97430e8b8603b6d875c5ddc5ebcd9c5288099c773a6bc9", size = 36844, upload-time = "2025-02-22T12:11:03.833Z" },
-    { url = "https://files.pythonhosted.org/packages/69/10/b16af4a0f3a30e7ecf516f820e3e165db3058983fd4ebd462145f3ae060c/bitstruct-8.20.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:1a063deb6b7b07906414ac460c807e483b6eea662abcb406c4ea6e2938c8fc21", size = 38247, upload-time = "2025-02-22T12:11:04.78Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/cd/d3332f67c138bee957b597819d56b2b95837f2b59868f9a54ff7b4eb8007/bitstruct-8.20.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0528f8da4cf919a3d4801603c4e5fc601b72b86955d37c51c8d7ddc69f291f0c", size = 80643, upload-time = "2025-02-22T12:11:05.66Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/81/c49ce66b4ee435eb76a49c62d6d3c701c66567165c463757dd5b592079fc/bitstruct-8.20.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6ac783d0bc7c57bee2c8f8cda4c83d60236e7c046f6f454e76943f9e0fb16112", size = 75225, upload-time = "2025-02-22T12:11:06.603Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/f3/292364e356c15d82c3d1b7de5bf27a3acd0b9f45ea1bc5b60710841b8a5a/bitstruct-8.20.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:a0482f8e2b73df16d080d5d8df23e2949c114e27acfeb659f0465ef8ce1da038", size = 73764, upload-time = "2025-02-22T12:11:07.575Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/1f/f6b46ba73aa7d6f969c67ff0f9f86cabdf00f3355fb9099f4e8d834b8cad/bitstruct-8.20.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:f6cc949e8030303b05728294b4feaca8c955150dd5042f66467da1dd18ff3410", size = 78523, upload-time = "2025-02-22T12:11:08.506Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/63/1cad55d3e11e6267367ee2c3f96953f41026da8a39df9b63bf0a83270336/bitstruct-8.20.0-cp39-cp39-win32.whl", hash = "sha256:3e5195cfe68952587a2fcb621b2ee766e78f5d2d5a1e94204ac302e3d3f441bc", size = 34828, upload-time = "2025-02-22T12:11:09.503Z" },
-    { url = "https://files.pythonhosted.org/packages/24/7a/41a2a44465e9985b795f1767d3157de82c94f82fba5f01e85d3d1d641224/bitstruct-8.20.0-cp39-cp39-win_amd64.whl", hash = "sha256:a7109b454a8cccc55e88165a903e5d9980e39f6f5268dc5ec5386ae96a89ff1b", size = 36852, upload-time = "2025-02-22T12:11:11.258Z" },
-]
-
-[[package]]
-name = "bitstruct"
-version = "8.21.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.15'",
-    "python_full_version >= '3.10' and python_full_version < '3.15'",
-    "python_full_version == '3.9.*'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ae/f5/ba6bf7ab575a095bb3d76ef40cccd4e60b1bda9996bfba8e640d54c00488/bitstruct-8.21.0.tar.gz", hash = "sha256:ff0be4968a45caf8688e075f55cca7a3fe9212b069ba67e5b27b0926a11948ac", size = 35597, upload-time = "2025-05-13T15:49:00.268Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/74/fb25d5dbb11dcebb1054182aa4fde9d4f83b98ea6524f28ea418b759ed9e/bitstruct-8.21.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:dcc4d9d09ed713af523dab5f1980229fc5280163d534589fcf9660c38be3a3aa", size = 37897, upload-time = "2025-05-13T15:47:55.103Z" },
-    { url = "https://files.pythonhosted.org/packages/80/36/4bc924d0e3158a3e4f1cf42af6f4916cc85c95ebb2b445a869b3b32e2328/bitstruct-8.21.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f3e2882e4c62c25a5e0f925715281197150dcf98a3a043e322872068e3aa2e63", size = 38437, upload-time = "2025-05-13T15:47:56.413Z" },
-    { url = "https://files.pythonhosted.org/packages/71/1d/6f0634c74a48182bc6a4d81a34ff85d3be8ae0bad21e361163b96d0374fb/bitstruct-8.21.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:27e49eef9f47c3b570e4142dd39384a04bcbf8e37a6c9ac5acc6c1f26f2a0e83", size = 82651, upload-time = "2025-05-13T15:47:57.315Z" },
-    { url = "https://files.pythonhosted.org/packages/02/d5/b648af1a4fd4346c996fb10da04263bf7b8570b1a77bf1a7c88e1a37297a/bitstruct-8.21.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:1f694e86c9e6a93bc087bb21292a02246afd314ebe093dd312f22ac8e6ae16dd", size = 84230, upload-time = "2025-05-13T15:47:58.252Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/6e/15cbc39b8b096f277ee5f0d874691cde3a88b6376d6ea8af4fd1eced9972/bitstruct-8.21.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ce075da108d7f1365441d4c79ebf327fd51c7269ccc5df883684d35fee224d9", size = 81228, upload-time = "2025-05-13T15:47:59.146Z" },
-    { url = "https://files.pythonhosted.org/packages/99/02/e6cbe00af40641afdecabe94716331d184cfb20a5f824d734078d304b7f6/bitstruct-8.21.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1bd9e07e8024ba76204fef264f6f63c8a5e409bb6b06b1b0e67d08cd02171f94", size = 75740, upload-time = "2025-05-13T15:48:00.317Z" },
-    { url = "https://files.pythonhosted.org/packages/05/a5/fe29fe46b32ae1207c99f2b79934bcfdfba02df51c4362673f373e227fac/bitstruct-8.21.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:8b338be695a7209b56dcdb9f2f7a6da3f812c1ee25308f51051c831c63504806", size = 79786, upload-time = "2025-05-13T15:48:01.242Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/89/7389f5b4deaf1760bfcf578b1d4cf0c3be8891bd32f4b9c20c56cef3d3f0/bitstruct-8.21.0-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:d6e12098f64d9f8c43ca49c39aea72e7ab9cae957f2562e0eef990bf29473c5c", size = 75898, upload-time = "2025-05-13T15:48:02.072Z" },
-    { url = "https://files.pythonhosted.org/packages/28/9c/2cdb76aba0363fa25d99b3ed615160cb5ef6c59f10dfec2a4d36646b3588/bitstruct-8.21.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:8ca9c13155c15a5d85682f49cb90cc3b62e84702f281226061055254b05d84fb", size = 74081, upload-time = "2025-05-13T15:48:02.959Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/ec/866fe3e5ab69e4c36ca2981034be72d6cbe4839ce5db1c08166864526644/bitstruct-8.21.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:771c7037718d9cb19cd60ccf9c6caa2e39fea1719ca1d499c25c7b8134ca1e33", size = 79028, upload-time = "2025-05-13T15:48:03.987Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/ee/2ae6fd23143b7ca609313b5216292d73b6e057002c9a3c86c9e79557c11d/bitstruct-8.21.0-cp310-cp310-win32.whl", hash = "sha256:dfd02a001f1224cc94c04fcf6fd6ae07bb2c34a949ac968e0c4a477390e9d20e", size = 34843, upload-time = "2025-05-13T15:48:04.831Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/9f/3d15ab6319c4d80687bbebc97326d40f3d5b3f6be0979c7ab64d46c1a756/bitstruct-8.21.0-cp310-cp310-win_amd64.whl", hash = "sha256:50fc1700ceef3049a9c9d9963538e56a229354b4dd5701ebb04cf96452a9cf56", size = 36850, upload-time = "2025-05-13T15:48:05.685Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/f9/7fd48eba504533f27742c7ad2525cf472150be5c480db54097991379aabb/bitstruct-8.21.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4ed2ebdceec1372330a4a9318a3c46983417015a160e46e27348fe7e53f8831a", size = 37890, upload-time = "2025-05-13T15:48:06.551Z" },
-    { url = "https://files.pythonhosted.org/packages/76/a9/daf8d4a36fbdcaf46ea9fe4f3c5f7b088d35d9e003545c2e398398e6c30e/bitstruct-8.21.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:3969761b8b37fc6f868180389e8587ed7e04b078d6a03c20a4f30c7024fa8389", size = 38437, upload-time = "2025-05-13T15:48:07.371Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/cc/cf9f70de02840fafc0968e01cefefb4739cb4b473e5805029edbf16f4370/bitstruct-8.21.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1f068e77c20d97bf21e693aa641e7d55c1473186f328476ba1a363f131194f42", size = 84364, upload-time = "2025-05-13T15:48:08.31Z" },
-    { url = "https://files.pythonhosted.org/packages/20/cd/65733278cf5f2c6ac1d22e165d24779c5701da2811368b0ed977b0e5706a/bitstruct-8.21.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:c8c296b5358564ef956140bc0489510659e67e8e03703ef5533a7d3bdf3be1b0", size = 86688, upload-time = "2025-05-13T15:48:09.522Z" },
-    { url = "https://files.pythonhosted.org/packages/94/cf/c1d157506ca389a51dcf0c7b474926ff7ada937f290e456648815b43eaec/bitstruct-8.21.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:760cb4993e056f514465e5801f4f1e99fab39f30c18ef5663c66aa1dd8fec3be", size = 82945, upload-time = "2025-05-13T15:48:10.466Z" },
-    { url = "https://files.pythonhosted.org/packages/90/9a/2e0b8ea7cf0d06ed2d009bc4dbd0920921716fa5a66eee3f6f723dbd5ba7/bitstruct-8.21.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b5c6d1b0aa8a842ddb97f5473d2e514f599417fc3cf73d4eaa117d9400f23293", size = 77667, upload-time = "2025-05-13T15:48:11.377Z" },
-    { url = "https://files.pythonhosted.org/packages/10/b5/bcf7ac5b58b475e2565c0aaa56d09317b24781cee999bf18a0f782c51cc2/bitstruct-8.21.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:796347dae4e9162d31cdbe69e6225edb21bd3cccf476a7fbdc6dc7d506064bc2", size = 81458, upload-time = "2025-05-13T15:48:12.567Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/62/913cc3b274bc666b5f48af63d1d411f298528febe1866eb6054d37ad3500/bitstruct-8.21.0-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:214bb06f69c6abaf2f8b707fe709ccf60d9c75a68736f0bf57354b7b8843cbae", size = 77569, upload-time = "2025-05-13T15:48:15.917Z" },
-    { url = "https://files.pythonhosted.org/packages/04/ab/87e8d084259d07220e8c868de115b0f0b0b88beb4651531352af93315615/bitstruct-8.21.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:89a39783a8af94e3fdf42e69f99928c780abd40842715e5cbc49429de6f0c2a6", size = 75569, upload-time = "2025-05-13T15:48:16.833Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/58/de694199149d6a769f19807f0d04138de0ebfcb0c20ce546a6814f28c138/bitstruct-8.21.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:8d249947093c3b6d6c9c2ee286d9398bf5a2231a1225a1f0efb7fa52eaa252bb", size = 80606, upload-time = "2025-05-13T15:48:18.229Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/6c/335ec432b9f9cc293657bf0cab1af9a597f54faf2ed235cc5cbb674ff158/bitstruct-8.21.0-cp311-cp311-win32.whl", hash = "sha256:e0bca81bb7e4cd76fbd3cf39e7b4a4bc53cbd12b996542e369ad67bb7a52ef8f", size = 34834, upload-time = "2025-05-13T15:48:19.192Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/a0/35116543bef28c6617a13cf77765aaca43d9ef0c20da12b83ac43f296289/bitstruct-8.21.0-cp311-cp311-win_amd64.whl", hash = "sha256:0be6dbc5fd0777877215edc516b84fabe9b94c37d46f8828c0c7b485e6ba6f88", size = 36842, upload-time = "2025-05-13T15:48:20Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/7e/2d93931410f1f2fa104076811be96e5a57f78197f10f5848bd5594120a58/bitstruct-8.21.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c83ec458453ed9950ff3735b9ad5d6a19b33317729abc5aebdf11b2768b05634", size = 38170, upload-time = "2025-05-13T15:48:20.795Z" },
-    { url = "https://files.pythonhosted.org/packages/52/80/bb6be4ad966efeb2ded4394ac39819d729948464718f55f3f116c2d3e521/bitstruct-8.21.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:426364d4054009003da15e37f95bd683762398949b7c544215d2613f192bc1d7", size = 38497, upload-time = "2025-05-13T15:48:21.694Z" },
-    { url = "https://files.pythonhosted.org/packages/20/15/d88dc97564cbbeba53c9f039a1a9c6b174a36286681e6f4528f3722f9914/bitstruct-8.21.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e1b970bed311aa269ea765bc32444beabc38e27acf203bf027b9d87a5f175e2e", size = 84881, upload-time = "2025-05-13T15:48:22.989Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/3d/32dbb382f31ac6fd0bfe6d624eb130c33cda6b452bc981d05fa66a36821a/bitstruct-8.21.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:64734ad9df02f366f6f60cc0dd20368f64e9e8d9fb739b19fc6acfd3c17e1c22", size = 87456, upload-time = "2025-05-13T15:48:23.85Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/b3/b2508269f443a20dbf528fb353332ccddb8824ec70853551c8cbc93d8ea6/bitstruct-8.21.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a8c18a9d6f5b5164ce18c2b764b0974f36809419f7084def7882b9ba411614bf", size = 83738, upload-time = "2025-05-13T15:48:24.705Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/10/b65e288b0603ae7fb1e2efe9650a9bd48dfd1e6351625e48a87831d9d3af/bitstruct-8.21.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:08aef3b4652183315ce44cebb48c6a9bac4d6f3516757e072557e0eb7ed361a8", size = 78068, upload-time = "2025-05-13T15:48:26.11Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/c8/541ad41960a9458bceb15cf1943180aeb6b5275417695f653d1880bae701/bitstruct-8.21.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:9d93b09fdc8aa503c2e8f3a68ee33e9bd3c4147de361ac3a92318f5465d4e234", size = 81721, upload-time = "2025-05-13T15:48:27.278Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/bb/bb81392d1afb856ce89c3f8aea2f8d58ab7c27b9b36819232406e9a839d6/bitstruct-8.21.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:9cfe200b35e618517af8e3827cf7a9b508015f391d4a7bb02f71be71e3be4581", size = 78260, upload-time = "2025-05-13T15:48:28.202Z" },
-    { url = "https://files.pythonhosted.org/packages/39/29/81742366a9dd43317113cda0f6d094c092a5a65191a43cad7a78144a0dcb/bitstruct-8.21.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:0e08bbb442d0cb36f993ff2756b68332b0d19eae4775f63c29ca29ccd95a7fc1", size = 76075, upload-time = "2025-05-13T15:48:29.162Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/72/953225f5925de89f1e69f49f09e685ad11c567c1b64ca1c842063e0b90c8/bitstruct-8.21.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5e803bb72bf786295dadf8c38b82f5e5339abf4eae8929b042f79580e071b411", size = 81234, upload-time = "2025-05-13T15:48:30.12Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/44/619c685bf775325c19437f5a8675bc1abd9b47dc8294b56fb05260e6ffc1/bitstruct-8.21.0-cp312-cp312-win32.whl", hash = "sha256:ffd0aefc9fc5f31cf02afea2ae93a38fe8c4785102aca9b6a40d33f44df1419b", size = 34810, upload-time = "2025-05-13T15:48:30.962Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/6f/a466e73cffe390da29ca82e344c6973640ea035cefc8e342f8d977898bf3/bitstruct-8.21.0-cp312-cp312-win_amd64.whl", hash = "sha256:516bdd523f3955630fcf21bed40007e49384904248ce9b232339f1307320dcce", size = 36932, upload-time = "2025-05-13T15:48:31.776Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/25/859028eaa6cbf66504d7aecc71e3bd6f6bac3193fb6ec233be0a85067ea8/bitstruct-8.21.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:55c114181188984cd214b432ea791c1c1d463d66b745e4d98451f214bc70a913", size = 38182, upload-time = "2025-05-13T15:48:32.671Z" },
-    { url = "https://files.pythonhosted.org/packages/02/00/bbc2d706207436b61ef5cf7d695c822e5e616b3a8a2f6bb72322dba19e85/bitstruct-8.21.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8eba4a6b62d5fb27a7256268e5ae72d5698aa05f6600bcf8ac8e4ed7dc0257fe", size = 38473, upload-time = "2025-05-13T15:48:33.518Z" },
-    { url = "https://files.pythonhosted.org/packages/58/fd/b2df4df5e882fbf19b0064f6cdebc84c44476005121ed324d17517dbb2bd/bitstruct-8.21.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5661d549dbd7222dc8c8ca0642ba119663b8989cec84ca897a00f8f8eae05666", size = 84840, upload-time = "2025-05-13T15:48:34.334Z" },
-    { url = "https://files.pythonhosted.org/packages/29/0b/c0303d4a868de68dfba7a3ed7f03e79770c5288896205eba4fb93f934760/bitstruct-8.21.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:7f2c5b8a0fae90432312df763f4798ee0bf280a88f87e83b461aa0d62c2a40a6", size = 86084, upload-time = "2025-05-13T15:48:35.309Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/3d/2fc35185f25dd14623b95413abd1bae325bc2cbf811cc77da59a31db2f25/bitstruct-8.21.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8b2325c5480474c6ecda1e61ffc5e0d2ce2b87c7125dd108ab6c2457fd36d30d", size = 83654, upload-time = "2025-05-13T15:48:36.638Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/4c/26fea1d4ab16cd10dbea1085f440ddcc7377d8d631a2e91d7d96ac788ece/bitstruct-8.21.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:19fd5a131a9f96e428ed9b96b770fbac6b18d6a90b40c8290af9a7ad1875c7b1", size = 78018, upload-time = "2025-05-13T15:48:37.495Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/66/3aaa0c7678958dbd70f29e8429f51f1cb10363c4ee21f4c66f761e6a4497/bitstruct-8.21.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f413d7854081669dfdbd57ab444066ac81fa2277204eed4a03ed7bb750ecc7d5", size = 81778, upload-time = "2025-05-13T15:48:38.347Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/d3/8c93a7acbbefa6918f845a8ff68825ddfd21d3fe2de3240d69c957ae57de/bitstruct-8.21.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:b88912f6942cc6a952a910bfb382b0883717e82a96d20e9bc80e20605373d5bb", size = 78316, upload-time = "2025-05-13T15:48:39.584Z" },
-    { url = "https://files.pythonhosted.org/packages/83/c2/976642a7f339e4835e8ff7478edd9137ff4c99dc5134a4867fd0266e3659/bitstruct-8.21.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:bf0ea3876f3c02999c0f32a200e8871b0e6822351be60d4524f8526cfc24018a", size = 76127, upload-time = "2025-05-13T15:48:40.789Z" },
-    { url = "https://files.pythonhosted.org/packages/72/58/aed86d66c492475e5d3d3be95938c9ce09fcf79a460b6fc425a7bc885608/bitstruct-8.21.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:efcd8ecbd52e97701ff4cdb68c6d6ec423fc6c90ad9d0d95c171c6630df645e5", size = 81283, upload-time = "2025-05-13T15:48:41.722Z" },
-    { url = "https://files.pythonhosted.org/packages/24/81/9eec9e530ef7102f26fdcec2f6a51242332a6cacf6fc715ec88378b61682/bitstruct-8.21.0-cp313-cp313-win32.whl", hash = "sha256:403bb9f4ed45decdb8d20143c59b780d953201cdf2e3567e5e608da807f1aa1f", size = 34812, upload-time = "2025-05-13T15:48:42.577Z" },
-    { url = "https://files.pythonhosted.org/packages/66/1d/32e5f22ca15e2f626fa7afd404d84341bdc05a7cc30d1e8517f399762e8b/bitstruct-8.21.0-cp313-cp313-win_amd64.whl", hash = "sha256:91c34823a6bcff40a2b482b298c62e01cc2f5c11f32f6d3cf94ca9cfbf3ae75d", size = 36931, upload-time = "2025-05-13T15:48:46.182Z" },
-    { url = "https://files.pythonhosted.org/packages/96/14/eff681ffce682e449a71d87182f02e62559ae77a646e4fc45f4333179a4d/bitstruct-8.21.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:2100430ec231e883f901fa192075910217b72de30d150cf711f855179d05a72b", size = 37891, upload-time = "2025-05-13T15:48:47.334Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/85/926aaf93aebdec69172443ebf8a578d8d0878cba77e40ec089c3ab2e8b68/bitstruct-8.21.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:4dcb64d1d550480d4f1a70e0540ad69345d43c805c6e972af1da8f57a7caf342", size = 38428, upload-time = "2025-05-13T15:48:48.219Z" },
-    { url = "https://files.pythonhosted.org/packages/25/c2/febc0b1dbff1fa2171cea1b4a4980c5c2d8f8b2e027b6693b44501b7461b/bitstruct-8.21.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:13d83a946afa26dbc5dbbc387490c05ba710bc678989a17057e7d7ede32af014", size = 82243, upload-time = "2025-05-13T15:48:49.042Z" },
-    { url = "https://files.pythonhosted.org/packages/90/b1/78162cdf63b22303859327612243735bbb448c499773bacf0c7006ae5664/bitstruct-8.21.0-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:495070c753a6d8dbf8d4849313d189bb68102dbf3594ce0fa9dd1b4fe02de148", size = 83785, upload-time = "2025-05-13T15:48:49.891Z" },
-    { url = "https://files.pythonhosted.org/packages/29/29/917c7c2f63589130f4cd3ce4715c233315779005e809152ee1c46f956551/bitstruct-8.21.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:176f5523bf507b60d508a1757e2bad47104db2f2b3565b101270100a48a0f6cf", size = 80812, upload-time = "2025-05-13T15:48:51.246Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/a7/639b9d034b8567ae9dd78e8a68cee75d2981c76c040d3107b27961a690a2/bitstruct-8.21.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a70a9cc202704ee63b2de5b895bff013e97f693722cf1ccba7d0112a3f3e0f28", size = 75387, upload-time = "2025-05-13T15:48:52.166Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/f5/568c09e36e6e9a97ce28200708eca13aa20e13bce842927034563a1fe834/bitstruct-8.21.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:3a5db5f7760245b7a94c8f0d7beb70d122567b779a0f8ed1b0c8a7f6cedfe869", size = 79440, upload-time = "2025-05-13T15:48:53.033Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/2f/2ac82edabc7e589b8dfce0d20d7c77536b6927bf924940362c8fc35a3461/bitstruct-8.21.0-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:53307ab06229953e35426d3c2f9889eb0f40d81e36a9dff446aac996f406db58", size = 75494, upload-time = "2025-05-13T15:48:53.906Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/31/944a5770d65766a8781b788392ca1785b1731b1b7f8e0d6f63e52427f449/bitstruct-8.21.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:d2035a5ddd776c76908e9d10c704ecfbfd8cd980c7356067b75cd710fca66ccf", size = 73711, upload-time = "2025-05-13T15:48:55.49Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/8d/95af39769767777306cce89e0bc3549c14c0a5951c36ed5f282ededab5c2/bitstruct-8.21.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:93116f94059693428a07fe48054201c62c2cd6a4369a1b2ac1a2144273dffdf1", size = 78653, upload-time = "2025-05-13T15:48:56.833Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/7e/ed49be12bfd117e66965dd81fe72debb5a260698a3c7a61360922c77af65/bitstruct-8.21.0-cp39-cp39-win32.whl", hash = "sha256:239f49c9e4749dc28bab5c2b54ba0b6be37b7bca2886d57cf68586a46fcba0a4", size = 34861, upload-time = "2025-05-13T15:48:57.698Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/8b/e3b33d8dc1094994644ad58f07893744380be7690e6afc245c877518deb3/bitstruct-8.21.0-cp39-cp39-win_amd64.whl", hash = "sha256:633654162cc9a107dd4777d0de30bbab4aab6777625a813e09cfef10c69c131c", size = 36886, upload-time = "2025-05-13T15:48:58.533Z" },
-]
-
-[[package]]
 name = "click"
 version = "8.1.8"
 source = { registry = "https://pypi.org/simple" }
@@ -556,14 +430,13 @@ wheels = [
 name = "fit-tool"
 version = "0.9.15"
 source = { editable = "." }
-dependencies = [
-    { name = "bitstruct", version = "8.20.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "bitstruct", version = "8.21.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
-    { name = "inflection" },
-    { name = "openpyxl" },
-]
 
 [package.optional-dependencies]
+gen = [
+    { name = "inflection" },
+    { name = "jinja2" },
+    { name = "openpyxl" },
+]
 test = [
     { name = "pytest", version = "8.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
@@ -574,9 +447,12 @@ test = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "inflection" },
+    { name = "jinja2" },
     { name = "mypy", version = "1.14.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "mypy", version = "1.19.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
     { name = "mypy", version = "2.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "openpyxl" },
     { name = "pytest", version = "8.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
     { name = "pytest", version = "9.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
@@ -589,17 +465,20 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "bitstruct", specifier = ">=8.11.1" },
-    { name = "inflection", specifier = ">=0.5.1" },
-    { name = "openpyxl", specifier = ">=2.5.12" },
+    { name = "inflection", marker = "extra == 'gen'", specifier = ">=0.5.1" },
+    { name = "jinja2", marker = "extra == 'gen'", specifier = ">=3.0" },
+    { name = "openpyxl", marker = "extra == 'gen'", specifier = ">=2.5.12" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=7.0" },
     { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=4.0" },
 ]
-provides-extras = ["test"]
+provides-extras = ["gen", "test"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "inflection", specifier = ">=0.5.1" },
+    { name = "jinja2", specifier = ">=3.0" },
     { name = "mypy", specifier = ">=1.14.1" },
+    { name = "openpyxl", specifier = ">=2.5.12" },
     { name = "pytest", specifier = ">=7.0" },
     { name = "pytest-cov", specifier = ">=4.0" },
     { name = "ruff", specifier = ">=0.15.22" },


### PR DESCRIPTION
## Summary

Separate end-user runtime install from profile-generation tooling so consumers of `fit-tool` do not pull gen-only packages.

- Core `dependencies` are now empty (runtime library + `fit-tool` CLI need no third-party packages)
- New optional `[gen]` extra: `openpyxl`, `inflection`, `jinja2` (jinja2 was previously undeclared but required by `gen-profile`)
- Removed unused `bitstruct`
- Dev dependency group still includes gen packages so `uv sync --group dev` runs the full suite and `gen-profile`
- `gen-profile` exits with a clear install hint when gen deps are missing
- Spreadsheet loading lazy-imports `openpyxl`; pure profile parser unit tests still run without it
- README / AGENTS install notes updated

Closes SHA-6

## Test plan

- [x] `uv lock` via uv (not hand-edited)
- [x] `uv sync --group dev` + `uv run pytest` → 224 passed, 1 skipped (Garmin JS interop)
- [x] `uv build` succeeds; wheel metadata has no hard Requires-Dist for openpyxl/inflection/bitstruct
- [x] Clean venv wheel install: only `fit-tool`; openpyxl/inflection/bitstruct/jinja2 absent; `import fit_tool` and `fit-tool -h` work
- [x] `gen-profile` without gen extras exits 1 with install hint
- [x] `pip install 'fit-tool[gen]'` pulls openpyxl/inflection/jinja2
- [x] `pytest fit_tool/tests/test_profile.py` without openpyxl: 10 passed, 1 skipped
- [x] `pytest fit_tool/tests/test_cli.py` without gen deps: 10 passed