### PR TITLE
SHA-9: composable Validation API (WIRE / PROFILE / FILE_TYPE)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ package already implements. Profile version in use: `21.205.0` (see
 | Status | Capabilities |
 | --- | --- |
 | **Supported** | Common Activity and Workout read/write via typed profile messages; `FitFileBuilder` encode path; file-level CRC check on load / stream exhaustion; developer fields for common declaration patterns; streaming iterators (`FitFile.iter_file` / `iter_stream`); CSV export (`to_csv` / `to_rows`); Course and similar message types when you construct them yourself |
-| **Partial** | Unknown global messages via `GenericMessage` (readable and rewritable as structured fields, not lossless wire preservation); strict Activity validation on write only (`FitFileBuilder(strict=True)` — wire limits always apply; profile/file-type rules are opt-in and Activity-focused) |
-| **Not supported / incomplete** | Compressed timestamp header reconstruction (5-bit offset / rollover); chained multi-segment FIT files (only the first segment is consumed); component expansion and accumulators (e.g. `compressed_speed_distance`, enhanced fields); lossless byte-for-byte rewrite of unknown fields / header extensions; header CRC validation on 14-byte headers; strict file-type rules for non-Activity types (strict mode fails closed) |
+| **Partial** | Unknown global messages via `GenericMessage` (readable and rewritable as structured fields, not lossless wire preservation); composable validation API (`validate_fit_file` / `FitFile.validate`) with WIRE + PROFILE + Activity FILE_TYPE levels; Builder `strict=True` is a thin wrapper over the same checks |
+| **Not supported / incomplete** | Compressed timestamp header reconstruction (5-bit offset / rollover); chained multi-segment FIT files (only the first segment is consumed); component expansion and accumulators (e.g. `compressed_speed_distance`, enhanced fields); lossless byte-for-byte rewrite of unknown fields / header extensions; header CRC validation on 14-byte headers; file-type rules for non-Activity types (FILE_TYPE level fails closed); PRESERVATION conformance level |
 
 If you need a construct listed as incomplete, prefer an official Garmin SDK or
 wait for the phased work in the design doc. Architecture reviews should judge
@@ -126,6 +126,8 @@ from fit_tool import (
     FitParseError,
     FitCRCError,
     FitValidationError,
+    ConformanceLevel,
+    validate_fit_file,
     PROTOCOL_VERSION,
     SDK_VERSION,
 )
@@ -133,8 +135,9 @@ from fit_tool import (
 
 | Symbol | Role |
 | --- | --- |
-| `FitFile` | Load, inspect, stream, and serialize FIT files |
+| `FitFile` | Load, inspect, stream, serialize, and validate FIT files |
 | `FitFileBuilder` | Build FIT files from messages |
+| `validate_fit_file`, `ConformanceLevel`, `ValidationReport` | Composable validation (independent of Builder) |
 | `FitError` and subclasses | Typed errors for parse, CRC, encode, and validation failures |
 | `PROTOCOL_VERSION`, `SDK_VERSION`, `FIT_DATA_TYPE` | Bundled protocol/profile version metadata |
 
@@ -187,11 +190,40 @@ for record in FitFile.iter_file("activity.fit"):
 CRC validation is performed when the iterator is fully exhausted. `FitFile.iter_stream()` accepts an already-open
 binary stream. Builders can serialize directly with `FitFileBuilder.build_bytes()` when a `FitFile` object is not needed.
 
-### Validate generated FIT files
+### Validate FIT files
 
-`FitFileBuilder` always validates wire-level limits such as local message numbers and Definition Message field sizes.
-Use strict mode to additionally validate Developer Field declarations, `file_id` ordering, and Activity file message
-cardinality before bytes are produced:
+Validation is a first-class API. Levels match the design doc
+([`docs/FIT_CONFORMANCE_DESIGN.md`](docs/FIT_CONFORMANCE_DESIGN.md) §3):
+
+| Level | What it checks | Status |
+| --- | --- | --- |
+| `ConformanceLevel.WIRE` | Local IDs, definition field layout/sizes, data records vs active definition | Implemented |
+| `ConformanceLevel.PROFILE` | Developer field declarations (`developer_data_id` / `field_description`) and base-type consistency | Implemented (developer-field subset; full Profile semantics deferred) |
+| `ConformanceLevel.FILE_TYPE` | `file_id` first/unique + required fields; Activity required messages and fields | **Activity only**; other `file_id.type` values **fail closed** (intentional until more validators exist) |
+
+Call validation on any `FitFile` or record list — after decode or before encode:
+
+```python
+from fit_tool import ConformanceLevel, FitFile, validate_fit_file
+
+fit_file = FitFile.from_file("activity.fit")
+
+# Report mode (default: all implemented levels)
+report = fit_file.validate()
+if report.has_errors:
+    for finding in report.errors:
+        print(finding.level, finding.message)
+
+# Raise on first error
+fit_file.validate(raise_on_error=True)
+
+# Wire-only (e.g. after decode, without file-type rules)
+validate_fit_file(fit_file, levels={ConformanceLevel.WIRE})
+```
+
+`FitFileBuilder` always checks wire limits on `add` (local message numbers, definition
+sizes). `strict=True` is a thin wrapper over the same API with all levels and
+`raise_on_error=True`:
 
 ```python
 from fit_tool import FitFileBuilder
@@ -201,8 +233,8 @@ builder.add_all(messages)
 fit_bytes = builder.build_bytes()
 ```
 
-Strict file-type rules currently cover Activity files and fail closed for other file types. Existing builder calls remain
-compatible because profile-level strict validation is opt-in.
+Non-strict builders remain unchanged. Prefer `validate_fit_file` / `FitFile.validate`
+when you need a report, level selection, or validation on the read path.
 
 ### Run Garmin SDK interoperability tests
 

--- a/docs/FIT_CONFORMANCE_DESIGN.md
+++ b/docs/FIT_CONFORMANCE_DESIGN.md
@@ -11,7 +11,7 @@ For the library as shipped today, use the capability matrix in
 | Area | Today | This design |
 | --- | --- | --- |
 | Common Activity / Workout read-write, Builder, file CRC, streaming, developer fields (common cases) | Supported | Baseline to preserve |
-| Unknown messages (`GenericMessage`), Activity-only strict write validation | Partial | Expand into wire preservation + full file-type validators |
+| Unknown messages (`GenericMessage`); composable validation (`validate_fit_file` / `FitFile.validate`) with WIRE + PROFILE + Activity FILE_TYPE; Builder `strict=True` wraps the same API | Partial | Full Profile semantics, remaining file types, PRESERVATION level |
 | Compressed timestamps, chained segments, components / accumulators, lossless rewrite, header CRC, non-Activity strict rules | Not supported / incomplete | Phases 1–4 below |
 
 Until Phase exit criteria in §10 are met, do not describe the library as fully
@@ -401,16 +401,24 @@ every repair.
 
 ### 6.1 Compatibility-layer implementation status
 
-`FitFileBuilder(strict=True)` now provides the first additive strict-encoding
-slice: wire-range and Definition Message checks, ordered Developer Field
-declaration checks, common `file_id` rules, and Activity required-message and
-required-field checks. It fails closed for file types whose rule set has not
-yet been implemented.
+Composable validation is available independently of the Builder:
 
-This compatibility validator does not complete the conformance claim. The
-lossless wire model, compressed timestamps, generated Profile constraints,
-components and accumulation, native overrides, chained files, and the remaining
-file-type validators still follow the phases below.
+```python
+from fit_tool import ConformanceLevel, validate_fit_file
+
+report = validate_fit_file(fit_file)  # WIRE + PROFILE + FILE_TYPE
+report = fit_file.validate(levels={ConformanceLevel.WIRE})
+report.raise_for_errors()
+```
+
+`FitFileBuilder(strict=True)` is a thin wrapper over the same API (all default
+levels, raise on error). Wire-range and Definition Message checks still run on
+every `add`. FILE_TYPE rules cover Activity and fail closed for other types.
+
+This does not complete the conformance claim. Full Profile field semantics,
+compressed timestamps, components and accumulation, native overrides, chained
+files, PRESERVATION, and remaining file-type validators still follow the phases
+below.
 
 ## 7. File-type validators
 

--- a/fit_tool/__init__.py
+++ b/fit_tool/__init__.py
@@ -17,6 +17,7 @@ SDK_VERSION = '21.205.0'
 FIT_DATA_TYPE = b'.FIT'
 
 from fit_tool.api import (  # noqa: E402
+    ConformanceLevel,
     FitCRCError,
     FitEncodingError,
     FitError,
@@ -26,6 +27,10 @@ from fit_tool.api import (  # noqa: E402
     FitParseError,
     FitRecordError,
     FitValidationError,
+    Severity,
+    ValidationFinding,
+    ValidationReport,
+    validate_fit_file,
 )
 
 __all__ = [
@@ -41,4 +46,9 @@ __all__ = [
     'FitCRCError',
     'FitEncodingError',
     'FitValidationError',
+    'ConformanceLevel',
+    'Severity',
+    'ValidationFinding',
+    'ValidationReport',
+    'validate_fit_file',
 ]

--- a/fit_tool/api.py
+++ b/fit_tool/api.py
@@ -27,6 +27,13 @@ from fit_tool.exceptions import (
 )
 from fit_tool.fit_file import FitFile
 from fit_tool.fit_file_builder import FitFileBuilder
+from fit_tool.validation import (
+    ConformanceLevel,
+    Severity,
+    ValidationFinding,
+    ValidationReport,
+    validate_fit_file,
+)
 
 __all__ = [
     'FitFile',
@@ -38,4 +45,9 @@ __all__ = [
     'FitCRCError',
     'FitEncodingError',
     'FitValidationError',
+    'ConformanceLevel',
+    'Severity',
+    'ValidationFinding',
+    'ValidationReport',
+    'validate_fit_file',
 ]

--- a/fit_tool/fit_file.py
+++ b/fit_tool/fit_file.py
@@ -4,7 +4,7 @@ import csv
 import shutil
 import struct
 import tempfile
-from typing import BinaryIO, Iterator
+from typing import TYPE_CHECKING, BinaryIO, Iterable, Iterator, Optional
 
 from fit_tool.decoder import FitDecoder
 from fit_tool.exceptions import FitCRCError, FitEncodingError
@@ -12,6 +12,9 @@ from fit_tool.fit_file_header import FitFileHeader
 from fit_tool.record import Record
 from fit_tool.utils.crc import crc16
 from fit_tool.utils.logging import logger
+
+if TYPE_CHECKING:
+    from fit_tool.validation import ConformanceLevel, ValidationReport
 
 
 class FitFile:
@@ -156,3 +159,21 @@ class FitFile:
     def to_file(self, path: str) -> None:
         with open(path, 'wb') as file_object:
             file_object.write(self.to_bytes())
+
+    def validate(
+        self,
+        levels: Optional[Iterable[ConformanceLevel]] = None,
+        *,
+        raise_on_error: bool = False,
+    ) -> ValidationReport:
+        """Validate this file at selected conformance levels.
+
+        Independent of :class:`~fit_tool.fit_file_builder.FitFileBuilder`.
+        Defaults to all implemented levels (WIRE, PROFILE, FILE_TYPE). Use
+        ``levels={ConformanceLevel.WIRE}`` for structure-only checks after decode.
+
+        See :func:`~fit_tool.validation.validate_fit_file` for details.
+        """
+        from fit_tool.validation import validate_fit_file
+
+        return validate_fit_file(self, levels=levels, raise_on_error=raise_on_error)

--- a/fit_tool/fit_file.py
+++ b/fit_tool/fit_file.py
@@ -4,7 +4,7 @@ import csv
 import shutil
 import struct
 import tempfile
-from typing import TYPE_CHECKING, BinaryIO, Iterable, Iterator, Optional
+from typing import TYPE_CHECKING, BinaryIO, Iterable, Iterator
 
 from fit_tool.decoder import FitDecoder
 from fit_tool.exceptions import FitCRCError, FitEncodingError
@@ -162,7 +162,7 @@ class FitFile:
 
     def validate(
         self,
-        levels: Optional[Iterable[ConformanceLevel]] = None,
+        levels: Iterable[ConformanceLevel] | None = None,
         *,
         raise_on_error: bool = False,
     ) -> ValidationReport:

--- a/fit_tool/fit_file_builder.py
+++ b/fit_tool/fit_file_builder.py
@@ -7,7 +7,12 @@ from fit_tool.fit_file_header import FitFileHeader
 from fit_tool.message import Message
 from fit_tool.record import Record
 from fit_tool.utils.crc import crc16
-from fit_tool.validation import FitFileValidator, validate_definition, validate_message_header
+from fit_tool.validation import (
+    STRICT_LEVELS,
+    validate_definition,
+    validate_fit_file,
+    validate_message_header,
+)
 
 
 def calc_records_size(records: list[Record]) -> int:
@@ -85,6 +90,11 @@ class FitFileBuilder:
         return FitFile(header, self.records).to_bytes()
 
     def validate(self) -> None:
-        """Validate profile-level ordering and cardinality rules when strict mode is enabled."""
+        """When ``strict=True``, run the composable validation API and raise on errors.
+
+        Wire limits are always checked on :meth:`add`. Strict mode additionally
+        runs WIRE + PROFILE + FILE_TYPE via :func:`~fit_tool.validation.validate_fit_file`
+        (same behavior as calling that API with ``raise_on_error=True``).
+        """
         if self.strict:
-            FitFileValidator(self.records).validate()
+            validate_fit_file(self.records, levels=STRICT_LEVELS, raise_on_error=True)

--- a/fit_tool/tests/test_public_api.py
+++ b/fit_tool/tests/test_public_api.py
@@ -11,6 +11,7 @@ class TestPublicApi(unittest.TestCase):
             FIT_DATA_TYPE,
             PROTOCOL_VERSION,
             SDK_VERSION,
+            ConformanceLevel,
             FitCRCError,
             FitEncodingError,
             FitError,
@@ -20,6 +21,10 @@ class TestPublicApi(unittest.TestCase):
             FitParseError,
             FitRecordError,
             FitValidationError,
+            Severity,
+            ValidationFinding,
+            ValidationReport,
+            validate_fit_file,
         )
 
         self.assertEqual(SDK_VERSION, '21.205.0')
@@ -33,6 +38,12 @@ class TestPublicApi(unittest.TestCase):
         self.assertTrue(issubclass(FitRecordError, FitParseError))
         self.assertTrue(callable(FitFile.from_file))
         self.assertTrue(callable(FitFileBuilder))
+        self.assertTrue(callable(validate_fit_file))
+        self.assertTrue(callable(FitFile.validate))
+        self.assertEqual(ConformanceLevel.WIRE.value, 'wire')
+        self.assertEqual(Severity.ERROR.value, 'error')
+        self.assertTrue(issubclass(ValidationFinding, object))
+        self.assertTrue(callable(ValidationReport))
 
     def test_package_all_matches_api_surface(self) -> None:
         import fit_tool

--- a/fit_tool/tests/test_validation.py
+++ b/fit_tool/tests/test_validation.py
@@ -255,7 +255,11 @@ class TestFitValidation(unittest.TestCase):
     def test_public_api_exports_validation_symbols(self):
         from fit_tool import (
             ConformanceLevel as RootLevel,
+        )
+        from fit_tool import (
             ValidationReport,
+        )
+        from fit_tool import (
             validate_fit_file as root_validate,
         )
 

--- a/fit_tool/tests/test_validation.py
+++ b/fit_tool/tests/test_validation.py
@@ -13,6 +13,12 @@ from fit_tool.profile.messages.record_message import RecordMessage
 from fit_tool.profile.messages.session_message import SessionMessage
 from fit_tool.profile.messages.workout_step_message import WorkoutStepMessage
 from fit_tool.profile.profile_type import FileType, Manufacturer, Sport
+from fit_tool.validation import (
+    ConformanceLevel,
+    FitFileValidator,
+    Severity,
+    validate_fit_file,
+)
 
 
 def add_minimal_activity_messages(builder, record_message=None):
@@ -177,3 +183,82 @@ class TestFitValidation(unittest.TestCase):
         builder.add(activity)
 
         self.assertGreater(len(builder.build_bytes()), 0)
+
+    def test_validate_fit_file_report_mode_on_fit_file(self):
+        builder = FitFileBuilder()
+        add_minimal_activity_messages(builder)
+        fit_file = builder.build()
+
+        report = validate_fit_file(fit_file)
+
+        self.assertTrue(report)
+        self.assertFalse(report.has_errors)
+        self.assertEqual(report.findings, [])
+
+    def test_validate_fit_file_raise_mode_matches_strict_builder(self):
+        builder = FitFileBuilder()
+        file_id = FileIdMessage()
+        file_id.type = FileType.ACTIVITY
+        file_id.manufacturer = Manufacturer.DEVELOPMENT.value
+        file_id.product = 0
+        file_id.serial_number = 1234
+        file_id.time_created = 1_700_000_000_000
+        builder.add(file_id)
+        fit_file = builder.build()
+
+        with self.assertRaisesRegex(FitValidationError, 'record'):
+            validate_fit_file(fit_file, raise_on_error=True)
+
+        report = fit_file.validate()
+        self.assertTrue(report.has_errors)
+        self.assertEqual(report.errors[0].level, ConformanceLevel.FILE_TYPE)
+        self.assertEqual(report.errors[0].severity, Severity.ERROR)
+        self.assertIn('record', report.errors[0].message)
+
+    def test_validate_wire_only_skips_file_type_rules(self):
+        builder = FitFileBuilder()
+        file_id = FileIdMessage()
+        file_id.type = FileType.WORKOUT
+        file_id.manufacturer = Manufacturer.DEVELOPMENT.value
+        file_id.product = 0
+        file_id.serial_number = 1234
+        file_id.time_created = 1_700_000_000_000
+        builder.add(file_id)
+        fit_file = builder.build()
+
+        wire_report = validate_fit_file(fit_file, levels={ConformanceLevel.WIRE})
+        self.assertFalse(wire_report.has_errors)
+
+        full_report = fit_file.validate()
+        self.assertTrue(full_report.has_errors)
+        self.assertTrue(
+            any('not implemented' in finding.message for finding in full_report.errors)
+        )
+
+    def test_fit_file_validator_legacy_facade(self):
+        builder = FitFileBuilder()
+        add_minimal_activity_messages(builder)
+        FitFileValidator(builder.records).validate()
+
+        incomplete = FitFileBuilder()
+        file_id = FileIdMessage()
+        file_id.type = FileType.ACTIVITY
+        file_id.manufacturer = Manufacturer.DEVELOPMENT.value
+        file_id.product = 0
+        file_id.serial_number = 1234
+        file_id.time_created = 1_700_000_000_000
+        incomplete.add(file_id)
+
+        with self.assertRaisesRegex(FitValidationError, 'record'):
+            FitFileValidator(incomplete.records).validate()
+
+    def test_public_api_exports_validation_symbols(self):
+        from fit_tool import (
+            ConformanceLevel as RootLevel,
+            ValidationReport,
+            validate_fit_file as root_validate,
+        )
+
+        self.assertIs(RootLevel, ConformanceLevel)
+        self.assertIs(root_validate, validate_fit_file)
+        self.assertTrue(callable(ValidationReport))

--- a/fit_tool/validation.py
+++ b/fit_tool/validation.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 from collections import Counter
 from dataclasses import dataclass
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Iterable, List, Mapping, Optional, Sequence, Union
+from typing import TYPE_CHECKING, Any, Iterable, Mapping, Sequence
 
 from fit_tool.base_type import BaseType
 from fit_tool.data_message import DataMessage
@@ -76,7 +76,7 @@ class ValidationFinding:
     level: ConformanceLevel
     severity: Severity
     message: str
-    record_index: Optional[int] = None
+    record_index: int | None = None
 
     def __str__(self) -> str:
         location = f' @ record {self.record_index}' if self.record_index is not None else ''
@@ -86,15 +86,15 @@ class ValidationFinding:
 class ValidationReport:
     """Collected findings from :func:`validate_fit_file`."""
 
-    def __init__(self, findings: Optional[Sequence[ValidationFinding]] = None):
-        self.findings: List[ValidationFinding] = list(findings or ())
+    def __init__(self, findings: Sequence[ValidationFinding] | None = None):
+        self.findings: list[ValidationFinding] = list(findings or ())
 
     @property
-    def errors(self) -> List[ValidationFinding]:
+    def errors(self) -> list[ValidationFinding]:
         return [finding for finding in self.findings if finding.severity is Severity.ERROR]
 
     @property
-    def warnings(self) -> List[ValidationFinding]:
+    def warnings(self) -> list[ValidationFinding]:
         return [finding for finding in self.findings if finding.severity is Severity.WARNING]
 
     @property
@@ -119,7 +119,7 @@ def _enum_value(value: Any) -> Any:
     return value.value if hasattr(value, 'value') else value
 
 
-def _normalize_levels(levels: Optional[Iterable[ConformanceLevel]]) -> frozenset:
+def _normalize_levels(levels: Iterable[ConformanceLevel] | None) -> frozenset:
     if levels is None:
         return DEFAULT_LEVELS
     normalized = frozenset(levels)
@@ -132,7 +132,7 @@ def _normalize_levels(levels: Optional[Iterable[ConformanceLevel]]) -> frozenset
     return normalized
 
 
-def _records_from_source(source: Union[FitFile, Sequence[Record]]) -> List[Record]:
+def _records_from_source(source: FitFile | Sequence[Record]) -> list[Record]:
     if hasattr(source, 'records'):
         return list(source.records)
     return list(source)
@@ -214,10 +214,10 @@ def validate_data_message(message: DataMessage, definition: DefinitionMessage) -
 
 
 def _error(
-    findings: List[ValidationFinding],
+    findings: list[ValidationFinding],
     level: ConformanceLevel,
     message: str,
-    record_index: Optional[int] = None,
+    record_index: int | None = None,
 ) -> None:
     findings.append(
         ValidationFinding(
@@ -229,7 +229,7 @@ def _error(
     )
 
 
-def _collect_wire_findings(records: Sequence[Record], findings: List[ValidationFinding]) -> None:
+def _collect_wire_findings(records: Sequence[Record], findings: list[ValidationFinding]) -> None:
     active_definitions = {}
     for record_index, record in enumerate(records):
         message = record.message
@@ -265,7 +265,7 @@ def _collect_wire_findings(records: Sequence[Record], findings: List[ValidationF
 
 def _collect_profile_findings(
     data_messages: Sequence[DataMessage],
-    findings: List[ValidationFinding],
+    findings: list[ValidationFinding],
     data_message_indices: Mapping[int, int],
 ) -> None:
     developer_data_indices = set()
@@ -361,10 +361,10 @@ def _collect_profile_findings(
 
 
 def _require_fields_findings(
-    findings: List[ValidationFinding],
+    findings: list[ValidationFinding],
     message: DataMessage,
     field_names: tuple,
-    record_index: Optional[int],
+    record_index: int | None,
 ) -> None:
     missing = [name for name in field_names if getattr(message, name, None) is None]
     if missing:
@@ -378,7 +378,7 @@ def _require_fields_findings(
 
 def _collect_file_type_findings(
     data_messages: Sequence[DataMessage],
-    findings: List[ValidationFinding],
+    findings: list[ValidationFinding],
     data_message_indices: Mapping[int, int],
 ) -> None:
     if not data_messages:
@@ -458,7 +458,7 @@ def _collect_file_type_findings(
 
 def _collect_activity_field_findings(
     data_messages: Sequence[DataMessage],
-    findings: List[ValidationFinding],
+    findings: list[ValidationFinding],
     data_message_indices: Mapping[int, int],
 ) -> None:
     required_fields = {
@@ -494,8 +494,8 @@ def _collect_activity_field_findings(
 
 
 def validate_fit_file(
-    source: Union[FitFile, Sequence[Record]],
-    levels: Optional[Iterable[ConformanceLevel]] = None,
+    source: FitFile | Sequence[Record],
+    levels: Iterable[ConformanceLevel] | None = None,
     *,
     raise_on_error: bool = False,
 ) -> ValidationReport:
@@ -520,9 +520,9 @@ def validate_fit_file(
     """
     selected = _normalize_levels(levels)
     records = _records_from_source(source)
-    findings: List[ValidationFinding] = []
+    findings: list[ValidationFinding] = []
 
-    data_messages: List[DataMessage] = []
+    data_messages: list[DataMessage] = []
     data_message_indices: dict = {}
     for record_index, record in enumerate(records):
         if not record.is_definition and isinstance(record.message, DataMessage):

--- a/fit_tool/validation.py
+++ b/fit_tool/validation.py
@@ -1,9 +1,25 @@
-"""Validation for FIT wire constraints and profile-level file rules."""
+"""Composable FIT validation: wire, profile, and file-type levels.
+
+Validation is a first-class API independent of :class:`~fit_tool.fit_file_builder.FitFileBuilder`.
+Builder ``strict=True`` is a thin wrapper that runs the same checks and raises on errors.
+
+Levels (aligned with ``docs/FIT_CONFORMANCE_DESIGN.md``):
+
+* **WIRE** — local IDs, definition layout, data-record size vs definition
+* **PROFILE** — developer-field declaration order and base-type consistency
+* **FILE_TYPE** — ``file_id`` rules and Activity required messages/fields
+
+File-type rules are implemented only for **Activity**. Other ``file_id.type``
+values fail closed at the FILE_TYPE level (intentional until more validators
+exist). PRESERVATION level is not implemented yet.
+"""
 
 from __future__ import annotations
 
 from collections import Counter
-from typing import Any, Mapping
+from dataclasses import dataclass
+from enum import Enum
+from typing import TYPE_CHECKING, Any, Iterable, List, Mapping, Optional, Sequence, Union
 
 from fit_tool.base_type import BaseType
 from fit_tool.data_message import DataMessage
@@ -13,15 +29,113 @@ from fit_tool.message import Message
 from fit_tool.profile.profile_type import FileType, MesgNum
 from fit_tool.record import Record
 
+if TYPE_CHECKING:
+    from fit_tool.fit_file import FitFile
+
 MAX_LOCAL_MESSAGE_NUMBER = 15
 MAX_GLOBAL_MESSAGE_NUMBER = 65535
 MAX_FIELD_NUMBER = 255
 MAX_FIELD_SIZE = 255
 MAX_FIELD_COUNT = 255
 
+# file_id.type values with a FILE_TYPE rule set implemented today.
+IMPLEMENTED_FILE_TYPES = frozenset({FileType.ACTIVITY.value})
+
+
+class ConformanceLevel(Enum):
+    """Independently selectable validation dimensions."""
+
+    WIRE = 'wire'
+    PROFILE = 'profile'
+    FILE_TYPE = 'file_type'
+
+
+class Severity(Enum):
+    """Finding severity at a conformance level."""
+
+    ERROR = 'error'
+    WARNING = 'warning'
+    INFO = 'info'
+
+
+# Levels available in this release (PRESERVATION deferred).
+DEFAULT_LEVELS = frozenset({
+    ConformanceLevel.WIRE,
+    ConformanceLevel.PROFILE,
+    ConformanceLevel.FILE_TYPE,
+})
+
+# Builder(strict=True) and FitFileValidator().validate() use all default levels.
+STRICT_LEVELS = DEFAULT_LEVELS
+
+
+@dataclass(frozen=True)
+class ValidationFinding:
+    """One validation finding at a conformance level."""
+
+    level: ConformanceLevel
+    severity: Severity
+    message: str
+    record_index: Optional[int] = None
+
+    def __str__(self) -> str:
+        location = f' @ record {self.record_index}' if self.record_index is not None else ''
+        return f'[{self.level.value}/{self.severity.value}]{location} {self.message}'
+
+
+class ValidationReport:
+    """Collected findings from :func:`validate_fit_file`."""
+
+    def __init__(self, findings: Optional[Sequence[ValidationFinding]] = None):
+        self.findings: List[ValidationFinding] = list(findings or ())
+
+    @property
+    def errors(self) -> List[ValidationFinding]:
+        return [finding for finding in self.findings if finding.severity is Severity.ERROR]
+
+    @property
+    def warnings(self) -> List[ValidationFinding]:
+        return [finding for finding in self.findings if finding.severity is Severity.WARNING]
+
+    @property
+    def has_errors(self) -> bool:
+        return bool(self.errors)
+
+    def raise_for_errors(self) -> None:
+        """Raise :class:`FitValidationError` with the first error message, if any."""
+        errors = self.errors
+        if not errors:
+            return
+        raise FitValidationError(errors[0].message)
+
+    def __bool__(self) -> bool:
+        return not self.has_errors
+
+    def __repr__(self) -> str:
+        return f'ValidationReport(findings={self.findings!r})'
+
 
 def _enum_value(value: Any) -> Any:
     return value.value if hasattr(value, 'value') else value
+
+
+def _normalize_levels(levels: Optional[Iterable[ConformanceLevel]]) -> frozenset:
+    if levels is None:
+        return DEFAULT_LEVELS
+    normalized = frozenset(levels)
+    if not normalized:
+        raise ValueError('levels must contain at least one ConformanceLevel')
+    unknown = normalized - DEFAULT_LEVELS
+    if unknown:
+        names = ', '.join(sorted(level.value for level in unknown))
+        raise ValueError(f'Unsupported conformance level(s): {names}')
+    return normalized
+
+
+def _records_from_source(source: Union[FitFile, Sequence[Record]]) -> List[Record]:
+    if hasattr(source, 'records'):
+        return list(source.records)
+    return list(source)
 
 
 def validate_message_header(message: Message) -> None:
@@ -99,10 +213,344 @@ def validate_data_message(message: DataMessage, definition: DefinitionMessage) -
         )
 
 
-class FitFileValidator:
-    """Validate ordered FIT records using protocol and selected file-type rules."""
+def _error(
+    findings: List[ValidationFinding],
+    level: ConformanceLevel,
+    message: str,
+    record_index: Optional[int] = None,
+) -> None:
+    findings.append(
+        ValidationFinding(
+            level=level,
+            severity=Severity.ERROR,
+            message=message,
+            record_index=record_index,
+        )
+    )
 
-    def __init__(self, records: list[Record]):
+
+def _collect_wire_findings(records: Sequence[Record], findings: List[ValidationFinding]) -> None:
+    active_definitions = {}
+    for record_index, record in enumerate(records):
+        message = record.message
+        if isinstance(message, DefinitionMessage):
+            try:
+                validate_definition(message)
+            except FitValidationError as exc:
+                _error(findings, ConformanceLevel.WIRE, str(exc), record_index)
+                continue
+            if not message.field_definitions:
+                _error(
+                    findings,
+                    ConformanceLevel.WIRE,
+                    f'Strict validation does not allow an empty definition for global_id {message.global_id}.',
+                    record_index,
+                )
+            active_definitions[message.local_id] = message
+        elif isinstance(message, DataMessage):
+            definition = active_definitions.get(message.local_id)
+            if definition is None:
+                _error(
+                    findings,
+                    ConformanceLevel.WIRE,
+                    f'{message.name} uses undefined local_id {message.local_id}.',
+                    record_index,
+                )
+                continue
+            try:
+                validate_data_message(message, definition)
+            except FitValidationError as exc:
+                _error(findings, ConformanceLevel.WIRE, str(exc), record_index)
+
+
+def _collect_profile_findings(
+    data_messages: Sequence[DataMessage],
+    findings: List[ValidationFinding],
+    data_message_indices: Mapping[int, int],
+) -> None:
+    developer_data_indices = set()
+    descriptions = {}
+
+    for message_pos, message in enumerate(data_messages):
+        record_index = data_message_indices.get(message_pos)
+        if message.global_id == MesgNum.DEVELOPER_DATA_ID.value:
+            developer_data_index = _enum_value(getattr(message, 'developer_data_index', None))
+            if developer_data_index is None:
+                _error(findings, ConformanceLevel.PROFILE, 'developer_data_id is missing developer_data_index.', record_index)
+            else:
+                application_id = getattr(message, 'application_id', None)
+                if application_id is None or len(application_id) != 16:
+                    _error(
+                        findings,
+                        ConformanceLevel.PROFILE,
+                        'developer_data_id.application_id must contain exactly 16 bytes.',
+                        record_index,
+                    )
+                if developer_data_index in developer_data_indices:
+                    _error(
+                        findings,
+                        ConformanceLevel.PROFILE,
+                        f'Duplicate developer_data_id for developer_data_index {developer_data_index}.',
+                        record_index,
+                    )
+                else:
+                    developer_data_indices.add(developer_data_index)
+
+        elif message.global_id == MesgNum.FIELD_DESCRIPTION.value:
+            developer_data_index = _enum_value(getattr(message, 'developer_data_index', None))
+            field_number = _enum_value(getattr(message, 'field_definition_number', None))
+            fit_base_type_id = _enum_value(getattr(message, 'fit_base_type_id', None))
+            if developer_data_index not in developer_data_indices:
+                _error(
+                    findings,
+                    ConformanceLevel.PROFILE,
+                    f'field_description references developer_data_index {developer_data_index} '
+                    f'before its developer_data_id message.',
+                    record_index,
+                )
+            if field_number is None or fit_base_type_id is None:
+                _error(
+                    findings,
+                    ConformanceLevel.PROFILE,
+                    'field_description requires field_definition_number and fit_base_type_id.',
+                    record_index,
+                )
+            else:
+                try:
+                    base_type = BaseType(fit_base_type_id)
+                except ValueError:
+                    _error(
+                        findings,
+                        ConformanceLevel.PROFILE,
+                        f'field_description contains unknown fit_base_type_id {fit_base_type_id}.',
+                        record_index,
+                    )
+                    base_type = None
+                if base_type is not None:
+                    key = (developer_data_index, field_number)
+                    if key in descriptions:
+                        _error(
+                            findings,
+                            ConformanceLevel.PROFILE,
+                            f'Duplicate field_description for developer field {key}.',
+                            record_index,
+                        )
+                    else:
+                        descriptions[key] = base_type
+
+        for developer_field in message.developer_fields:
+            if not developer_field.is_valid():
+                continue
+            key = (developer_field.developer_data_index, developer_field.field_id)
+            described_base_type = descriptions.get(key)
+            if described_base_type is None:
+                _error(
+                    findings,
+                    ConformanceLevel.PROFILE,
+                    f'Developer field {key} is used before a matching field_description message.',
+                    record_index,
+                )
+            elif described_base_type != developer_field.base_type:
+                _error(
+                    findings,
+                    ConformanceLevel.PROFILE,
+                    f'Developer field {key} uses {developer_field.base_type.name}, but its '
+                    f'field_description declares {described_base_type.name}.',
+                    record_index,
+                )
+
+
+def _require_fields_findings(
+    findings: List[ValidationFinding],
+    message: DataMessage,
+    field_names: tuple,
+    record_index: Optional[int],
+) -> None:
+    missing = [name for name in field_names if getattr(message, name, None) is None]
+    if missing:
+        _error(
+            findings,
+            ConformanceLevel.FILE_TYPE,
+            f'{message.name} is missing required field(s): {", ".join(missing)}.',
+            record_index,
+        )
+
+
+def _collect_file_type_findings(
+    data_messages: Sequence[DataMessage],
+    findings: List[ValidationFinding],
+    data_message_indices: Mapping[int, int],
+) -> None:
+    if not data_messages:
+        _error(findings, ConformanceLevel.FILE_TYPE, 'A FIT file must contain data messages.')
+        return
+
+    file_id_messages = [
+        message for message in data_messages
+        if message.global_id == MesgNum.FILE_ID.value
+    ]
+    if len(file_id_messages) != 1:
+        _error(
+            findings,
+            ConformanceLevel.FILE_TYPE,
+            f'A FIT file must contain exactly one file_id message; found {len(file_id_messages)}.',
+        )
+        return
+    if data_messages[0] is not file_id_messages[0]:
+        _error(
+            findings,
+            ConformanceLevel.FILE_TYPE,
+            'file_id must be the first data message in a FIT file.',
+            data_message_indices.get(0),
+        )
+        return
+
+    file_id = file_id_messages[0]
+    file_id_index = data_message_indices.get(0)
+    file_type = _enum_value(getattr(file_id, 'type', None))
+    if file_type is None:
+        _error(findings, ConformanceLevel.FILE_TYPE, 'file_id.type is required.', file_id_index)
+        return
+
+    _require_fields_findings(
+        findings,
+        file_id,
+        ('type', 'manufacturer', 'product', 'serial_number', 'time_created'),
+        file_id_index,
+    )
+
+    message_counts = Counter(message.global_id for message in data_messages)
+    if file_type == FileType.ACTIVITY.value:
+        if message_counts[MesgNum.RECORD.value] < 1:
+            _error(
+                findings,
+                ConformanceLevel.FILE_TYPE,
+                'An activity FIT file requires at least one record message.',
+            )
+        if message_counts[MesgNum.LAP.value] < 1:
+            _error(
+                findings,
+                ConformanceLevel.FILE_TYPE,
+                'An activity FIT file requires at least one lap message.',
+            )
+        if message_counts[MesgNum.SESSION.value] < 1:
+            _error(
+                findings,
+                ConformanceLevel.FILE_TYPE,
+                'An activity FIT file requires at least one session message.',
+            )
+        activity_count = message_counts[MesgNum.ACTIVITY.value]
+        if activity_count != 1:
+            _error(
+                findings,
+                ConformanceLevel.FILE_TYPE,
+                f'An activity FIT file requires exactly one activity message; found {activity_count}.',
+            )
+        _collect_activity_field_findings(data_messages, findings, data_message_indices)
+    else:
+        _error(
+            findings,
+            ConformanceLevel.FILE_TYPE,
+            f'Strict file-type validation is not implemented for file_id.type {file_type!r}.',
+            file_id_index,
+        )
+
+
+def _collect_activity_field_findings(
+    data_messages: Sequence[DataMessage],
+    findings: List[ValidationFinding],
+    data_message_indices: Mapping[int, int],
+) -> None:
+    required_fields = {
+        MesgNum.RECORD.value: ('timestamp',),
+        MesgNum.LAP.value: (
+            'message_index',
+            'timestamp',
+            'start_time',
+            'total_elapsed_time',
+            'total_timer_time',
+        ),
+        MesgNum.SESSION.value: (
+            'message_index',
+            'timestamp',
+            'start_time',
+            'total_elapsed_time',
+            'total_timer_time',
+            'sport',
+            'first_lap_index',
+            'num_laps',
+        ),
+        MesgNum.ACTIVITY.value: ('timestamp', 'num_sessions', 'total_timer_time'),
+    }
+    for message_pos, message in enumerate(data_messages):
+        field_names = required_fields.get(message.global_id)
+        if field_names is not None:
+            _require_fields_findings(
+                findings,
+                message,
+                field_names,
+                data_message_indices.get(message_pos),
+            )
+
+
+def validate_fit_file(
+    source: Union[FitFile, Sequence[Record]],
+    levels: Optional[Iterable[ConformanceLevel]] = None,
+    *,
+    raise_on_error: bool = False,
+) -> ValidationReport:
+    """Validate a :class:`~fit_tool.fit_file.FitFile` or ordered record list.
+
+    Parameters
+    ----------
+    source:
+        A :class:`FitFile` or a sequence of :class:`~fit_tool.record.Record`.
+    levels:
+        Conformance levels to run. Defaults to all implemented levels
+        (WIRE, PROFILE, FILE_TYPE). Pass a subset for partial checks
+        (for example wire-only after decode).
+    raise_on_error:
+        If true, raise :class:`FitValidationError` when any ERROR findings exist
+        (first error message is used, matching historical Builder strict behavior).
+
+    Returns
+    -------
+    ValidationReport
+        Collected findings. Truthy when there are no errors.
+    """
+    selected = _normalize_levels(levels)
+    records = _records_from_source(source)
+    findings: List[ValidationFinding] = []
+
+    data_messages: List[DataMessage] = []
+    data_message_indices: dict = {}
+    for record_index, record in enumerate(records):
+        if not record.is_definition and isinstance(record.message, DataMessage):
+            data_message_indices[len(data_messages)] = record_index
+            data_messages.append(record.message)
+
+    if ConformanceLevel.WIRE in selected:
+        _collect_wire_findings(records, findings)
+    if ConformanceLevel.PROFILE in selected:
+        _collect_profile_findings(data_messages, findings, data_message_indices)
+    if ConformanceLevel.FILE_TYPE in selected:
+        _collect_file_type_findings(data_messages, findings, data_message_indices)
+
+    report = ValidationReport(findings)
+    if raise_on_error:
+        report.raise_for_errors()
+    return report
+
+
+class FitFileValidator:
+    """Validate ordered FIT records (legacy raise-only facade).
+
+    Prefer :func:`validate_fit_file` for report mode and level selection.
+    This class preserves the historical ``FitFileValidator(records).validate()``
+    raise-on-error behavior used by Builder ``strict=True``.
+    """
+
+    def __init__(self, records: list):
         self.records = records
         self.data_messages = [
             record.message for record in records
@@ -110,171 +558,17 @@ class FitFileValidator:
         ]
 
     def validate(self) -> None:
-        self._validate_definitions_and_data()
-        self._validate_developer_fields()
-        self._validate_file_type()
+        """Run WIRE + PROFILE + FILE_TYPE and raise on the first error."""
+        validate_fit_file(self.records, levels=STRICT_LEVELS, raise_on_error=True)
 
     def _validate_definitions_and_data(self) -> None:
-        active_definitions = {}
-        for record in self.records:
-            message = record.message
-            if isinstance(message, DefinitionMessage):
-                validate_definition(message)
-                if not message.field_definitions:
-                    raise FitValidationError(
-                        f'Strict validation does not allow an empty definition for global_id {message.global_id}.'
-                    )
-                active_definitions[message.local_id] = message
-            elif isinstance(message, DataMessage):
-                definition = active_definitions.get(message.local_id)
-                if definition is None:
-                    raise FitValidationError(
-                        f'{message.name} uses undefined local_id {message.local_id}.'
-                    )
-                validate_data_message(message, definition)
+        report = validate_fit_file(self.records, levels={ConformanceLevel.WIRE})
+        report.raise_for_errors()
 
     def _validate_developer_fields(self) -> None:
-        developer_data_indices = set()
-        descriptions = {}
-
-        for message in self.data_messages:
-            if message.global_id == MesgNum.DEVELOPER_DATA_ID.value:
-                developer_data_index = _enum_value(getattr(message, 'developer_data_index', None))
-                if developer_data_index is None:
-                    raise FitValidationError('developer_data_id is missing developer_data_index.')
-                application_id = getattr(message, 'application_id', None)
-                if application_id is None or len(application_id) != 16:
-                    raise FitValidationError('developer_data_id.application_id must contain exactly 16 bytes.')
-                if developer_data_index in developer_data_indices:
-                    raise FitValidationError(
-                        f'Duplicate developer_data_id for developer_data_index {developer_data_index}.'
-                    )
-                developer_data_indices.add(developer_data_index)
-
-            elif message.global_id == MesgNum.FIELD_DESCRIPTION.value:
-                developer_data_index = _enum_value(getattr(message, 'developer_data_index', None))
-                field_number = _enum_value(getattr(message, 'field_definition_number', None))
-                fit_base_type_id = _enum_value(getattr(message, 'fit_base_type_id', None))
-                if developer_data_index not in developer_data_indices:
-                    raise FitValidationError(
-                        f'field_description references developer_data_index {developer_data_index} '
-                        f'before its developer_data_id message.'
-                    )
-                if field_number is None or fit_base_type_id is None:
-                    raise FitValidationError(
-                        'field_description requires field_definition_number and fit_base_type_id.'
-                    )
-                try:
-                    base_type = BaseType(fit_base_type_id)
-                except ValueError as exc:
-                    raise FitValidationError(
-                        f'field_description contains unknown fit_base_type_id {fit_base_type_id}.'
-                    ) from exc
-                if (developer_data_index, field_number) in descriptions:
-                    raise FitValidationError(
-                        f'Duplicate field_description for developer field '
-                        f'{(developer_data_index, field_number)}.'
-                    )
-                descriptions[(developer_data_index, field_number)] = base_type
-
-            for developer_field in message.developer_fields:
-                if not developer_field.is_valid():
-                    continue
-                key = (developer_field.developer_data_index, developer_field.field_id)
-                described_base_type = descriptions.get(key)
-                if described_base_type is None:
-                    raise FitValidationError(
-                        f'Developer field {key} is used before a matching field_description message.'
-                    )
-                if described_base_type != developer_field.base_type:
-                    raise FitValidationError(
-                        f'Developer field {key} uses {developer_field.base_type.name}, but its '
-                        f'field_description declares {described_base_type.name}.'
-                    )
+        report = validate_fit_file(self.records, levels={ConformanceLevel.PROFILE})
+        report.raise_for_errors()
 
     def _validate_file_type(self) -> None:
-        if not self.data_messages:
-            raise FitValidationError('A FIT file must contain data messages.')
-
-        file_id_messages = [
-            message for message in self.data_messages
-            if message.global_id == MesgNum.FILE_ID.value
-        ]
-        if len(file_id_messages) != 1:
-            raise FitValidationError(f'A FIT file must contain exactly one file_id message; found {len(file_id_messages)}.')
-        if self.data_messages[0] is not file_id_messages[0]:
-            raise FitValidationError('file_id must be the first data message in a FIT file.')
-
-        file_type = _enum_value(getattr(file_id_messages[0], 'type', None))
-        if file_type is None:
-            raise FitValidationError('file_id.type is required.')
-        self._require_fields(
-            file_id_messages[0],
-            ('type', 'manufacturer', 'product', 'serial_number', 'time_created'),
-        )
-
-        message_counts = Counter(message.global_id for message in self.data_messages)
-        if file_type == FileType.ACTIVITY.value:
-            self._require_at_least_one(message_counts, MesgNum.RECORD, 'record')
-            self._require_at_least_one(message_counts, MesgNum.LAP, 'lap')
-            self._require_at_least_one(message_counts, MesgNum.SESSION, 'session')
-            self._require_exactly_one(message_counts, MesgNum.ACTIVITY, 'activity')
-            self._validate_activity_fields()
-        else:
-            raise FitValidationError(
-                f'Strict file-type validation is not implemented for file_id.type {file_type!r}.'
-            )
-
-    def _validate_activity_fields(self) -> None:
-        required_fields = {
-            MesgNum.RECORD.value: ('timestamp',),
-            MesgNum.LAP.value: (
-                'message_index',
-                'timestamp',
-                'start_time',
-                'total_elapsed_time',
-                'total_timer_time',
-            ),
-            MesgNum.SESSION.value: (
-                'message_index',
-                'timestamp',
-                'start_time',
-                'total_elapsed_time',
-                'total_timer_time',
-                'sport',
-                'first_lap_index',
-                'num_laps',
-            ),
-            MesgNum.ACTIVITY.value: ('timestamp', 'num_sessions', 'total_timer_time'),
-        }
-        for message in self.data_messages:
-            field_names = required_fields.get(message.global_id)
-            if field_names is not None:
-                self._require_fields(message, field_names)
-
-    @staticmethod
-    def _require_fields(message: DataMessage, field_names: tuple[str, ...]) -> None:
-        missing = [name for name in field_names if getattr(message, name, None) is None]
-        if missing:
-            raise FitValidationError(
-                f'{message.name} is missing required field(s): {", ".join(missing)}.'
-            )
-
-    @staticmethod
-    def _require_at_least_one(
-        message_counts: Mapping[int, int],
-        message_number: MesgNum,
-        name: str,
-    ) -> None:
-        if message_counts[message_number.value] < 1:
-            raise FitValidationError(f'An activity FIT file requires at least one {name} message.')
-
-    @staticmethod
-    def _require_exactly_one(
-        message_counts: Mapping[int, int],
-        message_number: MesgNum,
-        name: str,
-    ) -> None:
-        count = message_counts[message_number.value]
-        if count != 1:
-            raise FitValidationError(f'An activity FIT file requires exactly one {name} message; found {count}.')
+        report = validate_fit_file(self.records, levels={ConformanceLevel.FILE_TYPE})
+        report.raise_for_errors()

--- a/news/SHA-9.feature
+++ b/news/SHA-9.feature
@@ -1,0 +1,3 @@
+Add a composable validation API (`validate_fit_file`, `FitFile.validate`) with
+WIRE / PROFILE / FILE_TYPE levels and report or raise modes. Builder
+`strict=True` now delegates to the same checks.


### PR DESCRIPTION
## Summary

Makes validation a first-class, composable API instead of a Builder-only `strict=` side effect (architecture Stage 3 / SHA-9).

- **`validate_fit_file(source, levels=..., raise_on_error=...)`** and **`FitFile.validate(...)`** return a `ValidationReport` or raise `FitValidationError`
- Levels: **WIRE** (definitions / sizes / local IDs), **PROFILE** (developer-field declarations), **FILE_TYPE** (Activity required messages/fields)
- Non-Activity `file_id.type` **fails closed** at FILE_TYPE (documented; intentional until more validators exist)
- **`FitFileBuilder(strict=True)`** is a thin wrapper over the same API (`STRICT_LEVELS` + `raise_on_error=True`); wire checks on `add` unchanged
- Public exports: `ConformanceLevel`, `Severity`, `ValidationFinding`, `ValidationReport`, `validate_fit_file`
- README + design-doc status updated; legacy `FitFileValidator` remains as a raise-only facade

## Test plan

- [x] `uv run pytest fit_tool/tests/test_validation.py fit_tool/tests/test_public_api.py`
- [x] Full suite: 246 passed, 1 skipped
- [x] Existing Builder strict tests still pass (backward compatible)

Closes coordination note: shares Stage 3 with SHA-8 (unified decoder); only additive `FitFile.validate` touchpoint on `FitFile`.