### PR TITLE
SHA-7: Wire layer MVP (RawRecord + FitFile facade)

### DIFF
--- a/fit_tool/compatibility.py
+++ b/fit_tool/compatibility.py
@@ -1,0 +1,187 @@
+"""Compatibility bridge from wire models to the existing public FitFile types.
+
+The wire package stays free of generated Profile message classes. This module
+projects raw records into :class:`~fit_tool.record.Record`,
+:class:`~fit_tool.definition_message.DefinitionMessage`, and
+:class:`~fit_tool.data_message.DataMessage` for the FitFile facade.
+"""
+
+from __future__ import annotations
+
+import struct
+
+from fit_tool.base_type import BaseType
+from fit_tool.data_message import DataMessage
+from fit_tool.definition_message import DefinitionMessage
+from fit_tool.developer_field import DeveloperField
+from fit_tool.developer_field_definition import DeveloperFieldDefinition
+from fit_tool.endian import Endian
+from fit_tool.exceptions import FitRecordError
+from fit_tool.field_definition import FieldDefinition
+from fit_tool.fit_file_header import FitFileHeader, ProfileVersion, ProtocolVersion
+from fit_tool.profile.messages.field_description_message import FieldDescriptionMessage
+from fit_tool.record import Record, RecordHeader
+from fit_tool.wire.model import (
+    FitSegment,
+    RawDataRecord,
+    RawDefinitionRecord,
+    RawFileHeader,
+    RawRecord,
+)
+
+
+def project_header(raw: RawFileHeader) -> FitFileHeader:
+    """Project a wire header into the existing FitFileHeader type."""
+    protocol = ProtocolVersion(raw.protocol_version >> 4, raw.protocol_version & 0x0F)
+    scale = (
+        ProfileVersion.CURRENT_MAJOR_SCALE
+        if raw.profile_version > ProfileVersion.SCALE_CHANGE_VALUE
+        else ProfileVersion.LEGACY_MAJOR_SCALE
+    )
+    profile = ProfileVersion(raw.profile_version // scale, raw.profile_version % scale)
+    return FitFileHeader(
+        records_size=raw.records_size,
+        protocol_version=protocol,
+        profile_version=profile,
+        crc=raw.crc,
+    )
+
+
+def definition_from_raw(raw: RawDefinitionRecord) -> DefinitionMessage:
+    """Build a DefinitionMessage from an immutable wire definition snapshot."""
+    field_definitions = [
+        FieldDefinition(
+            field_id=field_def.field_id,
+            size=field_def.size,
+            base_type=BaseType(field_def.base_type),
+        )
+        for field_def in raw.field_definitions
+    ]
+    developer_field_definitions = [
+        DeveloperFieldDefinition(
+            field_id=field_def.field_id,
+            size=field_def.size,
+            developer_data_index=field_def.developer_data_index,
+        )
+        for field_def in raw.developer_field_definitions
+    ]
+    return DefinitionMessage(
+        local_id=raw.local_id,
+        global_id=raw.global_id,
+        endian=Endian(raw.architecture),
+        field_definitions=field_definitions,
+        developer_field_definitions=developer_field_definitions,
+    )
+
+
+def record_header_from_raw(raw_header) -> RecordHeader:
+    """Project a wire record header into RecordHeader."""
+    return RecordHeader(
+        is_time_compressed=raw_header.is_time_compressed,
+        is_definition=raw_header.is_definition,
+        has_developer_fields=raw_header.has_developer_fields,
+        local_id=raw_header.local_id,
+        time_offset_seconds=raw_header.time_offset_seconds,
+    )
+
+
+def project_definition_record(raw: RawDefinitionRecord) -> Record:
+    """Project a wire definition record to a compatibility Record."""
+    header = record_header_from_raw(raw.header)
+    message = definition_from_raw(raw)
+    return Record(header, message)
+
+
+def project_data_record(
+        raw: RawDataRecord,
+        developer_fields_by_data_index: dict[int, dict[int, DeveloperField]],
+) -> Record:
+    """Project a wire data record to a typed DataMessage wrapped in a Record."""
+    header = record_header_from_raw(raw.header)
+    # Always build DefinitionMessage from the snapshot attached to this record so
+    # redefinition of the same local_id cannot mutate earlier projections.
+    definition_message = definition_from_raw(raw.definition)
+
+    if developer_fields_by_data_index and definition_message.developer_field_definitions:
+        developer_fields = definition_message.get_developer_fields(developer_fields_by_data_index)
+    else:
+        developer_fields = []
+
+    try:
+        message = DataMessage.from_bytes(
+            definition_message,
+            developer_fields,
+            raw.payload,
+            offset=0,
+        )
+    except (IndexError, struct.error, UnicodeError, ValueError) as exc:
+        raise FitRecordError(
+            f'Could not project data record at byte offset {raw.source_offset}: {exc}'
+        ) from exc
+
+    message.local_id = raw.local_id
+    return Record(header, message)
+
+
+def _register_developer_field(
+        record: Record,
+        developer_fields_by_data_index: dict[int, dict[int, DeveloperField]],
+) -> None:
+    if not isinstance(record.message, FieldDescriptionMessage):
+        return
+
+    message = record.message
+    if (
+        message.developer_data_index is None
+        or message.field_definition_number is None
+        or message.fit_base_type_id is None
+    ):
+        raise FitRecordError('Field description is missing required developer-field metadata.')
+
+    developer_field = DeveloperField(
+        developer_data_index=message.developer_data_index,
+        field_id=message.field_definition_number,
+        base_type=BaseType(message.fit_base_type_id),
+        name=message.field_name,
+        scale=message.scale,
+        offset=message.offset,
+        units=message.units,
+    )
+    fields_by_id = developer_fields_by_data_index.setdefault(developer_field.developer_data_index, {})
+    fields_by_id[developer_field.field_id] = developer_field
+
+
+def project_segment(segment: FitSegment) -> list[Record]:
+    """Project all wire records in a segment to compatibility Records."""
+    records: list[Record] = []
+    developer_fields_by_data_index: dict[int, dict[int, DeveloperField]] = {}
+
+    for raw in segment.records:
+        if isinstance(raw, RawDefinitionRecord):
+            record = project_definition_record(raw)
+        elif isinstance(raw, RawDataRecord):
+            record = project_data_record(raw, developer_fields_by_data_index)
+            _register_developer_field(record, developer_fields_by_data_index)
+        else:
+            raise FitRecordError(f'Unsupported wire record type: {type(raw)!r}')
+        records.append(record)
+
+    return records
+
+
+def project_records(records: list[RawRecord]) -> list[Record]:
+    """Project a sequence of raw records (used by unit tests)."""
+    segment = FitSegment(
+        header=RawFileHeader(
+            header_size=14,
+            protocol_version=0x20,
+            profile_version=0,
+            records_size=0,
+            data_type=b'.FIT',
+            crc=None,
+            source_offset=0,
+            source_bytes=b'',
+        ),
+        records=list(records),
+    )
+    return project_segment(segment)

--- a/fit_tool/fit_file.py
+++ b/fit_tool/fit_file.py
@@ -6,18 +6,24 @@ import struct
 import tempfile
 from typing import BinaryIO, Iterator
 
-from fit_tool.base_type import BaseType
-from fit_tool.definition_message import DefinitionMessage
-from fit_tool.developer_field import DeveloperField
-from fit_tool.exceptions import FitCRCError, FitEncodingError, FitHeaderError, FitRecordError
+from fit_tool.compatibility import project_header, project_segment
+from fit_tool.exceptions import FitCRCError, FitEncodingError
 from fit_tool.fit_file_header import FitFileHeader
-from fit_tool.profile.messages.field_description_message import FieldDescriptionMessage
 from fit_tool.record import Record
 from fit_tool.utils.crc import crc16
 from fit_tool.utils.logging import logger
+from fit_tool.wire.decoder import WireDecoder
 
 
 class FitFile:
+    """Public FIT file facade.
+
+    Decode goes through the wire layer (:class:`~fit_tool.wire.decoder.WireDecoder`)
+    and projects raw records to typed messages. Encode still serializes the
+    projected :class:`~fit_tool.record.Record` list (lossless unknown-field
+    rewrite is deferred).
+    """
+
     def __init__(self, header: FitFileHeader, records: list[Record], crc: int | None = None):
         self.header = header
         self.records = records
@@ -46,27 +52,6 @@ class FitFile:
         self.records.remove(record)
         self.mark_dirty()
 
-    @staticmethod
-    def _parse_record(
-            definition_messages: dict[int, DefinitionMessage],
-            bytes_buffer: bytes | memoryview,
-            offset: int,
-            developer_fields_by_data_index: dict[int, dict[int, DeveloperField]],
-            record_index: int) -> Record:
-        try:
-            return Record.from_bytes(
-                definition_messages=definition_messages,
-                bytes_buffer=bytes_buffer,
-                offset=offset,
-                developer_fields_by_data_index=developer_fields_by_data_index,
-            )
-        except FitRecordError:
-            raise
-        except (IndexError, struct.error, UnicodeError, ValueError) as exc:
-            raise FitRecordError(
-                f'Could not parse record {record_index} at byte offset {offset}: {exc}'
-            ) from exc
-
     @classmethod
     def from_file(cls, path: str) -> FitFile:
         with open(path, 'rb') as file_object:
@@ -86,92 +71,30 @@ class FitFile:
 
     @classmethod
     def from_bytes(cls, bytes_buffer: bytes, check_crc: bool = True) -> FitFile:
-        if len(bytes_buffer) < 1:
-            raise FitHeaderError('FIT data is empty; expected at least a header-size byte.')
+        """Parse FIT bytes via the wire decoder, then project to typed records."""
+        document = WireDecoder(check_crc=check_crc).decode(bytes_buffer)
+        segment = document.first_segment
+        if segment is None:
+            raise FitEncodingError('Wire decoder returned an empty document.')
 
-        crc = 0
-        buffer_view = memoryview(bytes_buffer)
-        offset = 0
-
-        header_size = bytes_buffer[0]
-        if header_size < 12:
-            raise FitHeaderError(f'FIT header size must be at least 12 bytes, got {header_size}.')
-        if len(bytes_buffer) < header_size:
-            raise FitHeaderError(f'FIT header declares {header_size} bytes but only {len(bytes_buffer)} are available.')
-
-        try:
-            header_bytes = buffer_view[:header_size]
-            header = FitFileHeader.from_bytes(header_bytes)
-        except (IndexError, struct.error, ValueError) as exc:
-            raise FitHeaderError(f'Invalid FIT header: {exc}') from exc
-        crc = crc16(header_bytes, crc=crc)
-        offset += header_size
-        records_end = offset + header.records_size
-        if records_end + 2 > len(bytes_buffer):
-            raise FitHeaderError('FIT data is truncated before the declared records and file CRC.')
-        records_view = buffer_view[:records_end]
-
-        records = []
-        definition_messages: dict[int, DefinitionMessage] = {}
-        developer_fields_by_data_index: dict[int, dict[int, DeveloperField]] = {}
-
-        record_index = 0
-        record_bytes_remaining_count = header.records_size
-        while record_bytes_remaining_count > 0:
-            record = cls._parse_record(
-                definition_messages,
-                records_view,
-                offset,
-                developer_fields_by_data_index,
-                record_index,
+        if segment.calculated_crc != segment.stored_crc and not check_crc:
+            logger.warning(
+                f'Calculated crc ({hex(segment.calculated_crc)}) does not match '
+                f'crc in file ({hex(segment.stored_crc)}).'
             )
 
-            if record.is_definition:
-                definition_messages[record.local_id] = record.message
-            elif isinstance(record.message, FieldDescriptionMessage):
-                message = record.message
-                developer_field = DeveloperField(developer_data_index=message.developer_data_index,
-                                                 field_id=message.field_definition_number,
-                                                 base_type=BaseType(message.fit_base_type_id),
-                                                 name=message.field_name,
-                                                 scale=message.scale,
-                                                 offset=message.offset,
-                                                 units=message.units)
-                if developer_field.developer_data_index not in developer_fields_by_data_index:
-                    developer_fields_by_data_index[developer_field.developer_data_index] = {}
+        header = project_header(segment.header)
+        records = project_segment(segment)
 
-                developer_fields_by_data_index[developer_field.developer_data_index][
-                    developer_field.field_id] = developer_field
-
-            records.append(record)
-            definition_message = definition_messages[record.local_id]
-            record_size = record.size
-            defined_size = record.defined_size(definition_message)
-            if defined_size <= 0 or defined_size > record_bytes_remaining_count:
-                raise FitRecordError(
-                    f'Record {record_index} at byte offset {offset} exceeds the declared records section.'
-                )
-            crc = crc16(records_view[offset:offset + defined_size], crc=crc)
-
-            if record_size != defined_size:
+        for record_index, (record, raw) in enumerate(zip(records, segment.records)):
+            defined_size = raw.size
+            if record.size != defined_size:
                 logger.warning(
-                    f'Record {record_index}, {record.message}: size ({record_size}) != defined size ({defined_size}). Some fields were not read correctly.')
+                    f'Record {record_index}, {record.message}: size ({record.size}) != '
+                    f'defined size ({defined_size}). Some fields were not read correctly.'
+                )
 
-            record_bytes_remaining_count -= defined_size
-            offset += defined_size
-            record_index += 1
-
-        file_crc, = struct.unpack_from('<H', buffer_view, offset)
-
-        if crc != file_crc:
-            message = f'Calculated crc ({hex(crc)}) does not match crc in file ({hex(file_crc)}).'
-
-            if check_crc:
-                raise FitCRCError(message)
-            else:
-                logger.warning(message)
-
-        return cls(header, records, crc)
+        return cls(header, records, segment.calculated_crc)
 
     def to_bytes(self, check_crc: bool = True) -> bytes:
         try:

--- a/fit_tool/tests/test_wire.py
+++ b/fit_tool/tests/test_wire.py
@@ -1,0 +1,226 @@
+"""Unit tests for the wire-layer MVP (raw models + decoder + FitFile facade)."""
+
+from __future__ import annotations
+
+import copy
+import struct
+import unittest
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+
+from fit_tool.compatibility import definition_from_raw, project_segment
+from fit_tool.definition_message import DefinitionMessage
+from fit_tool.exceptions import FitCRCError, FitHeaderError, FitRecordError
+from fit_tool.fit_file import FitFile
+from fit_tool.fit_file_builder import FitFileBuilder
+from fit_tool.profile.messages.file_id_message import FileIdMessage
+from fit_tool.profile.messages.workout_step_message import WorkoutStepMessage
+from fit_tool.profile.profile_type import Manufacturer, WorkoutStepDuration
+from fit_tool.wire import (
+    RawDataRecord,
+    RawDefinitionRecord,
+    WireDecoder,
+    decode_bytes,
+)
+from fit_tool.wire.model import RawFieldDefinition
+
+DATA_DIR = Path(__file__).resolve().parent / 'data'
+
+
+class TestWireDecoder(unittest.TestCase):
+    def _build_simple_fit_bytes(self) -> bytes:
+        mesg = WorkoutStepMessage(local_id=0)
+        mesg.workout_step_name = '1st step'
+        mesg.duration_type = WorkoutStepDuration.DISTANCE
+        builder = FitFileBuilder(auto_define=True)
+        builder.add(mesg)
+        return builder.build().to_bytes()
+
+    def test_decode_bytes_returns_single_segment(self):
+        raw = self._build_simple_fit_bytes()
+        document = decode_bytes(raw)
+
+        self.assertEqual(len(document.segments), 1)
+        segment = document.first_segment
+        self.assertIsNotNone(segment)
+        assert segment is not None
+        self.assertGreaterEqual(len(segment.records), 2)
+        self.assertEqual(segment.calculated_crc, segment.stored_crc)
+        self.assertTrue(segment.header.source_bytes.startswith(bytes([segment.header.header_size])))
+        self.assertEqual(segment.header.data_type, b'.FIT')
+
+    def test_decode_preserves_definition_and_data_source_bytes(self):
+        raw = self._build_simple_fit_bytes()
+        segment = WireDecoder().decode(raw).first_segment
+        assert segment is not None
+
+        definitions = [r for r in segment.records if isinstance(r, RawDefinitionRecord)]
+        data_records = [r for r in segment.records if isinstance(r, RawDataRecord)]
+        self.assertEqual(len(definitions), 1)
+        self.assertEqual(len(data_records), 1)
+
+        definition = definitions[0]
+        data = data_records[0]
+        self.assertEqual(raw[definition.source_offset:definition.source_offset + definition.size], definition.source_bytes)
+        self.assertEqual(raw[data.source_offset:data.source_offset + data.size], data.source_bytes)
+        self.assertEqual(data.payload, data.source_bytes[1:])
+        self.assertIs(data.definition, definition)
+
+    def test_definition_redefinition_keeps_prior_snapshot(self):
+        """Redefining local_id must not mutate the snapshot held by earlier data records."""
+        # Build a minimal multi-definition buffer via FitFileBuilder using two
+        # different message types on the same local_id.
+        step = WorkoutStepMessage(local_id=0)
+        step.workout_step_name = 'step'
+        step.duration_type = WorkoutStepDuration.DISTANCE
+
+        file_id = FileIdMessage(local_id=0)
+        file_id.manufacturer = Manufacturer.DEVELOPMENT
+        file_id.type = 4  # workout
+
+        builder = FitFileBuilder(auto_define=True)
+        builder.add(step)
+        # Force a second definition for local_id 0 by adding a different message type.
+        builder.add(file_id)
+        fit_bytes = builder.build().to_bytes()
+
+        segment = WireDecoder().decode(fit_bytes).first_segment
+        assert segment is not None
+
+        definition_records = [r for r in segment.records if isinstance(r, RawDefinitionRecord)]
+        data_records = [r for r in segment.records if isinstance(r, RawDataRecord)]
+        self.assertGreaterEqual(len(definition_records), 2)
+        self.assertGreaterEqual(len(data_records), 2)
+
+        first_def = definition_records[0]
+        second_def = definition_records[1]
+        self.assertEqual(first_def.local_id, second_def.local_id)
+        self.assertNotEqual(first_def.global_id, second_def.global_id)
+
+        # Each data record keeps the definition snapshot active when it was decoded.
+        first_data = data_records[0]
+        second_data = data_records[1]
+        self.assertIs(first_data.definition, first_def)
+        self.assertIs(second_data.definition, second_def)
+        self.assertEqual(first_data.definition.global_id, first_def.global_id)
+        self.assertEqual(second_data.definition.global_id, second_def.global_id)
+
+        # Frozen snapshots cannot be mutated in place.
+        with self.assertRaises(FrozenInstanceError):
+            first_def.global_id = 999  # type: ignore[misc]
+
+        # Replacing the "table" view (second def) does not change the first snapshot object.
+        self.assertEqual(first_data.definition.field_definitions, first_def.field_definitions)
+
+    def test_projected_definition_is_independent_copy(self):
+        raw = self._build_simple_fit_bytes()
+        segment = WireDecoder().decode(raw).first_segment
+        assert segment is not None
+        definition_raw = next(r for r in segment.records if isinstance(r, RawDefinitionRecord))
+
+        message_a = definition_from_raw(definition_raw)
+        message_b = definition_from_raw(definition_raw)
+        self.assertEqual(message_a.global_id, message_b.global_id)
+        self.assertIsNot(message_a.field_definitions, message_b.field_definitions)
+
+        message_a.field_definitions.clear()
+        self.assertNotEqual(len(message_a.field_definitions), len(message_b.field_definitions))
+        # Wire snapshot unchanged.
+        self.assertGreater(len(definition_raw.field_definitions), 0)
+
+    def test_invalid_crc_raises(self):
+        raw = bytearray(self._build_simple_fit_bytes())
+        stored, = struct.unpack_from('<H', raw, len(raw) - 2)
+        struct.pack_into('<H', raw, len(raw) - 2, (stored + 1) % 65536)
+
+        with self.assertRaises(FitCRCError):
+            decode_bytes(bytes(raw), check_crc=True)
+
+        document = decode_bytes(bytes(raw), check_crc=False)
+        segment = document.first_segment
+        assert segment is not None
+        self.assertNotEqual(segment.calculated_crc, segment.stored_crc)
+
+    def test_empty_buffer_raises_header_error(self):
+        with self.assertRaises(FitHeaderError):
+            decode_bytes(b'')
+
+    def test_data_without_definition_raises(self):
+        # 14-byte header, one data record header byte with no prior definition, CRC placeholder.
+        header = bytearray(14)
+        header[0] = 14
+        header[8:12] = b'.FIT'
+        # records_size = 1
+        struct.pack_into('<I', header, 4, 1)
+        body = bytes(header) + bytes([0x00]) + struct.pack('<H', 0)
+        with self.assertRaises(FitRecordError):
+            WireDecoder(check_crc=False).decode(body)
+
+    def test_sdk_activity_decodes(self):
+        path = DATA_DIR / 'sdk' / 'Activity.fit'
+        if not path.exists():
+            self.skipTest('SDK Activity.fit fixture missing')
+        document = decode_bytes(path.read_bytes())
+        segment = document.first_segment
+        assert segment is not None
+        self.assertGreater(len(segment.records), 10)
+        self.assertTrue(any(isinstance(r, RawDefinitionRecord) for r in segment.records))
+        self.assertTrue(any(isinstance(r, RawDataRecord) for r in segment.records))
+
+
+class TestFitFileWireFacade(unittest.TestCase):
+    def test_from_bytes_round_trip_compatible(self):
+        mesg = WorkoutStepMessage(local_id=0)
+        mesg.workout_step_name = '1st step'
+        mesg.duration_type = WorkoutStepDuration.DISTANCE
+        builder = FitFileBuilder(auto_define=True)
+        builder.add(mesg)
+        original = builder.build()
+        bytes1 = original.to_bytes()
+
+        reparsed = FitFile.from_bytes(bytes1)
+        bytes2 = reparsed.to_bytes()
+        self.assertEqual(bytes2, bytes1)
+
+    def test_from_bytes_projects_typed_messages(self):
+        mesg = WorkoutStepMessage(local_id=0)
+        mesg.workout_step_name = '1st step'
+        mesg.duration_type = WorkoutStepDuration.DISTANCE
+        builder = FitFileBuilder(auto_define=True)
+        builder.add(mesg)
+        fit_file = FitFile.from_bytes(builder.build().to_bytes())
+
+        data_messages = [r.message for r in fit_file.records if not r.is_definition]
+        self.assertEqual(len(data_messages), 1)
+        self.assertIsInstance(data_messages[0], WorkoutStepMessage)
+        self.assertEqual(data_messages[0].workout_step_name, '1st step')
+
+    def test_project_segment_definition_local_id(self):
+        mesg = WorkoutStepMessage(local_id=3)
+        mesg.workout_step_name = 'step'
+        mesg.duration_type = WorkoutStepDuration.DISTANCE
+        builder = FitFileBuilder(auto_define=True)
+        builder.add(mesg)
+        segment = WireDecoder().decode(builder.build().to_bytes()).first_segment
+        assert segment is not None
+        records = project_segment(segment)
+        definitions = [r for r in records if r.is_definition]
+        self.assertEqual(len(definitions), 1)
+        self.assertEqual(definitions[0].local_id, 3)
+        self.assertIsInstance(definitions[0].message, DefinitionMessage)
+        self.assertEqual(definitions[0].message.local_id, 3)
+
+
+class TestRawModelBasics(unittest.TestCase):
+    def test_raw_field_definition_is_frozen(self):
+        field_def = RawFieldDefinition(field_id=1, size=2, base_type=132)
+        with self.assertRaises(FrozenInstanceError):
+            field_def.size = 4  # type: ignore[misc]
+
+    def test_deepcopy_definition_snapshot_is_equal(self):
+        field_def = RawFieldDefinition(field_id=1, size=2, base_type=132)
+        self.assertEqual(copy.deepcopy(field_def), field_def)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/fit_tool/wire/__init__.py
+++ b/fit_tool/wire/__init__.py
@@ -1,0 +1,34 @@
+"""Wire layer: binary-authoritative FIT models and decoder.
+
+Semantic (Profile) projection lives in :mod:`fit_tool.compatibility`. The wire
+package must not import generated message classes.
+"""
+
+from fit_tool.wire.crc import crc16
+from fit_tool.wire.decoder import WireDecoder, decode_bytes
+from fit_tool.wire.model import (
+    FitDocument,
+    FitSegment,
+    RawDataRecord,
+    RawDefinitionRecord,
+    RawDeveloperFieldDefinition,
+    RawFieldDefinition,
+    RawFileHeader,
+    RawRecord,
+    RawRecordHeader,
+)
+
+__all__ = [
+    'FitDocument',
+    'FitSegment',
+    'RawDataRecord',
+    'RawDefinitionRecord',
+    'RawDeveloperFieldDefinition',
+    'RawFieldDefinition',
+    'RawFileHeader',
+    'RawRecord',
+    'RawRecordHeader',
+    'WireDecoder',
+    'crc16',
+    'decode_bytes',
+]

--- a/fit_tool/wire/crc.py
+++ b/fit_tool/wire/crc.py
@@ -1,0 +1,11 @@
+"""CRC helpers for the wire layer.
+
+Reuses the FIT CRC-16 implementation from :mod:`fit_tool.utils.crc` so the
+wire package does not duplicate the table or algorithm.
+"""
+
+from __future__ import annotations
+
+from fit_tool.utils.crc import CRC_TABLE, crc16
+
+__all__ = ['CRC_TABLE', 'crc16']

--- a/fit_tool/wire/decoder.py
+++ b/fit_tool/wire/decoder.py
@@ -1,0 +1,315 @@
+"""Stateful FIT wire decoder.
+
+Produces :class:`~fit_tool.wire.model.FitDocument` / raw records without
+constructing Profile-generated message classes.
+"""
+
+from __future__ import annotations
+
+import struct
+
+from fit_tool.exceptions import FitCRCError, FitHeaderError, FitRecordError
+from fit_tool.wire.crc import crc16
+from fit_tool.wire.model import (
+    FitDocument,
+    FitSegment,
+    RawDataRecord,
+    RawDefinitionRecord,
+    RawDeveloperFieldDefinition,
+    RawFieldDefinition,
+    RawFileHeader,
+    RawRecordHeader,
+)
+
+_IS_TIME_COMPRESSED = 0x80
+_IS_DEFINITION = 0x40
+_HAS_DEVELOPER_FIELDS = 0x20
+_NORMAL_LOCAL_ID = 0x0F
+_TIME_COMPRESSED_LOCAL_ID = 0x60
+_TIME_OFFSET = 0x1F
+
+_FIT_TAG = b'.FIT'
+_MIN_HEADER_SIZE = 12
+_FILE_CRC_SIZE = 2
+_FIELD_DEFINITION_SIZE = 3
+_DEFINITION_PREFIX_SIZE = 5  # reserved + architecture + global_id + field_count
+
+
+class WireDecoder:
+    """Decode FIT binary into raw wire models.
+
+    Definition table entries are immutable snapshots. Redefining a local message
+    ID replaces the table entry for *subsequent* records only.
+    """
+
+    def __init__(self, check_crc: bool = True) -> None:
+        self.check_crc = check_crc
+
+    def decode(self, bytes_buffer: bytes) -> FitDocument:
+        """Decode a buffer into a document (single segment for MVP)."""
+        if len(bytes_buffer) < 1:
+            raise FitHeaderError('FIT data is empty; expected at least a header-size byte.')
+
+        segment, _consumed = self._decode_segment(bytes_buffer, offset=0)
+        return FitDocument(segments=[segment])
+
+    def decode_segment(self, bytes_buffer: bytes, offset: int = 0) -> FitSegment:
+        """Decode a single segment starting at ``offset``."""
+        segment, _ = self._decode_segment(bytes_buffer, offset=offset)
+        return segment
+
+    def _decode_segment(self, bytes_buffer: bytes, offset: int) -> tuple:
+        buffer_view = memoryview(bytes_buffer)
+        start = offset
+
+        header, offset = self._decode_header(buffer_view, offset)
+        calculated_crc = crc16(header.source_bytes)
+
+        records_end = offset + header.records_size
+        file_crc_end = records_end + _FILE_CRC_SIZE
+        if file_crc_end > len(bytes_buffer):
+            raise FitHeaderError('FIT data is truncated before the declared records and file CRC.')
+
+        definitions: dict[int, RawDefinitionRecord] = {}
+        records = []
+        record_index = 0
+        remaining = header.records_size
+
+        while remaining > 0:
+            try:
+                raw_record, record_size = self._decode_record(
+                    buffer_view, offset, definitions, record_index
+                )
+            except FitRecordError:
+                raise
+            except (IndexError, struct.error, ValueError) as exc:
+                raise FitRecordError(
+                    f'Could not parse record {record_index} at byte offset {offset}: {exc}'
+                ) from exc
+
+            if record_size <= 0 or record_size > remaining:
+                raise FitRecordError(
+                    f'Record {record_index} at byte offset {offset} exceeds the declared records section.'
+                )
+
+            if isinstance(raw_record, RawDefinitionRecord):
+                # Store immutable snapshot; redefinition does not mutate prior snapshots.
+                definitions[raw_record.local_id] = raw_record
+
+            calculated_crc = crc16(buffer_view[offset:offset + record_size], crc=calculated_crc)
+            records.append(raw_record)
+            remaining -= record_size
+            offset += record_size
+            record_index += 1
+
+        stored_crc, = struct.unpack_from('<H', buffer_view, offset)
+        if calculated_crc != stored_crc:
+            message = (
+                f'Calculated crc ({hex(calculated_crc)}) does not match crc in file ({hex(stored_crc)}).'
+            )
+            if self.check_crc:
+                raise FitCRCError(message)
+
+        segment = FitSegment(
+            header=header,
+            records=records,
+            stored_crc=stored_crc,
+            calculated_crc=calculated_crc,
+            crc_offset=offset,
+        )
+        return segment, offset + _FILE_CRC_SIZE - start
+
+    def _decode_header(self, buffer_view: memoryview, offset: int) -> tuple:
+        if offset >= len(buffer_view):
+            raise FitHeaderError('FIT data is empty; expected at least a header-size byte.')
+
+        header_size = buffer_view[offset]
+        if header_size < _MIN_HEADER_SIZE:
+            raise FitHeaderError(
+                f'FIT header size must be at least {_MIN_HEADER_SIZE} bytes, got {header_size}.'
+            )
+        if offset + header_size > len(buffer_view):
+            raise FitHeaderError(
+                f'FIT header declares {header_size} bytes but only '
+                f'{len(buffer_view) - offset} are available.'
+            )
+
+        source_bytes = bytes(buffer_view[offset:offset + header_size])
+        try:
+            protocol_version = source_bytes[1]
+            profile_version, = struct.unpack_from('<H', source_bytes, 2)
+            records_size, = struct.unpack_from('<I', source_bytes, 4)
+            data_type = source_bytes[8:12]
+            if data_type != _FIT_TAG:
+                raise ValueError('".FIT" not in header.')
+            crc: int | None = None
+            if header_size >= 14:
+                crc, = struct.unpack_from('<H', source_bytes, 12)
+        except (IndexError, struct.error, ValueError) as exc:
+            raise FitHeaderError(f'Invalid FIT header: {exc}') from exc
+
+        header = RawFileHeader(
+            header_size=header_size,
+            protocol_version=protocol_version,
+            profile_version=profile_version,
+            records_size=records_size,
+            data_type=data_type,
+            crc=crc,
+            source_offset=offset,
+            source_bytes=source_bytes,
+        )
+        return header, offset + header_size
+
+    def _decode_record_header(self, buffer_view: memoryview, offset: int) -> RawRecordHeader:
+        if offset >= len(buffer_view):
+            raise FitRecordError(f'Truncated FIT input while reading record header at offset {offset}.')
+
+        byte = buffer_view[offset]
+        source_bytes = bytes(buffer_view[offset:offset + 1])
+
+        is_time_compressed = (byte & _IS_TIME_COMPRESSED) == _IS_TIME_COMPRESSED
+        if is_time_compressed:
+            # Compressed timestamp headers are always data-message headers.
+            local_id = (byte & _TIME_COMPRESSED_LOCAL_ID) >> 5
+            time_offset_seconds = byte & _TIME_OFFSET
+            return RawRecordHeader(
+                is_time_compressed=True,
+                is_definition=False,
+                has_developer_fields=False,
+                local_id=local_id,
+                time_offset_seconds=time_offset_seconds,
+                source_offset=offset,
+                source_bytes=source_bytes,
+            )
+
+        is_definition = (byte & _IS_DEFINITION) == _IS_DEFINITION
+        has_developer_fields = (byte & _HAS_DEVELOPER_FIELDS) == _HAS_DEVELOPER_FIELDS
+        local_id = byte & _NORMAL_LOCAL_ID
+        return RawRecordHeader(
+            is_time_compressed=False,
+            is_definition=is_definition,
+            has_developer_fields=has_developer_fields,
+            local_id=local_id,
+            time_offset_seconds=0,
+            source_offset=offset,
+            source_bytes=source_bytes,
+        )
+
+    def _decode_record(
+            self,
+            buffer_view: memoryview,
+            offset: int,
+            definitions: dict[int, RawDefinitionRecord],
+            record_index: int,
+    ) -> tuple:
+        header = self._decode_record_header(buffer_view, offset)
+        body_offset = offset + header.size
+
+        if header.is_definition:
+            return self._decode_definition(buffer_view, offset, body_offset, header)
+        return self._decode_data(buffer_view, offset, body_offset, header, definitions, record_index)
+
+    def _decode_definition(
+            self,
+            buffer_view: memoryview,
+            record_offset: int,
+            body_offset: int,
+            header: RawRecordHeader,
+    ) -> tuple:
+        if body_offset + _DEFINITION_PREFIX_SIZE > len(buffer_view):
+            raise FitRecordError(
+                f'Truncated definition message at offset {record_offset}.'
+            )
+
+        reserved = buffer_view[body_offset]
+        architecture = buffer_view[body_offset + 1]
+        if architecture not in (0, 1):
+            raise FitRecordError(
+                f'Invalid definition architecture {architecture} at offset {record_offset}.'
+            )
+
+        endian_symbol = '<' if architecture == 0 else '>'
+        global_id, = struct.unpack_from(f'{endian_symbol}H', buffer_view, body_offset + 2)
+        field_count = buffer_view[body_offset + 4]
+        cursor = body_offset + _DEFINITION_PREFIX_SIZE
+
+        field_definitions = []
+        for _ in range(field_count):
+            if cursor + _FIELD_DEFINITION_SIZE > len(buffer_view):
+                raise FitRecordError(f'Truncated field definitions at offset {record_offset}.')
+            field_id = buffer_view[cursor]
+            size = buffer_view[cursor + 1]
+            base_type = buffer_view[cursor + 2]
+            field_definitions.append(RawFieldDefinition(field_id, size, base_type))
+            cursor += _FIELD_DEFINITION_SIZE
+
+        developer_field_definitions = []
+        if header.has_developer_fields:
+            if cursor >= len(buffer_view):
+                raise FitRecordError(f'Truncated developer field count at offset {record_offset}.')
+            developer_count = buffer_view[cursor]
+            cursor += 1
+            for _ in range(developer_count):
+                if cursor + _FIELD_DEFINITION_SIZE > len(buffer_view):
+                    raise FitRecordError(
+                        f'Truncated developer field definitions at offset {record_offset}.'
+                    )
+                field_id = buffer_view[cursor]
+                size = buffer_view[cursor + 1]
+                developer_data_index = buffer_view[cursor + 2]
+                developer_field_definitions.append(
+                    RawDeveloperFieldDefinition(field_id, size, developer_data_index)
+                )
+                cursor += _FIELD_DEFINITION_SIZE
+
+        source_bytes = bytes(buffer_view[record_offset:cursor])
+        raw = RawDefinitionRecord(
+            header=header,
+            reserved=reserved,
+            architecture=architecture,
+            global_id=global_id,
+            field_definitions=tuple(field_definitions),
+            developer_field_definitions=tuple(developer_field_definitions),
+            source_offset=record_offset,
+            source_bytes=source_bytes,
+        )
+        return raw, len(source_bytes)
+
+    def _decode_data(
+            self,
+            buffer_view: memoryview,
+            record_offset: int,
+            body_offset: int,
+            header: RawRecordHeader,
+            definitions: dict[int, RawDefinitionRecord],
+            record_index: int,
+    ) -> tuple:
+        definition = definitions.get(header.local_id)
+        if definition is None:
+            raise FitRecordError(
+                f'DefinitionMessage not defined for local_id: {header.local_id}'
+            )
+
+        payload_size = definition.defined_data_size
+        end = body_offset + payload_size
+        if end > len(buffer_view):
+            raise FitRecordError(
+                f'Truncated data record {record_index} at offset {record_offset}: '
+                f'need {payload_size} payload bytes.'
+            )
+
+        payload = bytes(buffer_view[body_offset:end])
+        source_bytes = bytes(buffer_view[record_offset:end])
+        raw = RawDataRecord(
+            header=header,
+            definition=definition,
+            payload=payload,
+            source_offset=record_offset,
+            source_bytes=source_bytes,
+        )
+        return raw, len(source_bytes)
+
+
+def decode_bytes(bytes_buffer: bytes, check_crc: bool = True) -> FitDocument:
+    """Decode FIT bytes into a wire document."""
+    return WireDecoder(check_crc=check_crc).decode(bytes_buffer)

--- a/fit_tool/wire/model.py
+++ b/fit_tool/wire/model.py
@@ -1,0 +1,149 @@
+"""Authoritative binary (wire) models for FIT files.
+
+These types describe structure and source byte ranges. They must not depend on
+generated Profile message classes. Semantic projection happens outside this
+package (see :mod:`fit_tool.compatibility`).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Union
+
+
+@dataclass(frozen=True)
+class RawRecordHeader:
+    """One-byte FIT record header with structural flags."""
+
+    is_time_compressed: bool
+    is_definition: bool
+    has_developer_fields: bool
+    local_id: int
+    time_offset_seconds: int
+    source_offset: int
+    source_bytes: bytes
+
+    @property
+    def size(self) -> int:
+        return len(self.source_bytes)
+
+
+@dataclass(frozen=True)
+class RawFieldDefinition:
+    """Native field definition entry (3 bytes on the wire)."""
+
+    field_id: int
+    size: int
+    base_type: int
+
+
+@dataclass(frozen=True)
+class RawDeveloperFieldDefinition:
+    """Developer field definition entry (3 bytes on the wire)."""
+
+    field_id: int
+    size: int
+    developer_data_index: int
+
+
+@dataclass(frozen=True)
+class RawDefinitionRecord:
+    """Immutable definition-message snapshot.
+
+    When a local message ID is redefined, a *new* snapshot is stored for later
+    data records. Earlier data records keep the snapshot they were decoded with.
+    """
+
+    header: RawRecordHeader
+    reserved: int
+    architecture: int  # 0 = little-endian, 1 = big-endian
+    global_id: int
+    field_definitions: tuple[RawFieldDefinition, ...]
+    developer_field_definitions: tuple[RawDeveloperFieldDefinition, ...]
+    source_offset: int
+    source_bytes: bytes
+    dirty: bool = False
+
+    @property
+    def local_id(self) -> int:
+        return self.header.local_id
+
+    @property
+    def defined_data_size(self) -> int:
+        size = 0
+        for field_def in self.field_definitions:
+            size += field_def.size
+        for field_def in self.developer_field_definitions:
+            size += field_def.size
+        return size
+
+    @property
+    def size(self) -> int:
+        return len(self.source_bytes)
+
+
+@dataclass(frozen=True)
+class RawDataRecord:
+    """Data-message record with payload bytes and the definition snapshot used."""
+
+    header: RawRecordHeader
+    definition: RawDefinitionRecord
+    payload: bytes
+    source_offset: int
+    source_bytes: bytes
+    dirty: bool = False
+
+    @property
+    def local_id(self) -> int:
+        return self.header.local_id
+
+    @property
+    def size(self) -> int:
+        return len(self.source_bytes)
+
+
+RawRecord = Union[RawDefinitionRecord, RawDataRecord]
+
+
+@dataclass
+class RawFileHeader:
+    """Parsed FIT file header (12- or 14-byte form)."""
+
+    header_size: int
+    protocol_version: int  # raw packed byte (major << 4 | minor)
+    profile_version: int  # raw u16 version code
+    records_size: int
+    data_type: bytes
+    crc: int | None
+    source_offset: int
+    source_bytes: bytes
+
+    @property
+    def size(self) -> int:
+        return len(self.source_bytes)
+
+
+@dataclass
+class FitSegment:
+    """One FIT file segment (header + records + trailing file CRC)."""
+
+    header: RawFileHeader
+    records: list[RawRecord] = field(default_factory=list)
+    stored_crc: int = 0
+    calculated_crc: int = 0
+    crc_offset: int = 0
+
+
+@dataclass
+class FitDocument:
+    """Top-level wire document.
+
+    MVP decoder produces a single segment. Multi-segment (chained) documents
+    are deferred.
+    """
+
+    segments: list[FitSegment] = field(default_factory=list)
+
+    @property
+    def first_segment(self) -> FitSegment | None:
+        return self.segments[0] if self.segments else None

--- a/news/SHA-7.feature
+++ b/news/SHA-7.feature
@@ -1,0 +1,5 @@
+Introduce a wire-layer MVP (`fit_tool/wire`) with raw header/record models and a
+stateful decoder that keeps immutable definition snapshots. `FitFile.from_bytes`
+now decodes via the wire layer and projects to existing typed messages; public
+API behavior stays compatible. Deferred: compressed-timestamp reconstruction,
+component expansion, chained multi-segment API, and lossless unknown-field rewrite.


### PR DESCRIPTION
## Summary

Introduces a thin **wire** layer so binary layout is authoritative and typed messages are a projection (per `docs/FIT_CONFORMANCE_DESIGN.md` §4).

### What landed
- **`fit_tool/wire/`**
  - `model.py` — `RawFileHeader`, `RawRecordHeader`, frozen `RawDefinitionRecord` / `RawDataRecord` (source byte ranges + structural fields)
  - `decoder.py` — `WireDecoder` / `decode_bytes` with definition-table state and **immutable definition snapshots**
  - `crc.py` — reuses `fit_tool.utils.crc.crc16`
- **`fit_tool/compatibility.py`** — projects wire records → existing `Record` / `DefinitionMessage` / `DataMessage` (Profile types stay out of `wire/`)
- **`FitFile.from_bytes`** — decode path now uses the wire decoder, then projects; public API remains the facade (`from_file` / `from_bytes` / `to_bytes`)
- Tests in `fit_tool/tests/test_wire.py` (decoder basics, snapshot immutability, facade round-trip)

### Deferred (follow-on stages)
| Item | Notes |
| --- | --- |
| Compressed timestamp reconstruction | Wire parses compressed headers as data headers; full timestamp state/rollover not implemented |
| Component expansion & accumulators | Still profile-layer work |
| Chained multi-segment documents | MVP returns a single `FitSegment`; scanner loop not wired for trailing segments |
| Lossless unknown-field rewrite | Wire retains raw payload bytes; FitFile encode still goes through projected fields (unknown native fields may still be dropped on rewrite) |
| Wire encoder / preservation mode | Encode path unchanged (`Record.to_bytes`) |
| Full Phase-1 base-type codec registry | Existing field codecs remain |

### Acceptance mapping
- [x] Wire types exist and are used by `FitFile.from_bytes`
- [x] Public FitFile API remains the compatibility facade
- [x] Definition redefinition does not mutate prior snapshots
- [x] Existing suite green; new wire unit tests
- [x] Deferred work documented (this PR)

## Test plan
- [x] `uv run pytest fit_tool/tests/test_wire.py`
- [x] `uv run pytest` (241 passed, 1 skipped)
- [x] `ruff check` on touched modules