### PR TITLE
SHA-8: unify stream/memory FIT decode state machine

### DIFF
--- a/fit_tool/compatibility.py
+++ b/fit_tool/compatibility.py
@@ -102,18 +102,25 @@ def project_data_record(
     # redefinition of the same local_id cannot mutate earlier projections.
     definition_message = definition_from_raw(raw.definition)
 
-    if developer_fields_by_data_index and definition_message.developer_field_definitions:
-        developer_fields = definition_message.get_developer_fields(developer_fields_by_data_index)
-    else:
-        developer_fields = []
-
     try:
+        # Always resolve developer fields when the definition declares them so
+        # missing Field Description registration fails the same way on stream
+        # and full-load paths (empty registry is not treated as "no fields").
+        if definition_message.developer_field_definitions:
+            developer_fields = definition_message.get_developer_fields(
+                developer_fields_by_data_index
+            )
+        else:
+            developer_fields = []
+
         message = DataMessage.from_bytes(
             definition_message,
             developer_fields,
             raw.payload,
             offset=0,
         )
+    except FitRecordError:
+        raise
     except (IndexError, struct.error, UnicodeError, ValueError) as exc:
         raise FitRecordError(
             f'Could not project data record at byte offset {raw.source_offset}: {exc}'
@@ -123,10 +130,15 @@ def project_data_record(
     return Record(header, message)
 
 
-def _register_developer_field(
+def register_developer_field(
         record: Record,
         developer_fields_by_data_index: dict[int, dict[int, DeveloperField]],
 ) -> None:
+    """Register Field Description metadata into the developer-field registry.
+
+    Stream and full-load paths share this registration so validation strictness
+    stays aligned (missing required metadata raises :class:`FitRecordError`).
+    """
     if not isinstance(record.message, FieldDescriptionMessage):
         return
 
@@ -151,6 +163,10 @@ def _register_developer_field(
     fields_by_id[developer_field.field_id] = developer_field
 
 
+# Backward-compatible private alias used by earlier Stage 2 code / tests.
+_register_developer_field = register_developer_field
+
+
 def project_segment(segment: FitSegment) -> list[Record]:
     """Project all wire records in a segment to compatibility Records."""
     records: list[Record] = []
@@ -161,7 +177,7 @@ def project_segment(segment: FitSegment) -> list[Record]:
             record = project_definition_record(raw)
         elif isinstance(raw, RawDataRecord):
             record = project_data_record(raw, developer_fields_by_data_index)
-            _register_developer_field(record, developer_fields_by_data_index)
+            register_developer_field(record, developer_fields_by_data_index)
         else:
             raise FitRecordError(f'Unsupported wire record type: {type(raw)!r}')
         records.append(record)

--- a/fit_tool/decoder.py
+++ b/fit_tool/decoder.py
@@ -1,0 +1,115 @@
+"""Unified FIT decoder state machine for stream and in-memory paths.
+
+Built on the Stage 2 wire layer. One control loop owns:
+
+- local definition snapshots (via :class:`~fit_tool.wire.decoder.WireDecoder`)
+- developer field registry
+- CRC accumulation
+- ``last_timestamp`` hook (for compressed timestamps later)
+
+:meth:`FitFile.from_bytes` collects records from this machine;
+:func:`~fit_tool.fit_file_stream.iter_fit_stream` yields them.
+"""
+
+from __future__ import annotations
+
+from typing import BinaryIO, Iterator, Union
+
+from fit_tool.compatibility import (
+    project_data_record,
+    project_definition_record,
+    project_header,
+    register_developer_field,
+)
+from fit_tool.developer_field import DeveloperField
+from fit_tool.exceptions import FitEncodingError
+from fit_tool.fit_file_header import FitFileHeader
+from fit_tool.record import Record
+from fit_tool.utils.logging import logger
+from fit_tool.wire.decoder import ByteSourceInput, WireDecoder
+from fit_tool.wire.model import RawDataRecord, RawDefinitionRecord, RawRecord
+
+Source = Union[bytes, bytearray, memoryview, BinaryIO]
+
+
+class FitDecoder:
+    """Stateful decoder shared by full-load and streaming public APIs.
+
+    After :meth:`iter_records` completes (or is exhausted), session fields are
+    available: :attr:`header`, :attr:`calculated_crc`, :attr:`stored_crc`,
+    :attr:`last_timestamp`, and :attr:`developer_fields_by_data_index`.
+    """
+
+    def __init__(self, check_crc: bool = True) -> None:
+        self.check_crc = check_crc
+        self._wire = WireDecoder(check_crc=check_crc)
+        self._reset_session()
+
+    def _reset_session(self) -> None:
+        self.header: FitFileHeader | None = None
+        self.calculated_crc: int = 0
+        self.stored_crc: int = 0
+        self.last_timestamp: int | None = None
+        self.developer_fields_by_data_index: dict[int, dict[int, DeveloperField]] = {}
+
+    def iter_records(self, source: Source) -> Iterator[Record]:
+        """Yield projected records from bytes or a binary stream.
+
+        CRC is validated when iteration is exhausted (same as historical
+        ``iter_fit_stream`` behaviour). Developer-field registration runs as
+        Field Description data messages are projected, so later data messages
+        see the same registry on both stream and full-load paths.
+        """
+        self._reset_session()
+        developer_registry = self.developer_fields_by_data_index
+
+        for raw in self._wire.iter_raw_records(source):
+            record = self._project_raw(raw, developer_registry)
+            register_developer_field(record, developer_registry)
+            # Propagate wire timestamp hook for future compressed-timestamp work.
+            self.last_timestamp = self._wire.last_timestamp
+            yield record
+
+        assert self._wire.header is not None
+        self.header = project_header(self._wire.header)
+        self.calculated_crc = self._wire.calculated_crc
+        self.stored_crc = self._wire.stored_crc
+        self.last_timestamp = self._wire.last_timestamp
+
+        if self.calculated_crc != self.stored_crc and not self.check_crc:
+            logger.warning(
+                f'Calculated crc ({hex(self.calculated_crc)}) does not match '
+                f'crc in file ({hex(self.stored_crc)}).'
+            )
+
+    def decode(self, source: Source) -> tuple[FitFileHeader, list[Record], int]:
+        """Decode a full segment into header, records, and calculated CRC."""
+        records = list(self.iter_records(source))
+        if self.header is None:
+            raise FitEncodingError('Decoder finished without a FIT header.')
+        return self.header, records, self.calculated_crc
+
+    @staticmethod
+    def _project_raw(
+            raw: RawRecord,
+            developer_fields_by_data_index: dict[int, dict[int, DeveloperField]],
+    ) -> Record:
+        if isinstance(raw, RawDefinitionRecord):
+            return project_definition_record(raw)
+        if isinstance(raw, RawDataRecord):
+            return project_data_record(raw, developer_fields_by_data_index)
+        raise FitEncodingError(f'Unsupported wire record type: {type(raw)!r}')
+
+
+def iter_fit_records(source: Source, check_crc: bool = True) -> Iterator[Record]:
+    """Yield projected FIT records from bytes or a stream (shared decode path)."""
+    yield from FitDecoder(check_crc=check_crc).iter_records(source)
+
+
+# Re-export for type checkers / callers that need the wire source alias.
+__all__ = [
+    'ByteSourceInput',
+    'FitDecoder',
+    'Source',
+    'iter_fit_records',
+]

--- a/fit_tool/fit_file.py
+++ b/fit_tool/fit_file.py
@@ -6,22 +6,21 @@ import struct
 import tempfile
 from typing import BinaryIO, Iterator
 
-from fit_tool.compatibility import project_header, project_segment
+from fit_tool.decoder import FitDecoder
 from fit_tool.exceptions import FitCRCError, FitEncodingError
 from fit_tool.fit_file_header import FitFileHeader
 from fit_tool.record import Record
 from fit_tool.utils.crc import crc16
 from fit_tool.utils.logging import logger
-from fit_tool.wire.decoder import WireDecoder
 
 
 class FitFile:
     """Public FIT file facade.
 
-    Decode goes through the wire layer (:class:`~fit_tool.wire.decoder.WireDecoder`)
-    and projects raw records to typed messages. Encode still serializes the
-    projected :class:`~fit_tool.record.Record` list (lossless unknown-field
-    rewrite is deferred).
+    Decode uses the unified :class:`~fit_tool.decoder.FitDecoder` state machine
+    (wire layer + projection) shared with streaming APIs. Encode still
+    serializes the projected :class:`~fit_tool.record.Record` list (lossless
+    unknown-field rewrite is deferred).
     """
 
     def __init__(self, header: FitFileHeader, records: list[Record], crc: int | None = None):
@@ -71,30 +70,15 @@ class FitFile:
 
     @classmethod
     def from_bytes(cls, bytes_buffer: bytes, check_crc: bool = True) -> FitFile:
-        """Parse FIT bytes via the wire decoder, then project to typed records."""
-        document = WireDecoder(check_crc=check_crc).decode(bytes_buffer)
-        segment = document.first_segment
-        if segment is None:
-            raise FitEncodingError('Wire decoder returned an empty document.')
+        """Parse FIT bytes via the shared FitDecoder state machine.
 
-        if segment.calculated_crc != segment.stored_crc and not check_crc:
-            logger.warning(
-                f'Calculated crc ({hex(segment.calculated_crc)}) does not match '
-                f'crc in file ({hex(segment.stored_crc)}).'
-            )
-
-        header = project_header(segment.header)
-        records = project_segment(segment)
-
-        for record_index, (record, raw) in enumerate(zip(records, segment.records)):
-            defined_size = raw.size
-            if record.size != defined_size:
-                logger.warning(
-                    f'Record {record_index}, {record.message}: size ({record.size}) != '
-                    f'defined size ({defined_size}). Some fields were not read correctly.'
-                )
-
-        return cls(header, records, segment.calculated_crc)
+        Collects the same projected records that :meth:`iter_stream` would yield
+        from an equivalent stream, so CRC handling and developer-field
+        registration stay aligned between full-load and streaming paths.
+        """
+        decoder = FitDecoder(check_crc=check_crc)
+        header, records, calculated_crc = decoder.decode(bytes_buffer)
+        return cls(header, records, calculated_crc)
 
     def to_bytes(self, check_crc: bool = True) -> bytes:
         try:

--- a/fit_tool/fit_file_stream.py
+++ b/fit_tool/fit_file_stream.py
@@ -1,139 +1,21 @@
-"""Streaming FIT record parser."""
+"""Streaming FIT record parser.
+
+Both :func:`iter_fit_stream` and :meth:`~fit_tool.fit_file.FitFile.from_bytes`
+delegate to :class:`~fit_tool.decoder.FitDecoder` so stream and in-memory paths
+share one decode state machine (definitions, developer registry, CRC).
+"""
 
 from __future__ import annotations
 
-import struct
-from typing import BinaryIO, Iterator, cast
+from typing import BinaryIO, Iterator
 
-from fit_tool.base_type import BaseType
-from fit_tool.definition_message import DefinitionMessage
-from fit_tool.developer_field import DeveloperField
-from fit_tool.exceptions import FitCRCError, FitHeaderError, FitRecordError
-from fit_tool.fit_file_header import FitFileHeader
-from fit_tool.profile.messages.field_description_message import FieldDescriptionMessage
-from fit_tool.record import Record, RecordHeader
-from fit_tool.utils.crc import crc16
-from fit_tool.utils.logging import logger
-
-
-def _read_exact(file_object: BinaryIO, size: int, context: str, header: bool = False) -> bytes:
-    data = bytearray()
-    while len(data) < size:
-        chunk = file_object.read(size - len(data))
-        if not chunk:
-            break
-        data.extend(chunk)
-
-    if len(data) != size:
-        error_type = FitHeaderError if header else FitRecordError
-        raise error_type(f'Truncated FIT input while reading {context}: expected {size} bytes, got {len(data)}.')
-    return bytes(data)
-
-
-def _register_record(
-        record: Record,
-        definition_messages: dict[int, DefinitionMessage],
-        developer_fields_by_data_index: dict[int, dict[int, DeveloperField]]) -> None:
-    if record.is_definition:
-        definition_messages[record.local_id] = cast(DefinitionMessage, record.message)
-        return
-
-    if isinstance(record.message, FieldDescriptionMessage):
-        message = record.message
-        if (
-            message.developer_data_index is None
-            or message.field_definition_number is None
-            or message.fit_base_type_id is None
-        ):
-            raise FitRecordError('Field description is missing required developer-field metadata.')
-        developer_field = DeveloperField(
-            developer_data_index=message.developer_data_index,
-            field_id=message.field_definition_number,
-            base_type=BaseType(message.fit_base_type_id),
-            name=message.field_name,
-            scale=message.scale,
-            offset=message.offset,
-            units=message.units,
-        )
-        fields_by_id = developer_fields_by_data_index.setdefault(developer_field.developer_data_index, {})
-        fields_by_id[developer_field.field_id] = developer_field
+from fit_tool.decoder import FitDecoder
+from fit_tool.record import Record
 
 
 def iter_fit_stream(file_object: BinaryIO, check_crc: bool = True) -> Iterator[Record]:
     """Yield records from a binary FIT stream; CRC validation completes when iteration is exhausted."""
-    header_size_bytes = _read_exact(file_object, 1, 'header size', header=True)
-    header_size = header_size_bytes[0]
-    if header_size < 12:
-        raise FitHeaderError(f'FIT header size must be at least 12 bytes, got {header_size}.')
-
-    header_bytes = header_size_bytes + _read_exact(
-        file_object, header_size - 1, 'remaining header', header=True
-    )
-    try:
-        header = FitFileHeader.from_bytes(header_bytes)
-    except (IndexError, struct.error, ValueError) as exc:
-        raise FitHeaderError(f'Invalid FIT header: {exc}') from exc
-
-    crc = crc16(header_bytes)
-    remaining = header.records_size
-    definition_messages: dict[int, DefinitionMessage] = {}
-    developer_fields_by_data_index: dict[int, dict[int, DeveloperField]] = {}
-    record_index = 0
-
-    while remaining > 0:
-        record_header_bytes = _read_exact(file_object, 1, f'record {record_index} header')
-        try:
-            record_header = RecordHeader.from_bytes(record_header_bytes)
-        except (IndexError, ValueError) as exc:
-            raise FitRecordError(f'Invalid record {record_index} header: {exc}') from exc
-
-        if record_header.is_definition:
-            body = bytearray(_read_exact(file_object, 5, f'record {record_index} definition prefix'))
-            body.extend(_read_exact(file_object, body[4] * 3, f'record {record_index} field definitions'))
-            if record_header.has_developer_fields:
-                developer_count = _read_exact(file_object, 1, f'record {record_index} developer count')
-                body.extend(developer_count)
-                body.extend(_read_exact(
-                    file_object, developer_count[0] * 3, f'record {record_index} developer definitions'
-                ))
-        else:
-            definition_message = definition_messages.get(record_header.local_id)
-            if definition_message is None:
-                raise FitRecordError(
-                    f'DefinitionMessage not defined for local_id {record_header.local_id} at record {record_index}.'
-                )
-            body = bytearray(_read_exact(
-                file_object, definition_message.defined_data_size, f'record {record_index} data'
-            ))
-
-        record_bytes = record_header_bytes + bytes(body)
-        if len(record_bytes) > remaining:
-            raise FitRecordError(f'Record {record_index} exceeds the declared records section.')
-
-        try:
-            record = Record.from_bytes(
-                definition_messages,
-                record_bytes,
-                developer_fields_by_data_index=developer_fields_by_data_index,
-            )
-            _register_record(record, definition_messages, developer_fields_by_data_index)
-        except FitRecordError:
-            raise
-        except (IndexError, struct.error, UnicodeError, ValueError) as exc:
-            raise FitRecordError(f'Could not parse record {record_index}: {exc}') from exc
-
-        crc = crc16(record_bytes, crc=crc)
-        remaining -= len(record_bytes)
-        record_index += 1
-        yield record
-
-    file_crc_bytes = _read_exact(file_object, 2, 'file CRC', header=True)
-    file_crc, = struct.unpack('<H', file_crc_bytes)
-    if crc != file_crc:
-        message = f'Calculated crc ({hex(crc)}) does not match crc in file ({hex(file_crc)}).'
-        if check_crc:
-            raise FitCRCError(message)
-        logger.warning(message)
+    yield from FitDecoder(check_crc=check_crc).iter_records(file_object)
 
 
 def iter_fit_file(path: str, check_crc: bool = True) -> Iterator[Record]:

--- a/fit_tool/tests/test_decoder.py
+++ b/fit_tool/tests/test_decoder.py
@@ -1,0 +1,240 @@
+"""Tests for the unified FitDecoder / stream-memory parity (Stage 3)."""
+
+from __future__ import annotations
+
+import io
+import struct
+import unittest
+from pathlib import Path
+
+from fit_tool.base_type import BaseType
+from fit_tool.decoder import FitDecoder, iter_fit_records
+from fit_tool.developer_field import DeveloperField
+from fit_tool.exceptions import FitCRCError, FitHeaderError, FitRecordError
+from fit_tool.fit_file import FitFile
+from fit_tool.fit_file_builder import FitFileBuilder
+from fit_tool.profile.messages.developer_data_id_message import DeveloperDataIdMessage
+from fit_tool.profile.messages.field_description_message import FieldDescriptionMessage
+from fit_tool.profile.messages.record_message import RecordMessage
+from fit_tool.profile.messages.workout_step_message import WorkoutStepMessage
+from fit_tool.profile.profile_type import WorkoutStepDuration
+from fit_tool.wire import WireDecoder
+from fit_tool.wire.model import RawDataRecord, RawDefinitionRecord
+
+DATA_DIR = Path(__file__).resolve().parent / 'data'
+
+
+def _simple_workout_bytes() -> bytes:
+    message = WorkoutStepMessage(local_id=0)
+    message.workout_step_name = 'step'
+    message.duration_type = WorkoutStepDuration.DISTANCE
+    builder = FitFileBuilder(auto_define=True)
+    builder.add(message)
+    return builder.build().to_bytes()
+
+
+def _activity_with_developer_fields() -> bytes:
+    builder = FitFileBuilder(auto_define=True, min_string_size=50)
+
+    developer_data_id = DeveloperDataIdMessage()
+    developer_data_id.developer_data_index = 0
+    developer_data_id.application_id = bytes(range(16))
+    builder.add(developer_data_id)
+
+    field_description = FieldDescriptionMessage()
+    field_description.developer_data_index = 0
+    field_description.field_definition_number = 0
+    field_description.fit_base_type_id = BaseType.UINT8.value
+    field_description.field_name = 'doughnuts_earned'
+    field_description.units = 'doughnuts'
+    builder.add(field_description)
+
+    dev_field = DeveloperField(
+        developer_data_index=0,
+        field_id=0,
+        size=1,
+        base_type=BaseType.UINT8,
+        name='doughnuts_earned',
+        units='doughnuts',
+    )
+    dev_field.set_value(0, 1)
+    record = RecordMessage(developer_fields=[dev_field])
+    record.distance = 0
+    record.power = 100
+    builder.add(record)
+
+    return builder.build().to_bytes()
+
+
+class TestFitDecoderParity(unittest.TestCase):
+    def test_stream_and_from_bytes_record_bytes_match(self):
+        fit_bytes = _simple_workout_bytes()
+
+        full = FitFile.from_bytes(fit_bytes)
+        streamed = list(FitFile.iter_stream(io.BytesIO(fit_bytes)))
+
+        self.assertEqual(
+            [record.to_bytes() for record in streamed],
+            [record.to_bytes() for record in full.records],
+        )
+
+    def test_iter_fit_records_matches_from_bytes_on_bytes_and_stream(self):
+        fit_bytes = _simple_workout_bytes()
+
+        from_bytes_records = FitFile.from_bytes(fit_bytes).records
+        from_buffer = list(iter_fit_records(fit_bytes))
+        from_stream = list(iter_fit_records(io.BytesIO(fit_bytes)))
+
+        self.assertEqual(
+            [r.to_bytes() for r in from_buffer],
+            [r.to_bytes() for r in from_bytes_records],
+        )
+        self.assertEqual(
+            [r.to_bytes() for r in from_stream],
+            [r.to_bytes() for r in from_bytes_records],
+        )
+
+    def test_developer_field_registration_parity(self):
+        fit_bytes = _activity_with_developer_fields()
+
+        full_decoder = FitDecoder()
+        full_records = list(full_decoder.iter_records(fit_bytes))
+
+        stream_decoder = FitDecoder()
+        stream_records = list(stream_decoder.iter_records(io.BytesIO(fit_bytes)))
+
+        self.assertEqual(
+            full_decoder.developer_fields_by_data_index.keys(),
+            stream_decoder.developer_fields_by_data_index.keys(),
+        )
+        full_dev = full_decoder.developer_fields_by_data_index[0][0]
+        stream_dev = stream_decoder.developer_fields_by_data_index[0][0]
+        self.assertEqual(full_dev.name, stream_dev.name)
+        self.assertEqual(full_dev.field_id, stream_dev.field_id)
+        self.assertEqual(full_dev.base_type, stream_dev.base_type)
+
+        self.assertEqual(
+            [r.to_bytes() for r in full_records],
+            [r.to_bytes() for r in stream_records],
+        )
+
+        # Projected record carries the developer field value on both paths.
+        data_messages = [
+            r.message for r in full_records
+            if not r.is_definition and isinstance(r.message, RecordMessage)
+        ]
+        self.assertEqual(len(data_messages), 1)
+        self.assertEqual(len(data_messages[0].developer_fields), 1)
+        self.assertEqual(data_messages[0].developer_fields[0].get_value(0), 1)
+
+    def test_crc_mismatch_parity(self):
+        fit_bytes = bytearray(_simple_workout_bytes())
+        fit_bytes[-1] ^= 0xFF
+        corrupted = bytes(fit_bytes)
+
+        with self.assertRaises(FitCRCError):
+            FitFile.from_bytes(corrupted)
+        with self.assertRaises(FitCRCError):
+            list(FitFile.iter_stream(io.BytesIO(corrupted)))
+
+        # check_crc=False: both paths succeed and leave CRC mismatch visible.
+        full = FitFile.from_bytes(corrupted, check_crc=False)
+        streamed = list(FitFile.iter_stream(io.BytesIO(corrupted), check_crc=False))
+        self.assertEqual(
+            [r.to_bytes() for r in streamed],
+            [r.to_bytes() for r in full.records],
+        )
+
+    def test_sdk_developer_data_stream_matches_from_bytes(self):
+        path = DATA_DIR / 'sdk' / 'DeveloperData.fit'
+        if not path.exists():
+            self.skipTest('DeveloperData.fit fixture missing')
+        fit_bytes = path.read_bytes()
+
+        full = FitFile.from_bytes(fit_bytes)
+        streamed = list(FitFile.iter_stream(io.BytesIO(fit_bytes)))
+        self.assertEqual(
+            [r.to_bytes() for r in streamed],
+            [r.to_bytes() for r in full.records],
+        )
+
+
+class TestDecodeErrorParity(unittest.TestCase):
+    def test_truncated_stream_raises_parse_error(self):
+        fit_bytes = _simple_workout_bytes()
+        truncated = fit_bytes[:-5]
+
+        with self.assertRaises((FitHeaderError, FitRecordError)):
+            FitFile.from_bytes(truncated)
+        with self.assertRaises((FitHeaderError, FitRecordError)):
+            list(FitFile.iter_stream(io.BytesIO(truncated)))
+
+    def test_truncated_mid_record_stream(self):
+        fit_bytes = _simple_workout_bytes()
+        # Keep header + first few record bytes only.
+        header_size = fit_bytes[0]
+        partial = fit_bytes[: header_size + 3]
+
+        with self.assertRaises(FitRecordError):
+            list(FitFile.iter_stream(io.BytesIO(partial)))
+        with self.assertRaises((FitHeaderError, FitRecordError)):
+            FitFile.from_bytes(partial)
+
+    def test_missing_definition_raises_fit_record_error(self):
+        header = bytearray(14)
+        header[0] = 14
+        header[8:12] = b'.FIT'
+        struct.pack_into('<I', header, 4, 1)
+        body = bytes(header) + bytes([0x00]) + struct.pack('<H', 0)
+
+        with self.assertRaises(FitRecordError) as full_ctx:
+            FitFile.from_bytes(body, check_crc=False)
+        with self.assertRaises(FitRecordError) as stream_ctx:
+            list(FitFile.iter_stream(io.BytesIO(body), check_crc=False))
+
+        self.assertIn('local_id', str(full_ctx.exception))
+        self.assertIn('local_id', str(stream_ctx.exception))
+
+    def test_empty_input_raises_header_error_on_both_paths(self):
+        with self.assertRaises(FitHeaderError):
+            FitFile.from_bytes(b'')
+        with self.assertRaises(FitHeaderError):
+            list(FitFile.iter_stream(io.BytesIO(b'')))
+
+
+class TestWireStreamingSession(unittest.TestCase):
+    def test_wire_iter_raw_records_matches_decode(self):
+        fit_bytes = _simple_workout_bytes()
+
+        document = WireDecoder().decode(fit_bytes)
+        segment = document.first_segment
+        assert segment is not None
+
+        stream_decoder = WireDecoder()
+        streamed = list(stream_decoder.iter_raw_records(io.BytesIO(fit_bytes)))
+
+        self.assertEqual(len(streamed), len(segment.records))
+        for left, right in zip(streamed, segment.records):
+            self.assertEqual(type(left), type(right))
+            self.assertEqual(left.source_bytes, right.source_bytes)
+
+        self.assertEqual(stream_decoder.calculated_crc, segment.calculated_crc)
+        self.assertEqual(stream_decoder.stored_crc, segment.stored_crc)
+        self.assertIsNotNone(stream_decoder.header)
+        self.assertEqual(stream_decoder.last_timestamp, None)
+
+    def test_definition_snapshots_independent_on_stream_path(self):
+        fit_bytes = _simple_workout_bytes()
+        # Two messages on same local_id force redefinition when types differ —
+        # reuse workout builder double-add of same type still one definition.
+        decoder = WireDecoder()
+        records = list(decoder.iter_raw_records(fit_bytes))
+        definitions = [r for r in records if isinstance(r, RawDefinitionRecord)]
+        data = [r for r in records if isinstance(r, RawDataRecord)]
+        self.assertGreaterEqual(len(definitions), 1)
+        self.assertGreaterEqual(len(data), 1)
+        self.assertIs(data[0].definition, definitions[0])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/fit_tool/wire/__init__.py
+++ b/fit_tool/wire/__init__.py
@@ -5,7 +5,7 @@ package must not import generated message classes.
 """
 
 from fit_tool.wire.crc import crc16
-from fit_tool.wire.decoder import WireDecoder, decode_bytes
+from fit_tool.wire.decoder import ByteSourceInput, WireDecoder, decode_bytes
 from fit_tool.wire.model import (
     FitDocument,
     FitSegment,
@@ -19,6 +19,7 @@ from fit_tool.wire.model import (
 )
 
 __all__ = [
+    'ByteSourceInput',
     'FitDocument',
     'FitSegment',
     'RawDataRecord',

--- a/fit_tool/wire/decoder.py
+++ b/fit_tool/wire/decoder.py
@@ -2,11 +2,16 @@
 
 Produces :class:`~fit_tool.wire.model.FitDocument` / raw records without
 constructing Profile-generated message classes.
+
+Streaming and in-memory paths share one control loop via a byte-source
+abstraction. Session state (definition snapshots, CRC, last_timestamp hook)
+lives on the decoder instance for the duration of a segment decode.
 """
 
 from __future__ import annotations
 
 import struct
+from typing import BinaryIO, Iterator, Protocol, Union
 
 from fit_tool.exceptions import FitCRCError, FitHeaderError, FitRecordError
 from fit_tool.wire.crc import crc16
@@ -18,6 +23,7 @@ from fit_tool.wire.model import (
     RawDeveloperFieldDefinition,
     RawFieldDefinition,
     RawFileHeader,
+    RawRecord,
     RawRecordHeader,
 )
 
@@ -34,107 +40,205 @@ _FILE_CRC_SIZE = 2
 _FIELD_DEFINITION_SIZE = 3
 _DEFINITION_PREFIX_SIZE = 5  # reserved + architecture + global_id + field_count
 
+ByteSourceInput = Union[bytes, bytearray, memoryview, BinaryIO]
+
+
+class _ByteSource(Protocol):
+    """Sequential reader used by the shared decode loop."""
+
+    @property
+    def position(self) -> int:
+        ...
+
+    def read_exact(self, size: int, context: str, *, header: bool = False) -> bytes:
+        ...
+
+
+class _BufferSource:
+    """Read from an in-memory buffer starting at ``offset``."""
+
+    def __init__(self, data: bytes, offset: int = 0) -> None:
+        self._view = memoryview(data)
+        self._offset = offset
+
+    @property
+    def position(self) -> int:
+        return self._offset
+
+    def read_exact(self, size: int, context: str, *, header: bool = False) -> bytes:
+        available = len(self._view) - self._offset
+        if size > available:
+            error_type = FitHeaderError if header else FitRecordError
+            raise error_type(
+                f'Truncated FIT input while reading {context}: expected {size} bytes, got {available}.'
+            )
+        data = bytes(self._view[self._offset:self._offset + size])
+        self._offset += size
+        return data
+
+
+class _StreamSource:
+    """Read from a binary stream, handling short reads."""
+
+    def __init__(self, file_object: BinaryIO, position: int = 0) -> None:
+        self._file = file_object
+        self._position = position
+
+    @property
+    def position(self) -> int:
+        return self._position
+
+    def read_exact(self, size: int, context: str, *, header: bool = False) -> bytes:
+        data = bytearray()
+        while len(data) < size:
+            chunk = self._file.read(size - len(data))
+            if not chunk:
+                break
+            data.extend(chunk)
+
+        if len(data) != size:
+            error_type = FitHeaderError if header else FitRecordError
+            raise error_type(
+                f'Truncated FIT input while reading {context}: expected {size} bytes, got {len(data)}.'
+            )
+        self._position += size
+        return bytes(data)
+
+
+def _as_byte_source(source: ByteSourceInput, offset: int = 0) -> _ByteSource:
+    if isinstance(source, (bytes, bytearray, memoryview)):
+        return _BufferSource(bytes(source), offset=offset)
+    return _StreamSource(source, position=offset)
+
 
 class WireDecoder:
     """Decode FIT binary into raw wire models.
 
     Definition table entries are immutable snapshots. Redefining a local message
     ID replaces the table entry for *subsequent* records only.
+
+    Session state after a successful :meth:`iter_raw_records` / :meth:`decode_segment`
+    call:
+
+    - :attr:`header` — parsed file header
+    - :attr:`definitions` — final local-id → definition snapshot map
+    - :attr:`calculated_crc` / :attr:`stored_crc`
+    - :attr:`last_timestamp` — reserved for compressed-timestamp reconstruction
     """
 
     def __init__(self, check_crc: bool = True) -> None:
         self.check_crc = check_crc
+        self._reset_session()
+
+    def _reset_session(self) -> None:
+        self.header: RawFileHeader | None = None
+        self.definitions: dict[int, RawDefinitionRecord] = {}
+        self.calculated_crc: int = 0
+        self.stored_crc: int = 0
+        self.crc_offset: int = 0
+        # Hook for compressed timestamp reconstruction (Stage later).
+        self.last_timestamp: int | None = None
 
     def decode(self, bytes_buffer: bytes) -> FitDocument:
         """Decode a buffer into a document (single segment for MVP)."""
         if len(bytes_buffer) < 1:
             raise FitHeaderError('FIT data is empty; expected at least a header-size byte.')
 
-        segment, _consumed = self._decode_segment(bytes_buffer, offset=0)
+        segment = self.decode_segment(bytes_buffer, offset=0)
         return FitDocument(segments=[segment])
 
-    def decode_segment(self, bytes_buffer: bytes, offset: int = 0) -> FitSegment:
-        """Decode a single segment starting at ``offset``."""
-        segment, _ = self._decode_segment(bytes_buffer, offset=offset)
-        return segment
+    def decode_segment(self, source: ByteSourceInput, offset: int = 0) -> FitSegment:
+        """Decode a single segment from bytes or a binary stream."""
+        records = list(self.iter_raw_records(source, offset=offset))
+        assert self.header is not None
+        return FitSegment(
+            header=self.header,
+            records=records,
+            stored_crc=self.stored_crc,
+            calculated_crc=self.calculated_crc,
+            crc_offset=self.crc_offset,
+        )
 
-    def _decode_segment(self, bytes_buffer: bytes, offset: int) -> tuple:
-        buffer_view = memoryview(bytes_buffer)
-        start = offset
+    def iter_raw_records(
+            self,
+            source: ByteSourceInput,
+            offset: int = 0,
+    ) -> Iterator[RawRecord]:
+        """Yield raw records for one segment; validates file CRC when exhausted.
 
-        header, offset = self._decode_header(buffer_view, offset)
-        calculated_crc = crc16(header.source_bytes)
+        Both streaming and in-memory callers use this same control loop.
+        """
+        self._reset_session()
+        byte_source = _as_byte_source(source, offset=offset)
 
-        records_end = offset + header.records_size
-        file_crc_end = records_end + _FILE_CRC_SIZE
-        if file_crc_end > len(bytes_buffer):
-            raise FitHeaderError('FIT data is truncated before the declared records and file CRC.')
-
-        definitions: dict[int, RawDefinitionRecord] = {}
-        records = []
-        record_index = 0
+        header = self._read_header(byte_source)
+        self.header = header
+        self.calculated_crc = crc16(header.source_bytes)
         remaining = header.records_size
+        record_index = 0
+
+        # Buffer sources know their total length: reject undersized payloads
+        # early with FitHeaderError (matches historical from_bytes behaviour).
+        # Streams discover truncation while reading and raise FitRecordError /
+        # FitHeaderError from read_exact instead.
+        if isinstance(byte_source, _BufferSource):
+            available = len(byte_source._view) - byte_source.position
+            needed = remaining + _FILE_CRC_SIZE
+            if available < needed:
+                raise FitHeaderError(
+                    'FIT data is truncated before the declared records and file CRC.'
+                )
 
         while remaining > 0:
             try:
-                raw_record, record_size = self._decode_record(
-                    buffer_view, offset, definitions, record_index
-                )
+                raw_record = self._read_record(byte_source, record_index)
             except FitRecordError:
                 raise
             except (IndexError, struct.error, ValueError) as exc:
                 raise FitRecordError(
-                    f'Could not parse record {record_index} at byte offset {offset}: {exc}'
+                    f'Could not parse record {record_index} at byte offset '
+                    f'{byte_source.position}: {exc}'
                 ) from exc
 
+            record_size = raw_record.size
             if record_size <= 0 or record_size > remaining:
                 raise FitRecordError(
-                    f'Record {record_index} at byte offset {offset} exceeds the declared records section.'
+                    f'Record {record_index} at byte offset {raw_record.source_offset} '
+                    f'exceeds the declared records section.'
                 )
 
             if isinstance(raw_record, RawDefinitionRecord):
                 # Store immutable snapshot; redefinition does not mutate prior snapshots.
-                definitions[raw_record.local_id] = raw_record
+                self.definitions[raw_record.local_id] = raw_record
 
-            calculated_crc = crc16(buffer_view[offset:offset + record_size], crc=calculated_crc)
-            records.append(raw_record)
+            self.calculated_crc = crc16(raw_record.source_bytes, crc=self.calculated_crc)
             remaining -= record_size
-            offset += record_size
             record_index += 1
+            yield raw_record
 
-        stored_crc, = struct.unpack_from('<H', buffer_view, offset)
-        if calculated_crc != stored_crc:
+        self.crc_offset = byte_source.position
+        file_crc_bytes = byte_source.read_exact(_FILE_CRC_SIZE, 'file CRC', header=True)
+        self.stored_crc, = struct.unpack('<H', file_crc_bytes)
+        if self.calculated_crc != self.stored_crc:
             message = (
-                f'Calculated crc ({hex(calculated_crc)}) does not match crc in file ({hex(stored_crc)}).'
+                f'Calculated crc ({hex(self.calculated_crc)}) does not match '
+                f'crc in file ({hex(self.stored_crc)}).'
             )
             if self.check_crc:
                 raise FitCRCError(message)
 
-        segment = FitSegment(
-            header=header,
-            records=records,
-            stored_crc=stored_crc,
-            calculated_crc=calculated_crc,
-            crc_offset=offset,
-        )
-        return segment, offset + _FILE_CRC_SIZE - start
-
-    def _decode_header(self, buffer_view: memoryview, offset: int) -> tuple:
-        if offset >= len(buffer_view):
-            raise FitHeaderError('FIT data is empty; expected at least a header-size byte.')
-
-        header_size = buffer_view[offset]
+    def _read_header(self, source: _ByteSource) -> RawFileHeader:
+        offset = source.position
+        header_size_bytes = source.read_exact(1, 'header size', header=True)
+        header_size = header_size_bytes[0]
         if header_size < _MIN_HEADER_SIZE:
             raise FitHeaderError(
                 f'FIT header size must be at least {_MIN_HEADER_SIZE} bytes, got {header_size}.'
             )
-        if offset + header_size > len(buffer_view):
-            raise FitHeaderError(
-                f'FIT header declares {header_size} bytes but only '
-                f'{len(buffer_view) - offset} are available.'
-            )
 
-        source_bytes = bytes(buffer_view[offset:offset + header_size])
+        source_bytes = header_size_bytes + source.read_exact(
+            header_size - 1, 'remaining header', header=True
+        )
         try:
             protocol_version = source_bytes[1]
             profile_version, = struct.unpack_from('<H', source_bytes, 2)
@@ -148,7 +252,7 @@ class WireDecoder:
         except (IndexError, struct.error, ValueError) as exc:
             raise FitHeaderError(f'Invalid FIT header: {exc}') from exc
 
-        header = RawFileHeader(
+        return RawFileHeader(
             header_size=header_size,
             protocol_version=protocol_version,
             profile_version=profile_version,
@@ -158,15 +262,12 @@ class WireDecoder:
             source_offset=offset,
             source_bytes=source_bytes,
         )
-        return header, offset + header_size
 
-    def _decode_record_header(self, buffer_view: memoryview, offset: int) -> RawRecordHeader:
-        if offset >= len(buffer_view):
+    def _decode_record_header(self, source_bytes: bytes, offset: int) -> RawRecordHeader:
+        if not source_bytes:
             raise FitRecordError(f'Truncated FIT input while reading record header at offset {offset}.')
 
-        byte = buffer_view[offset]
-        source_bytes = bytes(buffer_view[offset:offset + 1])
-
+        byte = source_bytes[0]
         is_time_compressed = (byte & _IS_TIME_COMPRESSED) == _IS_TIME_COMPRESSED
         if is_time_compressed:
             # Compressed timestamp headers are always data-message headers.
@@ -195,75 +296,65 @@ class WireDecoder:
             source_bytes=source_bytes,
         )
 
-    def _decode_record(
-            self,
-            buffer_view: memoryview,
-            offset: int,
-            definitions: dict[int, RawDefinitionRecord],
-            record_index: int,
-    ) -> tuple:
-        header = self._decode_record_header(buffer_view, offset)
-        body_offset = offset + header.size
+    def _read_record(self, source: _ByteSource, record_index: int) -> RawRecord:
+        record_offset = source.position
+        header_bytes = source.read_exact(1, f'record {record_index} header')
+        header = self._decode_record_header(header_bytes, record_offset)
 
         if header.is_definition:
-            return self._decode_definition(buffer_view, offset, body_offset, header)
-        return self._decode_data(buffer_view, offset, body_offset, header, definitions, record_index)
+            return self._read_definition(source, header, record_offset, header_bytes)
+        return self._read_data(source, header, record_offset, header_bytes, record_index)
 
-    def _decode_definition(
+    def _read_definition(
             self,
-            buffer_view: memoryview,
-            record_offset: int,
-            body_offset: int,
+            source: _ByteSource,
             header: RawRecordHeader,
-    ) -> tuple:
-        if body_offset + _DEFINITION_PREFIX_SIZE > len(buffer_view):
-            raise FitRecordError(
-                f'Truncated definition message at offset {record_offset}.'
-            )
-
-        reserved = buffer_view[body_offset]
-        architecture = buffer_view[body_offset + 1]
+            record_offset: int,
+            header_bytes: bytes,
+    ) -> RawDefinitionRecord:
+        prefix = source.read_exact(
+            _DEFINITION_PREFIX_SIZE, f'definition prefix at offset {record_offset}'
+        )
+        reserved = prefix[0]
+        architecture = prefix[1]
         if architecture not in (0, 1):
             raise FitRecordError(
                 f'Invalid definition architecture {architecture} at offset {record_offset}.'
             )
 
         endian_symbol = '<' if architecture == 0 else '>'
-        global_id, = struct.unpack_from(f'{endian_symbol}H', buffer_view, body_offset + 2)
-        field_count = buffer_view[body_offset + 4]
-        cursor = body_offset + _DEFINITION_PREFIX_SIZE
+        global_id, = struct.unpack(f'{endian_symbol}H', prefix[2:4])
+        field_count = prefix[4]
 
         field_definitions = []
+        field_bytes = bytearray()
         for _ in range(field_count):
-            if cursor + _FIELD_DEFINITION_SIZE > len(buffer_view):
-                raise FitRecordError(f'Truncated field definitions at offset {record_offset}.')
-            field_id = buffer_view[cursor]
-            size = buffer_view[cursor + 1]
-            base_type = buffer_view[cursor + 2]
-            field_definitions.append(RawFieldDefinition(field_id, size, base_type))
-            cursor += _FIELD_DEFINITION_SIZE
+            entry = source.read_exact(
+                _FIELD_DEFINITION_SIZE, f'field definitions at offset {record_offset}'
+            )
+            field_bytes.extend(entry)
+            field_definitions.append(RawFieldDefinition(entry[0], entry[1], entry[2]))
 
         developer_field_definitions = []
+        developer_bytes = bytearray()
         if header.has_developer_fields:
-            if cursor >= len(buffer_view):
-                raise FitRecordError(f'Truncated developer field count at offset {record_offset}.')
-            developer_count = buffer_view[cursor]
-            cursor += 1
+            developer_count_bytes = source.read_exact(
+                1, f'developer field count at offset {record_offset}'
+            )
+            developer_bytes.extend(developer_count_bytes)
+            developer_count = developer_count_bytes[0]
             for _ in range(developer_count):
-                if cursor + _FIELD_DEFINITION_SIZE > len(buffer_view):
-                    raise FitRecordError(
-                        f'Truncated developer field definitions at offset {record_offset}.'
-                    )
-                field_id = buffer_view[cursor]
-                size = buffer_view[cursor + 1]
-                developer_data_index = buffer_view[cursor + 2]
-                developer_field_definitions.append(
-                    RawDeveloperFieldDefinition(field_id, size, developer_data_index)
+                entry = source.read_exact(
+                    _FIELD_DEFINITION_SIZE,
+                    f'developer field definitions at offset {record_offset}',
                 )
-                cursor += _FIELD_DEFINITION_SIZE
+                developer_bytes.extend(entry)
+                developer_field_definitions.append(
+                    RawDeveloperFieldDefinition(entry[0], entry[1], entry[2])
+                )
 
-        source_bytes = bytes(buffer_view[record_offset:cursor])
-        raw = RawDefinitionRecord(
+        source_bytes = header_bytes + prefix + bytes(field_bytes) + bytes(developer_bytes)
+        return RawDefinitionRecord(
             header=header,
             reserved=reserved,
             architecture=architecture,
@@ -273,41 +364,34 @@ class WireDecoder:
             source_offset=record_offset,
             source_bytes=source_bytes,
         )
-        return raw, len(source_bytes)
 
-    def _decode_data(
+    def _read_data(
             self,
-            buffer_view: memoryview,
-            record_offset: int,
-            body_offset: int,
+            source: _ByteSource,
             header: RawRecordHeader,
-            definitions: dict[int, RawDefinitionRecord],
+            record_offset: int,
+            header_bytes: bytes,
             record_index: int,
-    ) -> tuple:
-        definition = definitions.get(header.local_id)
+    ) -> RawDataRecord:
+        definition = self.definitions.get(header.local_id)
         if definition is None:
             raise FitRecordError(
                 f'DefinitionMessage not defined for local_id: {header.local_id}'
             )
 
         payload_size = definition.defined_data_size
-        end = body_offset + payload_size
-        if end > len(buffer_view):
-            raise FitRecordError(
-                f'Truncated data record {record_index} at offset {record_offset}: '
-                f'need {payload_size} payload bytes.'
-            )
-
-        payload = bytes(buffer_view[body_offset:end])
-        source_bytes = bytes(buffer_view[record_offset:end])
-        raw = RawDataRecord(
+        payload = source.read_exact(
+            payload_size,
+            f'data record {record_index} payload at offset {record_offset}',
+        )
+        source_bytes = header_bytes + payload
+        return RawDataRecord(
             header=header,
             definition=definition,
             payload=payload,
             source_offset=record_offset,
             source_bytes=source_bytes,
         )
-        return raw, len(source_bytes)
 
 
 def decode_bytes(bytes_buffer: bytes, check_crc: bool = True) -> FitDocument:

--- a/news/SHA-8.feature
+++ b/news/SHA-8.feature
@@ -1,0 +1,3 @@
+Unify stream and in-memory FIT decoding on one state machine (`FitDecoder`
+over the wire layer) so definition snapshots, developer-field registration,
+and CRC handling stay aligned between `FitFile.from_bytes` and `iter_*`.


### PR DESCRIPTION
## Summary
Stage 3 of the architecture plan: **one decoder state machine** for streaming and full-load paths.

- **`WireDecoder`** now uses a byte-source abstraction (`bytes` or `BinaryIO`) and a single control loop (`iter_raw_records`) for definition snapshots, CRC accumulation, and a `last_timestamp` hook.
- **`FitDecoder`** (`fit_tool/decoder.py`) projects wire records, owns the developer-field registry, and is used by both `FitFile.from_bytes` and `iter_fit_stream` / `iter_fit_file`.
- Developer-field registration strictness and CRC check/warn behaviour are aligned between paths.
- `fit_file_stream` is a thin wrapper over `FitDecoder`.

## Tests
- New `fit_tool/tests/test_decoder.py`: stream/memory parity, developer-field registry parity, CRC parity, truncated input, missing definition, empty input, wire streaming session.
- Full suite: **251 passed, 2 skipped**.

## Acceptance
- [x] Stream and full-load paths share one implementation (no duplicated record loops)
- [x] Behavioral parity tests for CRC and developer fields
- [x] Existing suite passes

Closes SHA-8 / architecture Stage 3 decoder unification.