### PR TITLE
SHA-10: split message create vs from_definition construction

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,33 @@ The generator deletes and rebuilds the entire `fit_tool/profile/` directory. Bef
 
 Keep generator changes and their generated output in the same change. Do not apply broad formatting or lint fixes to generated files; adjust the Jinja templates instead.
 
+### Message construction paths
+
+Generated profile messages have **two explicit construction modes**. Do not
+reintroduce a dual-mode `__init__(definition_message=None, ...)` that switches
+growable/size behavior from a nullable definition argument.
+
+| Path | Call | Purpose |
+| --- | --- | --- |
+| **Create (authoring)** | `RecordMessage()` / `RecordMessage(local_id=..., endian=..., developer_fields=...)` | Blank growable fields for writing new data |
+| **Project (decode)** | `RecordMessage.from_definition(definition, developer_fields=...)` | Wire definition projection; fixed field sizes, not growable |
+
+Decode and factory entry points:
+
+- `MessageFactory.from_definition(definition, developer_fields)` — polymorphic
+  (typed class or `GenericMessage`)
+- `DataMessage.from_definition(...)` — delegates to MessageFactory
+- `MessageClass.from_bytes(definition, developer_fields, bytes, offset)` —
+  uses `from_definition` then reads payload
+
+`GenericMessage` has no blank create path (unknown global IDs only exist as
+definition projections). Prefer `GenericMessage.from_definition(...)`; its
+`__init__(definition_message, ...)` remains an alias.
+
+When changing construction, edit `fit_tool/gen/templates/template_message.jinja`
+and `template_message_factory.jinja`, then regenerate. Document public usage in
+`README.md` if the authoring/decode story changes for application callers.
+
 ## Implementation guidelines
 
 - Preserve the public behavior of FIT parsing, serialization, CRC validation, field scaling, developer fields, and local message definitions unless the change explicitly alters that behavior.

--- a/README.md
+++ b/README.md
@@ -155,6 +155,25 @@ from fit_tool.profile.profile_type import FileType, Sport
 Naming convention: message module is the snake_case form of the class
 (`record_message` → `RecordMessage`), under `fit_tool.profile.messages`.
 
+**Construction paths** (do not pass a definition into `__init__`):
+
+| Mode | API | Use when |
+| --- | --- | --- |
+| Create / author | `RecordMessage()` | Writing new messages in a builder |
+| Project / decode | `RecordMessage.from_definition(definition, developer_fields=...)` | Applying a local definition (decode path) |
+
+`MessageFactory.from_definition` and the FitFile/wire projection path use the
+definition factory. Example authoring:
+
+```python
+from fit_tool.profile.messages.file_id_message import FileIdMessage
+from fit_tool.profile.profile_type import FileType, Manufacturer
+
+msg = FileIdMessage()
+msg.type = FileType.ACTIVITY
+msg.manufacturer = Manufacturer.DEVELOPMENT
+```
+
 **Compatibility:** deep imports such as `from fit_tool.fit_file import FitFile`
 remain supported. Prefer the package-root form for new code. No deep-import paths
 are removed in this release; future deprecations will be announced in the changelog.

--- a/fit_tool/data_message.py
+++ b/fit_tool/data_message.py
@@ -9,6 +9,22 @@ from fit_tool.utils.logging import logger
 
 
 class DataMessage(Message):
+    """Base class for FIT data messages.
+
+    Construction modes for generated subclasses:
+
+    * **Create (authoring):** ``MessageClass()`` or ``MessageClass(local_id=...,
+      endian=..., developer_fields=...)`` — blank growable fields, no wire
+      definition attached.
+    * **Project (decode):** ``MessageClass.from_definition(definition,
+      developer_fields=...)`` — field sizes fixed from the local definition.
+      :class:`~fit_tool.profile.messages.message_factory.MessageFactory` and
+      the wire projection path use this factory.
+
+    Do not pass a definition into ``__init__`` on generated message classes;
+    use :meth:`from_definition` (class method on each generated type) or this
+    base :meth:`from_definition` static method (routes via MessageFactory).
+    """
 
     def __init__(self, local_id: int = 0, global_id: int = 0, endian: Endian = Endian.LITTLE,
                  name: str = '',
@@ -26,6 +42,11 @@ class DataMessage(Message):
 
     @staticmethod
     def from_definition(definition_message: DefinitionMessage, developer_fields: list[DeveloperField]):
+        """Build the typed message for *definition_message* via MessageFactory.
+
+        Prefer ``SomeMessage.from_definition(...)`` when the concrete class is
+        known; use this entry point for polymorphic decode projection.
+        """
         from fit_tool.profile.messages.message_factory import MessageFactory
         return MessageFactory.from_definition(definition_message, developer_fields)
 

--- a/fit_tool/gen/templates/template_message.jinja
+++ b/fit_tool/gen/templates/template_message.jinja
@@ -17,42 +17,76 @@ from typing import Dict as dict
 
 
 class {{class_name}}(DataMessage):
+    """{{class_name}} — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``{{class_name}}()`` — create path: growable fields, no wire definition.
+    * ``{{class_name}}.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = {{message.id}}
     NAME = '{{message.name}}'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name={{class_name}}.NAME,
                          global_id={{class_name}}.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
                              {%- for field_name, field in message.fields_by_name.items() %}
         {{message.field_class_name_by_name[field_name]}}(
-            size=self.__get_field_size(definition_message, {{message.field_class_name_by_name[field_name]}}.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         {%- if not loop.last %}, {% endif %}
         {%- endfor %}
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+                {%- for field_name, field in message.fields_by_name.items() %}
+        {{message.field_class_name_by_name[field_name]}}(
+            size=cls._field_size_from_definition(
+                definition_message, {{message.field_class_name_by_name[field_name]}}.ID),
+            growable=False)
+        {%- if not loop.last %}, {% endif %}
+        {%- endfor %}
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/gen/templates/template_message_factory.jinja
+++ b/fit_tool/gen/templates/template_message_factory.jinja
@@ -30,6 +30,7 @@ def _get_message_class(global_id: int) -> Optional[Type[DataMessage]]:
 
 
 class MessageFactory:
+    """Build typed data messages from wire definitions (decode projection)."""
 
     @staticmethod
     def from_definition(
@@ -37,6 +38,8 @@ class MessageFactory:
             developer_fields: List[DeveloperField]) -> DataMessage:
         message_class = _get_message_class(definition_message.global_id)
         if message_class is None:
-            return GenericMessage(definition_message=definition_message, developer_fields=developer_fields)
+            return GenericMessage.from_definition(
+                definition_message, developer_fields=developer_fields)
 
-        return message_class(definition_message=definition_message, developer_fields=developer_fields)
+        return message_class.from_definition(
+            definition_message, developer_fields=developer_fields)

--- a/fit_tool/generic_message.py
+++ b/fit_tool/generic_message.py
@@ -7,6 +7,14 @@ from fit_tool.field import Field
 
 
 class GenericMessage(DataMessage):
+    """Fallback message for unknown global IDs (always definition-projected).
+
+    Generic messages have no blank authoring constructor: they only exist as a
+    projection of a local definition from the wire. Prefer
+    :meth:`from_definition` for new code; ``__init__(definition_message, ...)``
+    remains supported as an alias.
+    """
+
     NAME = 'generic'
 
     def __init__(self, definition_message: DefinitionMessage, developer_fields: list[DeveloperField] = None):
@@ -15,12 +23,18 @@ class GenericMessage(DataMessage):
                          endian=definition_message.endian, name=GenericMessage.NAME,
                          definition_message=definition_message, fields=fields, developer_fields=developer_fields)
 
-    #
-    # final bool growable;
+    @classmethod
+    def from_definition(
+            cls,
+            definition_message: DefinitionMessage,
+            developer_fields: list[DeveloperField] = None,
+    ) -> GenericMessage:
+        """Project a wire definition onto a generic (unknown-profile) message."""
+        return cls(definition_message, developer_fields=developer_fields)
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = GenericMessage(definition_message=definition_message)
-        message.read_from_bytes(bytes_buffer)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
+        message.read_from_bytes(bytes_buffer, offset)
         return message

--- a/fit_tool/profile/messages/aad_accel_features_message.py
+++ b/fit_tool/profile/messages/aad_accel_features_message.py
@@ -17,54 +17,105 @@ from typing import Dict as dict
 
 
 class AadAccelFeaturesMessage(DataMessage):
+    """AadAccelFeaturesMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``AadAccelFeaturesMessage()`` — create path: growable fields, no wire definition.
+    * ``AadAccelFeaturesMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 289
     NAME = 'aad_accel_features'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=AadAccelFeaturesMessage.NAME,
                          global_id=AadAccelFeaturesMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         TimestampField(
-            size=self.__get_field_size(definition_message, TimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         AadAccelFeaturesTimeField(
-            size=self.__get_field_size(definition_message, AadAccelFeaturesTimeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         AadAccelFeaturesEnergyTotalField(
-            size=self.__get_field_size(definition_message, AadAccelFeaturesEnergyTotalField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         AadAccelFeaturesZeroCrossCntField(
-            size=self.__get_field_size(definition_message, AadAccelFeaturesZeroCrossCntField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         AadAccelFeaturesInstanceField(
-            size=self.__get_field_size(definition_message, AadAccelFeaturesInstanceField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         AadAccelFeaturesTimeAboveThresholdField(
-            size=self.__get_field_size(definition_message, AadAccelFeaturesTimeAboveThresholdField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        TimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampField.ID),
+            growable=False), 
+        AadAccelFeaturesTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, AadAccelFeaturesTimeField.ID),
+            growable=False), 
+        AadAccelFeaturesEnergyTotalField(
+            size=cls._field_size_from_definition(
+                definition_message, AadAccelFeaturesEnergyTotalField.ID),
+            growable=False), 
+        AadAccelFeaturesZeroCrossCntField(
+            size=cls._field_size_from_definition(
+                definition_message, AadAccelFeaturesZeroCrossCntField.ID),
+            growable=False), 
+        AadAccelFeaturesInstanceField(
+            size=cls._field_size_from_definition(
+                definition_message, AadAccelFeaturesInstanceField.ID),
+            growable=False), 
+        AadAccelFeaturesTimeAboveThresholdField(
+            size=cls._field_size_from_definition(
+                definition_message, AadAccelFeaturesTimeAboveThresholdField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/accelerometer_data_message.py
+++ b/fit_tool/profile/messages/accelerometer_data_message.py
@@ -17,72 +17,147 @@ from typing import Dict as dict
 
 
 class AccelerometerDataMessage(DataMessage):
+    """AccelerometerDataMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``AccelerometerDataMessage()`` — create path: growable fields, no wire definition.
+    * ``AccelerometerDataMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 165
     NAME = 'accelerometer_data'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=AccelerometerDataMessage.NAME,
                          global_id=AccelerometerDataMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         TimestampField(
-            size=self.__get_field_size(definition_message, TimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         AccelerometerDataTimestampMsField(
-            size=self.__get_field_size(definition_message, AccelerometerDataTimestampMsField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         AccelerometerDataSampleTimeOffsetField(
-            size=self.__get_field_size(definition_message, AccelerometerDataSampleTimeOffsetField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         AccelerometerDataAccelXField(
-            size=self.__get_field_size(definition_message, AccelerometerDataAccelXField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         AccelerometerDataAccelYField(
-            size=self.__get_field_size(definition_message, AccelerometerDataAccelYField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         AccelerometerDataAccelZField(
-            size=self.__get_field_size(definition_message, AccelerometerDataAccelZField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         AccelerometerDataCalibratedAccelXField(
-            size=self.__get_field_size(definition_message, AccelerometerDataCalibratedAccelXField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         AccelerometerDataCalibratedAccelYField(
-            size=self.__get_field_size(definition_message, AccelerometerDataCalibratedAccelYField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         AccelerometerDataCalibratedAccelZField(
-            size=self.__get_field_size(definition_message, AccelerometerDataCalibratedAccelZField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         AccelerometerDataCompressedCalibratedAccelXField(
-            size=self.__get_field_size(definition_message, AccelerometerDataCompressedCalibratedAccelXField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         AccelerometerDataCompressedCalibratedAccelYField(
-            size=self.__get_field_size(definition_message, AccelerometerDataCompressedCalibratedAccelYField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         AccelerometerDataCompressedCalibratedAccelZField(
-            size=self.__get_field_size(definition_message, AccelerometerDataCompressedCalibratedAccelZField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        TimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampField.ID),
+            growable=False), 
+        AccelerometerDataTimestampMsField(
+            size=cls._field_size_from_definition(
+                definition_message, AccelerometerDataTimestampMsField.ID),
+            growable=False), 
+        AccelerometerDataSampleTimeOffsetField(
+            size=cls._field_size_from_definition(
+                definition_message, AccelerometerDataSampleTimeOffsetField.ID),
+            growable=False), 
+        AccelerometerDataAccelXField(
+            size=cls._field_size_from_definition(
+                definition_message, AccelerometerDataAccelXField.ID),
+            growable=False), 
+        AccelerometerDataAccelYField(
+            size=cls._field_size_from_definition(
+                definition_message, AccelerometerDataAccelYField.ID),
+            growable=False), 
+        AccelerometerDataAccelZField(
+            size=cls._field_size_from_definition(
+                definition_message, AccelerometerDataAccelZField.ID),
+            growable=False), 
+        AccelerometerDataCalibratedAccelXField(
+            size=cls._field_size_from_definition(
+                definition_message, AccelerometerDataCalibratedAccelXField.ID),
+            growable=False), 
+        AccelerometerDataCalibratedAccelYField(
+            size=cls._field_size_from_definition(
+                definition_message, AccelerometerDataCalibratedAccelYField.ID),
+            growable=False), 
+        AccelerometerDataCalibratedAccelZField(
+            size=cls._field_size_from_definition(
+                definition_message, AccelerometerDataCalibratedAccelZField.ID),
+            growable=False), 
+        AccelerometerDataCompressedCalibratedAccelXField(
+            size=cls._field_size_from_definition(
+                definition_message, AccelerometerDataCompressedCalibratedAccelXField.ID),
+            growable=False), 
+        AccelerometerDataCompressedCalibratedAccelYField(
+            size=cls._field_size_from_definition(
+                definition_message, AccelerometerDataCompressedCalibratedAccelYField.ID),
+            growable=False), 
+        AccelerometerDataCompressedCalibratedAccelZField(
+            size=cls._field_size_from_definition(
+                definition_message, AccelerometerDataCompressedCalibratedAccelZField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/activity_message.py
+++ b/fit_tool/profile/messages/activity_message.py
@@ -17,60 +17,119 @@ from typing import Dict as dict
 
 
 class ActivityMessage(DataMessage):
+    """ActivityMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``ActivityMessage()`` — create path: growable fields, no wire definition.
+    * ``ActivityMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 34
     NAME = 'activity'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=ActivityMessage.NAME,
                          global_id=ActivityMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         TimestampField(
-            size=self.__get_field_size(definition_message, TimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ActivityTotalTimerTimeField(
-            size=self.__get_field_size(definition_message, ActivityTotalTimerTimeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ActivityNumSessionsField(
-            size=self.__get_field_size(definition_message, ActivityNumSessionsField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ActivityTypeField(
-            size=self.__get_field_size(definition_message, ActivityTypeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ActivityEventField(
-            size=self.__get_field_size(definition_message, ActivityEventField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ActivityEventTypeField(
-            size=self.__get_field_size(definition_message, ActivityEventTypeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ActivityLocalTimestampField(
-            size=self.__get_field_size(definition_message, ActivityLocalTimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ActivityEventGroupField(
-            size=self.__get_field_size(definition_message, ActivityEventGroupField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        TimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampField.ID),
+            growable=False), 
+        ActivityTotalTimerTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, ActivityTotalTimerTimeField.ID),
+            growable=False), 
+        ActivityNumSessionsField(
+            size=cls._field_size_from_definition(
+                definition_message, ActivityNumSessionsField.ID),
+            growable=False), 
+        ActivityTypeField(
+            size=cls._field_size_from_definition(
+                definition_message, ActivityTypeField.ID),
+            growable=False), 
+        ActivityEventField(
+            size=cls._field_size_from_definition(
+                definition_message, ActivityEventField.ID),
+            growable=False), 
+        ActivityEventTypeField(
+            size=cls._field_size_from_definition(
+                definition_message, ActivityEventTypeField.ID),
+            growable=False), 
+        ActivityLocalTimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, ActivityLocalTimestampField.ID),
+            growable=False), 
+        ActivityEventGroupField(
+            size=cls._field_size_from_definition(
+                definition_message, ActivityEventGroupField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/ant_channel_id_message.py
+++ b/fit_tool/profile/messages/ant_channel_id_message.py
@@ -17,51 +17,98 @@ from typing import Dict as dict
 
 
 class AntChannelIdMessage(DataMessage):
+    """AntChannelIdMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``AntChannelIdMessage()`` — create path: growable fields, no wire definition.
+    * ``AntChannelIdMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 82
     NAME = 'ant_channel_id'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=AntChannelIdMessage.NAME,
                          global_id=AntChannelIdMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         AntChannelIdChannelNumberField(
-            size=self.__get_field_size(definition_message, AntChannelIdChannelNumberField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         AntChannelIdDeviceTypeField(
-            size=self.__get_field_size(definition_message, AntChannelIdDeviceTypeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         AntChannelIdDeviceNumberField(
-            size=self.__get_field_size(definition_message, AntChannelIdDeviceNumberField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         AntChannelIdTransmissionTypeField(
-            size=self.__get_field_size(definition_message, AntChannelIdTransmissionTypeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         AntChannelIdDeviceIndexField(
-            size=self.__get_field_size(definition_message, AntChannelIdDeviceIndexField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        AntChannelIdChannelNumberField(
+            size=cls._field_size_from_definition(
+                definition_message, AntChannelIdChannelNumberField.ID),
+            growable=False), 
+        AntChannelIdDeviceTypeField(
+            size=cls._field_size_from_definition(
+                definition_message, AntChannelIdDeviceTypeField.ID),
+            growable=False), 
+        AntChannelIdDeviceNumberField(
+            size=cls._field_size_from_definition(
+                definition_message, AntChannelIdDeviceNumberField.ID),
+            growable=False), 
+        AntChannelIdTransmissionTypeField(
+            size=cls._field_size_from_definition(
+                definition_message, AntChannelIdTransmissionTypeField.ID),
+            growable=False), 
+        AntChannelIdDeviceIndexField(
+            size=cls._field_size_from_definition(
+                definition_message, AntChannelIdDeviceIndexField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/ant_rx_message.py
+++ b/fit_tool/profile/messages/ant_rx_message.py
@@ -17,54 +17,105 @@ from typing import Dict as dict
 
 
 class AntRxMessage(DataMessage):
+    """AntRxMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``AntRxMessage()`` — create path: growable fields, no wire definition.
+    * ``AntRxMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 80
     NAME = 'ant_rx'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=AntRxMessage.NAME,
                          global_id=AntRxMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         TimestampField(
-            size=self.__get_field_size(definition_message, TimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         AntRxFractionalTimestampField(
-            size=self.__get_field_size(definition_message, AntRxFractionalTimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         AntRxMesgIdField(
-            size=self.__get_field_size(definition_message, AntRxMesgIdField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         AntRxMesgDataField(
-            size=self.__get_field_size(definition_message, AntRxMesgDataField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         AntRxChannelNumberField(
-            size=self.__get_field_size(definition_message, AntRxChannelNumberField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         AntRxDataField(
-            size=self.__get_field_size(definition_message, AntRxDataField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        TimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampField.ID),
+            growable=False), 
+        AntRxFractionalTimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, AntRxFractionalTimestampField.ID),
+            growable=False), 
+        AntRxMesgIdField(
+            size=cls._field_size_from_definition(
+                definition_message, AntRxMesgIdField.ID),
+            growable=False), 
+        AntRxMesgDataField(
+            size=cls._field_size_from_definition(
+                definition_message, AntRxMesgDataField.ID),
+            growable=False), 
+        AntRxChannelNumberField(
+            size=cls._field_size_from_definition(
+                definition_message, AntRxChannelNumberField.ID),
+            growable=False), 
+        AntRxDataField(
+            size=cls._field_size_from_definition(
+                definition_message, AntRxDataField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/ant_tx_message.py
+++ b/fit_tool/profile/messages/ant_tx_message.py
@@ -17,54 +17,105 @@ from typing import Dict as dict
 
 
 class AntTxMessage(DataMessage):
+    """AntTxMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``AntTxMessage()`` — create path: growable fields, no wire definition.
+    * ``AntTxMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 81
     NAME = 'ant_tx'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=AntTxMessage.NAME,
                          global_id=AntTxMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         TimestampField(
-            size=self.__get_field_size(definition_message, TimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         AntTxFractionalTimestampField(
-            size=self.__get_field_size(definition_message, AntTxFractionalTimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         AntTxMesgIdField(
-            size=self.__get_field_size(definition_message, AntTxMesgIdField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         AntTxMesgDataField(
-            size=self.__get_field_size(definition_message, AntTxMesgDataField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         AntTxChannelNumberField(
-            size=self.__get_field_size(definition_message, AntTxChannelNumberField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         AntTxDataField(
-            size=self.__get_field_size(definition_message, AntTxDataField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        TimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampField.ID),
+            growable=False), 
+        AntTxFractionalTimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, AntTxFractionalTimestampField.ID),
+            growable=False), 
+        AntTxMesgIdField(
+            size=cls._field_size_from_definition(
+                definition_message, AntTxMesgIdField.ID),
+            growable=False), 
+        AntTxMesgDataField(
+            size=cls._field_size_from_definition(
+                definition_message, AntTxMesgDataField.ID),
+            growable=False), 
+        AntTxChannelNumberField(
+            size=cls._field_size_from_definition(
+                definition_message, AntTxChannelNumberField.ID),
+            growable=False), 
+        AntTxDataField(
+            size=cls._field_size_from_definition(
+                definition_message, AntTxDataField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/aviation_attitude_message.py
+++ b/fit_tool/profile/messages/aviation_attitude_message.py
@@ -17,72 +17,147 @@ from typing import Dict as dict
 
 
 class AviationAttitudeMessage(DataMessage):
+    """AviationAttitudeMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``AviationAttitudeMessage()`` — create path: growable fields, no wire definition.
+    * ``AviationAttitudeMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 178
     NAME = 'aviation_attitude'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=AviationAttitudeMessage.NAME,
                          global_id=AviationAttitudeMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         TimestampField(
-            size=self.__get_field_size(definition_message, TimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         AviationAttitudeTimestampMsField(
-            size=self.__get_field_size(definition_message, AviationAttitudeTimestampMsField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         AviationAttitudeSystemTimeField(
-            size=self.__get_field_size(definition_message, AviationAttitudeSystemTimeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         AviationAttitudePitchField(
-            size=self.__get_field_size(definition_message, AviationAttitudePitchField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         AviationAttitudeRollField(
-            size=self.__get_field_size(definition_message, AviationAttitudeRollField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         AviationAttitudeAccelLateralField(
-            size=self.__get_field_size(definition_message, AviationAttitudeAccelLateralField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         AviationAttitudeAccelNormalField(
-            size=self.__get_field_size(definition_message, AviationAttitudeAccelNormalField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         AviationAttitudeTurnRateField(
-            size=self.__get_field_size(definition_message, AviationAttitudeTurnRateField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         AviationAttitudeStageField(
-            size=self.__get_field_size(definition_message, AviationAttitudeStageField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         AviationAttitudeAttitudeStageCompleteField(
-            size=self.__get_field_size(definition_message, AviationAttitudeAttitudeStageCompleteField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         AviationAttitudeTrackField(
-            size=self.__get_field_size(definition_message, AviationAttitudeTrackField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         AviationAttitudeValidityField(
-            size=self.__get_field_size(definition_message, AviationAttitudeValidityField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        TimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampField.ID),
+            growable=False), 
+        AviationAttitudeTimestampMsField(
+            size=cls._field_size_from_definition(
+                definition_message, AviationAttitudeTimestampMsField.ID),
+            growable=False), 
+        AviationAttitudeSystemTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, AviationAttitudeSystemTimeField.ID),
+            growable=False), 
+        AviationAttitudePitchField(
+            size=cls._field_size_from_definition(
+                definition_message, AviationAttitudePitchField.ID),
+            growable=False), 
+        AviationAttitudeRollField(
+            size=cls._field_size_from_definition(
+                definition_message, AviationAttitudeRollField.ID),
+            growable=False), 
+        AviationAttitudeAccelLateralField(
+            size=cls._field_size_from_definition(
+                definition_message, AviationAttitudeAccelLateralField.ID),
+            growable=False), 
+        AviationAttitudeAccelNormalField(
+            size=cls._field_size_from_definition(
+                definition_message, AviationAttitudeAccelNormalField.ID),
+            growable=False), 
+        AviationAttitudeTurnRateField(
+            size=cls._field_size_from_definition(
+                definition_message, AviationAttitudeTurnRateField.ID),
+            growable=False), 
+        AviationAttitudeStageField(
+            size=cls._field_size_from_definition(
+                definition_message, AviationAttitudeStageField.ID),
+            growable=False), 
+        AviationAttitudeAttitudeStageCompleteField(
+            size=cls._field_size_from_definition(
+                definition_message, AviationAttitudeAttitudeStageCompleteField.ID),
+            growable=False), 
+        AviationAttitudeTrackField(
+            size=cls._field_size_from_definition(
+                definition_message, AviationAttitudeTrackField.ID),
+            growable=False), 
+        AviationAttitudeValidityField(
+            size=cls._field_size_from_definition(
+                definition_message, AviationAttitudeValidityField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/barometer_data_message.py
+++ b/fit_tool/profile/messages/barometer_data_message.py
@@ -17,48 +17,91 @@ from typing import Dict as dict
 
 
 class BarometerDataMessage(DataMessage):
+    """BarometerDataMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``BarometerDataMessage()`` — create path: growable fields, no wire definition.
+    * ``BarometerDataMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 209
     NAME = 'barometer_data'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=BarometerDataMessage.NAME,
                          global_id=BarometerDataMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         TimestampField(
-            size=self.__get_field_size(definition_message, TimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         BarometerDataTimestampMsField(
-            size=self.__get_field_size(definition_message, BarometerDataTimestampMsField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         BarometerDataSampleTimeOffsetField(
-            size=self.__get_field_size(definition_message, BarometerDataSampleTimeOffsetField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         BarometerDataBaroPresField(
-            size=self.__get_field_size(definition_message, BarometerDataBaroPresField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        TimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampField.ID),
+            growable=False), 
+        BarometerDataTimestampMsField(
+            size=cls._field_size_from_definition(
+                definition_message, BarometerDataTimestampMsField.ID),
+            growable=False), 
+        BarometerDataSampleTimeOffsetField(
+            size=cls._field_size_from_definition(
+                definition_message, BarometerDataSampleTimeOffsetField.ID),
+            growable=False), 
+        BarometerDataBaroPresField(
+            size=cls._field_size_from_definition(
+                definition_message, BarometerDataBaroPresField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/beat_intervals_message.py
+++ b/fit_tool/profile/messages/beat_intervals_message.py
@@ -17,45 +17,84 @@ from typing import Dict as dict
 
 
 class BeatIntervalsMessage(DataMessage):
+    """BeatIntervalsMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``BeatIntervalsMessage()`` — create path: growable fields, no wire definition.
+    * ``BeatIntervalsMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 290
     NAME = 'beat_intervals'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=BeatIntervalsMessage.NAME,
                          global_id=BeatIntervalsMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         TimestampField(
-            size=self.__get_field_size(definition_message, TimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         BeatIntervalsTimestampMsField(
-            size=self.__get_field_size(definition_message, BeatIntervalsTimestampMsField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         BeatIntervalsTimeField(
-            size=self.__get_field_size(definition_message, BeatIntervalsTimeField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        TimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampField.ID),
+            growable=False), 
+        BeatIntervalsTimestampMsField(
+            size=cls._field_size_from_definition(
+                definition_message, BeatIntervalsTimestampMsField.ID),
+            growable=False), 
+        BeatIntervalsTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, BeatIntervalsTimeField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/bike_profile_message.py
+++ b/fit_tool/profile/messages/bike_profile_message.py
@@ -17,132 +17,287 @@ from typing import Dict as dict
 
 
 class BikeProfileMessage(DataMessage):
+    """BikeProfileMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``BikeProfileMessage()`` — create path: growable fields, no wire definition.
+    * ``BikeProfileMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 6
     NAME = 'bike_profile'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=BikeProfileMessage.NAME,
                          global_id=BikeProfileMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         MessageIndexField(
-            size=self.__get_field_size(definition_message, MessageIndexField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         BikeProfileNameField(
-            size=self.__get_field_size(definition_message, BikeProfileNameField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         BikeProfileSportField(
-            size=self.__get_field_size(definition_message, BikeProfileSportField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         BikeProfileSubSportField(
-            size=self.__get_field_size(definition_message, BikeProfileSubSportField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         BikeProfileOdometerField(
-            size=self.__get_field_size(definition_message, BikeProfileOdometerField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         BikeProfileBikeSpdAntIdField(
-            size=self.__get_field_size(definition_message, BikeProfileBikeSpdAntIdField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         BikeProfileBikeCadAntIdField(
-            size=self.__get_field_size(definition_message, BikeProfileBikeCadAntIdField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         BikeProfileBikeSpdcadAntIdField(
-            size=self.__get_field_size(definition_message, BikeProfileBikeSpdcadAntIdField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         BikeProfileBikePowerAntIdField(
-            size=self.__get_field_size(definition_message, BikeProfileBikePowerAntIdField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         BikeProfileCustomWheelsizeField(
-            size=self.__get_field_size(definition_message, BikeProfileCustomWheelsizeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         BikeProfileAutoWheelsizeField(
-            size=self.__get_field_size(definition_message, BikeProfileAutoWheelsizeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         BikeProfileBikeWeightField(
-            size=self.__get_field_size(definition_message, BikeProfileBikeWeightField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         BikeProfilePowerCalFactorField(
-            size=self.__get_field_size(definition_message, BikeProfilePowerCalFactorField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         BikeProfileAutoWheelCalField(
-            size=self.__get_field_size(definition_message, BikeProfileAutoWheelCalField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         BikeProfileAutoPowerZeroField(
-            size=self.__get_field_size(definition_message, BikeProfileAutoPowerZeroField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         BikeProfileIdField(
-            size=self.__get_field_size(definition_message, BikeProfileIdField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         BikeProfileSpdEnabledField(
-            size=self.__get_field_size(definition_message, BikeProfileSpdEnabledField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         BikeProfileCadEnabledField(
-            size=self.__get_field_size(definition_message, BikeProfileCadEnabledField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         BikeProfileSpdcadEnabledField(
-            size=self.__get_field_size(definition_message, BikeProfileSpdcadEnabledField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         BikeProfilePowerEnabledField(
-            size=self.__get_field_size(definition_message, BikeProfilePowerEnabledField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         BikeProfileCrankLengthField(
-            size=self.__get_field_size(definition_message, BikeProfileCrankLengthField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         BikeProfileEnabledField(
-            size=self.__get_field_size(definition_message, BikeProfileEnabledField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         BikeProfileBikeSpdAntIdTransTypeField(
-            size=self.__get_field_size(definition_message, BikeProfileBikeSpdAntIdTransTypeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         BikeProfileBikeCadAntIdTransTypeField(
-            size=self.__get_field_size(definition_message, BikeProfileBikeCadAntIdTransTypeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         BikeProfileBikeSpdcadAntIdTransTypeField(
-            size=self.__get_field_size(definition_message, BikeProfileBikeSpdcadAntIdTransTypeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         BikeProfileBikePowerAntIdTransTypeField(
-            size=self.__get_field_size(definition_message, BikeProfileBikePowerAntIdTransTypeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         BikeProfileOdometerRolloverField(
-            size=self.__get_field_size(definition_message, BikeProfileOdometerRolloverField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         BikeProfileFrontGearNumField(
-            size=self.__get_field_size(definition_message, BikeProfileFrontGearNumField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         BikeProfileFrontGearField(
-            size=self.__get_field_size(definition_message, BikeProfileFrontGearField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         BikeProfileRearGearNumField(
-            size=self.__get_field_size(definition_message, BikeProfileRearGearNumField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         BikeProfileRearGearField(
-            size=self.__get_field_size(definition_message, BikeProfileRearGearField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         BikeProfileShimanoDi2EnabledField(
-            size=self.__get_field_size(definition_message, BikeProfileShimanoDi2EnabledField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        MessageIndexField(
+            size=cls._field_size_from_definition(
+                definition_message, MessageIndexField.ID),
+            growable=False), 
+        BikeProfileNameField(
+            size=cls._field_size_from_definition(
+                definition_message, BikeProfileNameField.ID),
+            growable=False), 
+        BikeProfileSportField(
+            size=cls._field_size_from_definition(
+                definition_message, BikeProfileSportField.ID),
+            growable=False), 
+        BikeProfileSubSportField(
+            size=cls._field_size_from_definition(
+                definition_message, BikeProfileSubSportField.ID),
+            growable=False), 
+        BikeProfileOdometerField(
+            size=cls._field_size_from_definition(
+                definition_message, BikeProfileOdometerField.ID),
+            growable=False), 
+        BikeProfileBikeSpdAntIdField(
+            size=cls._field_size_from_definition(
+                definition_message, BikeProfileBikeSpdAntIdField.ID),
+            growable=False), 
+        BikeProfileBikeCadAntIdField(
+            size=cls._field_size_from_definition(
+                definition_message, BikeProfileBikeCadAntIdField.ID),
+            growable=False), 
+        BikeProfileBikeSpdcadAntIdField(
+            size=cls._field_size_from_definition(
+                definition_message, BikeProfileBikeSpdcadAntIdField.ID),
+            growable=False), 
+        BikeProfileBikePowerAntIdField(
+            size=cls._field_size_from_definition(
+                definition_message, BikeProfileBikePowerAntIdField.ID),
+            growable=False), 
+        BikeProfileCustomWheelsizeField(
+            size=cls._field_size_from_definition(
+                definition_message, BikeProfileCustomWheelsizeField.ID),
+            growable=False), 
+        BikeProfileAutoWheelsizeField(
+            size=cls._field_size_from_definition(
+                definition_message, BikeProfileAutoWheelsizeField.ID),
+            growable=False), 
+        BikeProfileBikeWeightField(
+            size=cls._field_size_from_definition(
+                definition_message, BikeProfileBikeWeightField.ID),
+            growable=False), 
+        BikeProfilePowerCalFactorField(
+            size=cls._field_size_from_definition(
+                definition_message, BikeProfilePowerCalFactorField.ID),
+            growable=False), 
+        BikeProfileAutoWheelCalField(
+            size=cls._field_size_from_definition(
+                definition_message, BikeProfileAutoWheelCalField.ID),
+            growable=False), 
+        BikeProfileAutoPowerZeroField(
+            size=cls._field_size_from_definition(
+                definition_message, BikeProfileAutoPowerZeroField.ID),
+            growable=False), 
+        BikeProfileIdField(
+            size=cls._field_size_from_definition(
+                definition_message, BikeProfileIdField.ID),
+            growable=False), 
+        BikeProfileSpdEnabledField(
+            size=cls._field_size_from_definition(
+                definition_message, BikeProfileSpdEnabledField.ID),
+            growable=False), 
+        BikeProfileCadEnabledField(
+            size=cls._field_size_from_definition(
+                definition_message, BikeProfileCadEnabledField.ID),
+            growable=False), 
+        BikeProfileSpdcadEnabledField(
+            size=cls._field_size_from_definition(
+                definition_message, BikeProfileSpdcadEnabledField.ID),
+            growable=False), 
+        BikeProfilePowerEnabledField(
+            size=cls._field_size_from_definition(
+                definition_message, BikeProfilePowerEnabledField.ID),
+            growable=False), 
+        BikeProfileCrankLengthField(
+            size=cls._field_size_from_definition(
+                definition_message, BikeProfileCrankLengthField.ID),
+            growable=False), 
+        BikeProfileEnabledField(
+            size=cls._field_size_from_definition(
+                definition_message, BikeProfileEnabledField.ID),
+            growable=False), 
+        BikeProfileBikeSpdAntIdTransTypeField(
+            size=cls._field_size_from_definition(
+                definition_message, BikeProfileBikeSpdAntIdTransTypeField.ID),
+            growable=False), 
+        BikeProfileBikeCadAntIdTransTypeField(
+            size=cls._field_size_from_definition(
+                definition_message, BikeProfileBikeCadAntIdTransTypeField.ID),
+            growable=False), 
+        BikeProfileBikeSpdcadAntIdTransTypeField(
+            size=cls._field_size_from_definition(
+                definition_message, BikeProfileBikeSpdcadAntIdTransTypeField.ID),
+            growable=False), 
+        BikeProfileBikePowerAntIdTransTypeField(
+            size=cls._field_size_from_definition(
+                definition_message, BikeProfileBikePowerAntIdTransTypeField.ID),
+            growable=False), 
+        BikeProfileOdometerRolloverField(
+            size=cls._field_size_from_definition(
+                definition_message, BikeProfileOdometerRolloverField.ID),
+            growable=False), 
+        BikeProfileFrontGearNumField(
+            size=cls._field_size_from_definition(
+                definition_message, BikeProfileFrontGearNumField.ID),
+            growable=False), 
+        BikeProfileFrontGearField(
+            size=cls._field_size_from_definition(
+                definition_message, BikeProfileFrontGearField.ID),
+            growable=False), 
+        BikeProfileRearGearNumField(
+            size=cls._field_size_from_definition(
+                definition_message, BikeProfileRearGearNumField.ID),
+            growable=False), 
+        BikeProfileRearGearField(
+            size=cls._field_size_from_definition(
+                definition_message, BikeProfileRearGearField.ID),
+            growable=False), 
+        BikeProfileShimanoDi2EnabledField(
+            size=cls._field_size_from_definition(
+                definition_message, BikeProfileShimanoDi2EnabledField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/blood_pressure_message.py
+++ b/fit_tool/profile/messages/blood_pressure_message.py
@@ -17,69 +17,140 @@ from typing import Dict as dict
 
 
 class BloodPressureMessage(DataMessage):
+    """BloodPressureMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``BloodPressureMessage()`` — create path: growable fields, no wire definition.
+    * ``BloodPressureMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 51
     NAME = 'blood_pressure'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=BloodPressureMessage.NAME,
                          global_id=BloodPressureMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         TimestampField(
-            size=self.__get_field_size(definition_message, TimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         BloodPressureSystolicPressureField(
-            size=self.__get_field_size(definition_message, BloodPressureSystolicPressureField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         BloodPressureDiastolicPressureField(
-            size=self.__get_field_size(definition_message, BloodPressureDiastolicPressureField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         BloodPressureMeanArterialPressureField(
-            size=self.__get_field_size(definition_message, BloodPressureMeanArterialPressureField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         BloodPressureMap3SampleMeanField(
-            size=self.__get_field_size(definition_message, BloodPressureMap3SampleMeanField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         BloodPressureMapMorningValuesField(
-            size=self.__get_field_size(definition_message, BloodPressureMapMorningValuesField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         BloodPressureMapEveningValuesField(
-            size=self.__get_field_size(definition_message, BloodPressureMapEveningValuesField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         BloodPressureHeartRateField(
-            size=self.__get_field_size(definition_message, BloodPressureHeartRateField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         BloodPressureHeartRateTypeField(
-            size=self.__get_field_size(definition_message, BloodPressureHeartRateTypeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         BloodPressureStatusField(
-            size=self.__get_field_size(definition_message, BloodPressureStatusField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         BloodPressureUserProfileIndexField(
-            size=self.__get_field_size(definition_message, BloodPressureUserProfileIndexField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        TimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampField.ID),
+            growable=False), 
+        BloodPressureSystolicPressureField(
+            size=cls._field_size_from_definition(
+                definition_message, BloodPressureSystolicPressureField.ID),
+            growable=False), 
+        BloodPressureDiastolicPressureField(
+            size=cls._field_size_from_definition(
+                definition_message, BloodPressureDiastolicPressureField.ID),
+            growable=False), 
+        BloodPressureMeanArterialPressureField(
+            size=cls._field_size_from_definition(
+                definition_message, BloodPressureMeanArterialPressureField.ID),
+            growable=False), 
+        BloodPressureMap3SampleMeanField(
+            size=cls._field_size_from_definition(
+                definition_message, BloodPressureMap3SampleMeanField.ID),
+            growable=False), 
+        BloodPressureMapMorningValuesField(
+            size=cls._field_size_from_definition(
+                definition_message, BloodPressureMapMorningValuesField.ID),
+            growable=False), 
+        BloodPressureMapEveningValuesField(
+            size=cls._field_size_from_definition(
+                definition_message, BloodPressureMapEveningValuesField.ID),
+            growable=False), 
+        BloodPressureHeartRateField(
+            size=cls._field_size_from_definition(
+                definition_message, BloodPressureHeartRateField.ID),
+            growable=False), 
+        BloodPressureHeartRateTypeField(
+            size=cls._field_size_from_definition(
+                definition_message, BloodPressureHeartRateTypeField.ID),
+            growable=False), 
+        BloodPressureStatusField(
+            size=cls._field_size_from_definition(
+                definition_message, BloodPressureStatusField.ID),
+            growable=False), 
+        BloodPressureUserProfileIndexField(
+            size=cls._field_size_from_definition(
+                definition_message, BloodPressureUserProfileIndexField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/cadence_zone_message.py
+++ b/fit_tool/profile/messages/cadence_zone_message.py
@@ -17,45 +17,84 @@ from typing import Dict as dict
 
 
 class CadenceZoneMessage(DataMessage):
+    """CadenceZoneMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``CadenceZoneMessage()`` — create path: growable fields, no wire definition.
+    * ``CadenceZoneMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 131
     NAME = 'cadence_zone'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=CadenceZoneMessage.NAME,
                          global_id=CadenceZoneMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         MessageIndexField(
-            size=self.__get_field_size(definition_message, MessageIndexField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         CadenceZoneHighValueField(
-            size=self.__get_field_size(definition_message, CadenceZoneHighValueField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         CadenceZoneNameField(
-            size=self.__get_field_size(definition_message, CadenceZoneNameField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        MessageIndexField(
+            size=cls._field_size_from_definition(
+                definition_message, MessageIndexField.ID),
+            growable=False), 
+        CadenceZoneHighValueField(
+            size=cls._field_size_from_definition(
+                definition_message, CadenceZoneHighValueField.ID),
+            growable=False), 
+        CadenceZoneNameField(
+            size=cls._field_size_from_definition(
+                definition_message, CadenceZoneNameField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/camera_event_message.py
+++ b/fit_tool/profile/messages/camera_event_message.py
@@ -17,51 +17,98 @@ from typing import Dict as dict
 
 
 class CameraEventMessage(DataMessage):
+    """CameraEventMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``CameraEventMessage()`` — create path: growable fields, no wire definition.
+    * ``CameraEventMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 161
     NAME = 'camera_event'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=CameraEventMessage.NAME,
                          global_id=CameraEventMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         TimestampField(
-            size=self.__get_field_size(definition_message, TimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         CameraEventTimestampMsField(
-            size=self.__get_field_size(definition_message, CameraEventTimestampMsField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         CameraEventCameraEventTypeField(
-            size=self.__get_field_size(definition_message, CameraEventCameraEventTypeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         CameraEventCameraFileUuidField(
-            size=self.__get_field_size(definition_message, CameraEventCameraFileUuidField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         CameraEventCameraOrientationField(
-            size=self.__get_field_size(definition_message, CameraEventCameraOrientationField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        TimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampField.ID),
+            growable=False), 
+        CameraEventTimestampMsField(
+            size=cls._field_size_from_definition(
+                definition_message, CameraEventTimestampMsField.ID),
+            growable=False), 
+        CameraEventCameraEventTypeField(
+            size=cls._field_size_from_definition(
+                definition_message, CameraEventCameraEventTypeField.ID),
+            growable=False), 
+        CameraEventCameraFileUuidField(
+            size=cls._field_size_from_definition(
+                definition_message, CameraEventCameraFileUuidField.ID),
+            growable=False), 
+        CameraEventCameraOrientationField(
+            size=cls._field_size_from_definition(
+                definition_message, CameraEventCameraOrientationField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/capabilities_message.py
+++ b/fit_tool/profile/messages/capabilities_message.py
@@ -17,48 +17,91 @@ from typing import Dict as dict
 
 
 class CapabilitiesMessage(DataMessage):
+    """CapabilitiesMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``CapabilitiesMessage()`` — create path: growable fields, no wire definition.
+    * ``CapabilitiesMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 1
     NAME = 'capabilities'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=CapabilitiesMessage.NAME,
                          global_id=CapabilitiesMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         CapabilitiesLanguagesField(
-            size=self.__get_field_size(definition_message, CapabilitiesLanguagesField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         CapabilitiesSportsField(
-            size=self.__get_field_size(definition_message, CapabilitiesSportsField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         CapabilitiesWorkoutsSupportedField(
-            size=self.__get_field_size(definition_message, CapabilitiesWorkoutsSupportedField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         CapabilitiesConnectivitySupportedField(
-            size=self.__get_field_size(definition_message, CapabilitiesConnectivitySupportedField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        CapabilitiesLanguagesField(
+            size=cls._field_size_from_definition(
+                definition_message, CapabilitiesLanguagesField.ID),
+            growable=False), 
+        CapabilitiesSportsField(
+            size=cls._field_size_from_definition(
+                definition_message, CapabilitiesSportsField.ID),
+            growable=False), 
+        CapabilitiesWorkoutsSupportedField(
+            size=cls._field_size_from_definition(
+                definition_message, CapabilitiesWorkoutsSupportedField.ID),
+            growable=False), 
+        CapabilitiesConnectivitySupportedField(
+            size=cls._field_size_from_definition(
+                definition_message, CapabilitiesConnectivitySupportedField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/chrono_shot_data_message.py
+++ b/fit_tool/profile/messages/chrono_shot_data_message.py
@@ -17,45 +17,84 @@ from typing import Dict as dict
 
 
 class ChronoShotDataMessage(DataMessage):
+    """ChronoShotDataMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``ChronoShotDataMessage()`` — create path: growable fields, no wire definition.
+    * ``ChronoShotDataMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 388
     NAME = 'chrono_shot_data'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=ChronoShotDataMessage.NAME,
                          global_id=ChronoShotDataMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         TimestampField(
-            size=self.__get_field_size(definition_message, TimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ChronoShotDataShotSpeedField(
-            size=self.__get_field_size(definition_message, ChronoShotDataShotSpeedField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ChronoShotDataShotNumField(
-            size=self.__get_field_size(definition_message, ChronoShotDataShotNumField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        TimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampField.ID),
+            growable=False), 
+        ChronoShotDataShotSpeedField(
+            size=cls._field_size_from_definition(
+                definition_message, ChronoShotDataShotSpeedField.ID),
+            growable=False), 
+        ChronoShotDataShotNumField(
+            size=cls._field_size_from_definition(
+                definition_message, ChronoShotDataShotNumField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/chrono_shot_session_message.py
+++ b/fit_tool/profile/messages/chrono_shot_session_message.py
@@ -17,60 +17,119 @@ from typing import Dict as dict
 
 
 class ChronoShotSessionMessage(DataMessage):
+    """ChronoShotSessionMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``ChronoShotSessionMessage()`` — create path: growable fields, no wire definition.
+    * ``ChronoShotSessionMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 387
     NAME = 'chrono_shot_session'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=ChronoShotSessionMessage.NAME,
                          global_id=ChronoShotSessionMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         TimestampField(
-            size=self.__get_field_size(definition_message, TimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ChronoShotSessionMinSpeedField(
-            size=self.__get_field_size(definition_message, ChronoShotSessionMinSpeedField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ChronoShotSessionMaxSpeedField(
-            size=self.__get_field_size(definition_message, ChronoShotSessionMaxSpeedField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ChronoShotSessionAvgSpeedField(
-            size=self.__get_field_size(definition_message, ChronoShotSessionAvgSpeedField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ChronoShotSessionShotCountField(
-            size=self.__get_field_size(definition_message, ChronoShotSessionShotCountField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ChronoShotSessionProjectileTypeField(
-            size=self.__get_field_size(definition_message, ChronoShotSessionProjectileTypeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ChronoShotSessionGrainWeightField(
-            size=self.__get_field_size(definition_message, ChronoShotSessionGrainWeightField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ChronoShotSessionStandardDeviationField(
-            size=self.__get_field_size(definition_message, ChronoShotSessionStandardDeviationField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        TimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampField.ID),
+            growable=False), 
+        ChronoShotSessionMinSpeedField(
+            size=cls._field_size_from_definition(
+                definition_message, ChronoShotSessionMinSpeedField.ID),
+            growable=False), 
+        ChronoShotSessionMaxSpeedField(
+            size=cls._field_size_from_definition(
+                definition_message, ChronoShotSessionMaxSpeedField.ID),
+            growable=False), 
+        ChronoShotSessionAvgSpeedField(
+            size=cls._field_size_from_definition(
+                definition_message, ChronoShotSessionAvgSpeedField.ID),
+            growable=False), 
+        ChronoShotSessionShotCountField(
+            size=cls._field_size_from_definition(
+                definition_message, ChronoShotSessionShotCountField.ID),
+            growable=False), 
+        ChronoShotSessionProjectileTypeField(
+            size=cls._field_size_from_definition(
+                definition_message, ChronoShotSessionProjectileTypeField.ID),
+            growable=False), 
+        ChronoShotSessionGrainWeightField(
+            size=cls._field_size_from_definition(
+                definition_message, ChronoShotSessionGrainWeightField.ID),
+            growable=False), 
+        ChronoShotSessionStandardDeviationField(
+            size=cls._field_size_from_definition(
+                definition_message, ChronoShotSessionStandardDeviationField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/climb_pro_message.py
+++ b/fit_tool/profile/messages/climb_pro_message.py
@@ -17,57 +17,112 @@ from typing import Dict as dict
 
 
 class ClimbProMessage(DataMessage):
+    """ClimbProMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``ClimbProMessage()`` — create path: growable fields, no wire definition.
+    * ``ClimbProMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 317
     NAME = 'climb_pro'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=ClimbProMessage.NAME,
                          global_id=ClimbProMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         TimestampField(
-            size=self.__get_field_size(definition_message, TimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ClimbProPositionLatField(
-            size=self.__get_field_size(definition_message, ClimbProPositionLatField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ClimbProPositionLongField(
-            size=self.__get_field_size(definition_message, ClimbProPositionLongField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ClimbProClimbProEventField(
-            size=self.__get_field_size(definition_message, ClimbProClimbProEventField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ClimbProClimbNumberField(
-            size=self.__get_field_size(definition_message, ClimbProClimbNumberField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ClimbProClimbCategoryField(
-            size=self.__get_field_size(definition_message, ClimbProClimbCategoryField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ClimbProCurrentDistField(
-            size=self.__get_field_size(definition_message, ClimbProCurrentDistField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        TimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampField.ID),
+            growable=False), 
+        ClimbProPositionLatField(
+            size=cls._field_size_from_definition(
+                definition_message, ClimbProPositionLatField.ID),
+            growable=False), 
+        ClimbProPositionLongField(
+            size=cls._field_size_from_definition(
+                definition_message, ClimbProPositionLongField.ID),
+            growable=False), 
+        ClimbProClimbProEventField(
+            size=cls._field_size_from_definition(
+                definition_message, ClimbProClimbProEventField.ID),
+            growable=False), 
+        ClimbProClimbNumberField(
+            size=cls._field_size_from_definition(
+                definition_message, ClimbProClimbNumberField.ID),
+            growable=False), 
+        ClimbProClimbCategoryField(
+            size=cls._field_size_from_definition(
+                definition_message, ClimbProClimbCategoryField.ID),
+            growable=False), 
+        ClimbProCurrentDistField(
+            size=cls._field_size_from_definition(
+                definition_message, ClimbProCurrentDistField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/connectivity_message.py
+++ b/fit_tool/profile/messages/connectivity_message.py
@@ -17,75 +17,154 @@ from typing import Dict as dict
 
 
 class ConnectivityMessage(DataMessage):
+    """ConnectivityMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``ConnectivityMessage()`` — create path: growable fields, no wire definition.
+    * ``ConnectivityMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 127
     NAME = 'connectivity'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=ConnectivityMessage.NAME,
                          global_id=ConnectivityMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         ConnectivityBluetoothEnabledField(
-            size=self.__get_field_size(definition_message, ConnectivityBluetoothEnabledField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ConnectivityBluetoothLeEnabledField(
-            size=self.__get_field_size(definition_message, ConnectivityBluetoothLeEnabledField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ConnectivityAntEnabledField(
-            size=self.__get_field_size(definition_message, ConnectivityAntEnabledField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ConnectivityNameField(
-            size=self.__get_field_size(definition_message, ConnectivityNameField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ConnectivityLiveTrackingEnabledField(
-            size=self.__get_field_size(definition_message, ConnectivityLiveTrackingEnabledField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ConnectivityWeatherConditionsEnabledField(
-            size=self.__get_field_size(definition_message, ConnectivityWeatherConditionsEnabledField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ConnectivityWeatherAlertsEnabledField(
-            size=self.__get_field_size(definition_message, ConnectivityWeatherAlertsEnabledField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ConnectivityAutoActivityUploadEnabledField(
-            size=self.__get_field_size(definition_message, ConnectivityAutoActivityUploadEnabledField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ConnectivityCourseDownloadEnabledField(
-            size=self.__get_field_size(definition_message, ConnectivityCourseDownloadEnabledField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ConnectivityWorkoutDownloadEnabledField(
-            size=self.__get_field_size(definition_message, ConnectivityWorkoutDownloadEnabledField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ConnectivityGpsEphemerisDownloadEnabledField(
-            size=self.__get_field_size(definition_message, ConnectivityGpsEphemerisDownloadEnabledField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ConnectivityIncidentDetectionEnabledField(
-            size=self.__get_field_size(definition_message, ConnectivityIncidentDetectionEnabledField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ConnectivityGrouptrackEnabledField(
-            size=self.__get_field_size(definition_message, ConnectivityGrouptrackEnabledField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        ConnectivityBluetoothEnabledField(
+            size=cls._field_size_from_definition(
+                definition_message, ConnectivityBluetoothEnabledField.ID),
+            growable=False), 
+        ConnectivityBluetoothLeEnabledField(
+            size=cls._field_size_from_definition(
+                definition_message, ConnectivityBluetoothLeEnabledField.ID),
+            growable=False), 
+        ConnectivityAntEnabledField(
+            size=cls._field_size_from_definition(
+                definition_message, ConnectivityAntEnabledField.ID),
+            growable=False), 
+        ConnectivityNameField(
+            size=cls._field_size_from_definition(
+                definition_message, ConnectivityNameField.ID),
+            growable=False), 
+        ConnectivityLiveTrackingEnabledField(
+            size=cls._field_size_from_definition(
+                definition_message, ConnectivityLiveTrackingEnabledField.ID),
+            growable=False), 
+        ConnectivityWeatherConditionsEnabledField(
+            size=cls._field_size_from_definition(
+                definition_message, ConnectivityWeatherConditionsEnabledField.ID),
+            growable=False), 
+        ConnectivityWeatherAlertsEnabledField(
+            size=cls._field_size_from_definition(
+                definition_message, ConnectivityWeatherAlertsEnabledField.ID),
+            growable=False), 
+        ConnectivityAutoActivityUploadEnabledField(
+            size=cls._field_size_from_definition(
+                definition_message, ConnectivityAutoActivityUploadEnabledField.ID),
+            growable=False), 
+        ConnectivityCourseDownloadEnabledField(
+            size=cls._field_size_from_definition(
+                definition_message, ConnectivityCourseDownloadEnabledField.ID),
+            growable=False), 
+        ConnectivityWorkoutDownloadEnabledField(
+            size=cls._field_size_from_definition(
+                definition_message, ConnectivityWorkoutDownloadEnabledField.ID),
+            growable=False), 
+        ConnectivityGpsEphemerisDownloadEnabledField(
+            size=cls._field_size_from_definition(
+                definition_message, ConnectivityGpsEphemerisDownloadEnabledField.ID),
+            growable=False), 
+        ConnectivityIncidentDetectionEnabledField(
+            size=cls._field_size_from_definition(
+                definition_message, ConnectivityIncidentDetectionEnabledField.ID),
+            growable=False), 
+        ConnectivityGrouptrackEnabledField(
+            size=cls._field_size_from_definition(
+                definition_message, ConnectivityGrouptrackEnabledField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/course_message.py
+++ b/fit_tool/profile/messages/course_message.py
@@ -17,48 +17,91 @@ from typing import Dict as dict
 
 
 class CourseMessage(DataMessage):
+    """CourseMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``CourseMessage()`` — create path: growable fields, no wire definition.
+    * ``CourseMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 31
     NAME = 'course'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=CourseMessage.NAME,
                          global_id=CourseMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         CourseSportField(
-            size=self.__get_field_size(definition_message, CourseSportField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         CourseNameField(
-            size=self.__get_field_size(definition_message, CourseNameField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         CourseCapabilitiesField(
-            size=self.__get_field_size(definition_message, CourseCapabilitiesField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         CourseSubSportField(
-            size=self.__get_field_size(definition_message, CourseSubSportField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        CourseSportField(
+            size=cls._field_size_from_definition(
+                definition_message, CourseSportField.ID),
+            growable=False), 
+        CourseNameField(
+            size=cls._field_size_from_definition(
+                definition_message, CourseNameField.ID),
+            growable=False), 
+        CourseCapabilitiesField(
+            size=cls._field_size_from_definition(
+                definition_message, CourseCapabilitiesField.ID),
+            growable=False), 
+        CourseSubSportField(
+            size=cls._field_size_from_definition(
+                definition_message, CourseSubSportField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/course_point_message.py
+++ b/fit_tool/profile/messages/course_point_message.py
@@ -17,60 +17,119 @@ from typing import Dict as dict
 
 
 class CoursePointMessage(DataMessage):
+    """CoursePointMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``CoursePointMessage()`` — create path: growable fields, no wire definition.
+    * ``CoursePointMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 32
     NAME = 'course_point'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=CoursePointMessage.NAME,
                          global_id=CoursePointMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         MessageIndexField(
-            size=self.__get_field_size(definition_message, MessageIndexField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         CoursePointTimestampField(
-            size=self.__get_field_size(definition_message, CoursePointTimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         CoursePointPositionLatField(
-            size=self.__get_field_size(definition_message, CoursePointPositionLatField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         CoursePointPositionLongField(
-            size=self.__get_field_size(definition_message, CoursePointPositionLongField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         CoursePointDistanceField(
-            size=self.__get_field_size(definition_message, CoursePointDistanceField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         CoursePointTypeField(
-            size=self.__get_field_size(definition_message, CoursePointTypeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         CoursePointNameField(
-            size=self.__get_field_size(definition_message, CoursePointNameField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         CoursePointFavoriteField(
-            size=self.__get_field_size(definition_message, CoursePointFavoriteField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        MessageIndexField(
+            size=cls._field_size_from_definition(
+                definition_message, MessageIndexField.ID),
+            growable=False), 
+        CoursePointTimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, CoursePointTimestampField.ID),
+            growable=False), 
+        CoursePointPositionLatField(
+            size=cls._field_size_from_definition(
+                definition_message, CoursePointPositionLatField.ID),
+            growable=False), 
+        CoursePointPositionLongField(
+            size=cls._field_size_from_definition(
+                definition_message, CoursePointPositionLongField.ID),
+            growable=False), 
+        CoursePointDistanceField(
+            size=cls._field_size_from_definition(
+                definition_message, CoursePointDistanceField.ID),
+            growable=False), 
+        CoursePointTypeField(
+            size=cls._field_size_from_definition(
+                definition_message, CoursePointTypeField.ID),
+            growable=False), 
+        CoursePointNameField(
+            size=cls._field_size_from_definition(
+                definition_message, CoursePointNameField.ID),
+            growable=False), 
+        CoursePointFavoriteField(
+            size=cls._field_size_from_definition(
+                definition_message, CoursePointFavoriteField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/developer_data_id_message.py
+++ b/fit_tool/profile/messages/developer_data_id_message.py
@@ -17,51 +17,98 @@ from typing import Dict as dict
 
 
 class DeveloperDataIdMessage(DataMessage):
+    """DeveloperDataIdMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``DeveloperDataIdMessage()`` — create path: growable fields, no wire definition.
+    * ``DeveloperDataIdMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 207
     NAME = 'developer_data_id'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=DeveloperDataIdMessage.NAME,
                          global_id=DeveloperDataIdMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         DeveloperDataIdDeveloperIdField(
-            size=self.__get_field_size(definition_message, DeveloperDataIdDeveloperIdField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DeveloperDataIdApplicationIdField(
-            size=self.__get_field_size(definition_message, DeveloperDataIdApplicationIdField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DeveloperDataIdManufacturerIdField(
-            size=self.__get_field_size(definition_message, DeveloperDataIdManufacturerIdField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DeveloperDataIdDeveloperDataIndexField(
-            size=self.__get_field_size(definition_message, DeveloperDataIdDeveloperDataIndexField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DeveloperDataIdApplicationVersionField(
-            size=self.__get_field_size(definition_message, DeveloperDataIdApplicationVersionField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        DeveloperDataIdDeveloperIdField(
+            size=cls._field_size_from_definition(
+                definition_message, DeveloperDataIdDeveloperIdField.ID),
+            growable=False), 
+        DeveloperDataIdApplicationIdField(
+            size=cls._field_size_from_definition(
+                definition_message, DeveloperDataIdApplicationIdField.ID),
+            growable=False), 
+        DeveloperDataIdManufacturerIdField(
+            size=cls._field_size_from_definition(
+                definition_message, DeveloperDataIdManufacturerIdField.ID),
+            growable=False), 
+        DeveloperDataIdDeveloperDataIndexField(
+            size=cls._field_size_from_definition(
+                definition_message, DeveloperDataIdDeveloperDataIndexField.ID),
+            growable=False), 
+        DeveloperDataIdApplicationVersionField(
+            size=cls._field_size_from_definition(
+                definition_message, DeveloperDataIdApplicationVersionField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/device_aux_battery_info_message.py
+++ b/fit_tool/profile/messages/device_aux_battery_info_message.py
@@ -17,51 +17,98 @@ from typing import Dict as dict
 
 
 class DeviceAuxBatteryInfoMessage(DataMessage):
+    """DeviceAuxBatteryInfoMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``DeviceAuxBatteryInfoMessage()`` — create path: growable fields, no wire definition.
+    * ``DeviceAuxBatteryInfoMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 375
     NAME = 'device_aux_battery_info'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=DeviceAuxBatteryInfoMessage.NAME,
                          global_id=DeviceAuxBatteryInfoMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         TimestampField(
-            size=self.__get_field_size(definition_message, TimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DeviceAuxBatteryInfoDeviceIndexField(
-            size=self.__get_field_size(definition_message, DeviceAuxBatteryInfoDeviceIndexField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DeviceAuxBatteryInfoBatteryVoltageField(
-            size=self.__get_field_size(definition_message, DeviceAuxBatteryInfoBatteryVoltageField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DeviceAuxBatteryInfoBatteryStatusField(
-            size=self.__get_field_size(definition_message, DeviceAuxBatteryInfoBatteryStatusField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DeviceAuxBatteryInfoBatteryIdentifierField(
-            size=self.__get_field_size(definition_message, DeviceAuxBatteryInfoBatteryIdentifierField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        TimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampField.ID),
+            growable=False), 
+        DeviceAuxBatteryInfoDeviceIndexField(
+            size=cls._field_size_from_definition(
+                definition_message, DeviceAuxBatteryInfoDeviceIndexField.ID),
+            growable=False), 
+        DeviceAuxBatteryInfoBatteryVoltageField(
+            size=cls._field_size_from_definition(
+                definition_message, DeviceAuxBatteryInfoBatteryVoltageField.ID),
+            growable=False), 
+        DeviceAuxBatteryInfoBatteryStatusField(
+            size=cls._field_size_from_definition(
+                definition_message, DeviceAuxBatteryInfoBatteryStatusField.ID),
+            growable=False), 
+        DeviceAuxBatteryInfoBatteryIdentifierField(
+            size=cls._field_size_from_definition(
+                definition_message, DeviceAuxBatteryInfoBatteryIdentifierField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/device_info_message.py
+++ b/fit_tool/profile/messages/device_info_message.py
@@ -17,93 +17,196 @@ from typing import Dict as dict
 
 
 class DeviceInfoMessage(DataMessage):
+    """DeviceInfoMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``DeviceInfoMessage()`` — create path: growable fields, no wire definition.
+    * ``DeviceInfoMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 23
     NAME = 'device_info'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=DeviceInfoMessage.NAME,
                          global_id=DeviceInfoMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         TimestampField(
-            size=self.__get_field_size(definition_message, TimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DeviceInfoDeviceIndexField(
-            size=self.__get_field_size(definition_message, DeviceInfoDeviceIndexField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DeviceInfoDeviceTypeField(
-            size=self.__get_field_size(definition_message, DeviceInfoDeviceTypeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DeviceInfoManufacturerField(
-            size=self.__get_field_size(definition_message, DeviceInfoManufacturerField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DeviceInfoSerialNumberField(
-            size=self.__get_field_size(definition_message, DeviceInfoSerialNumberField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DeviceInfoProductField(
-            size=self.__get_field_size(definition_message, DeviceInfoProductField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DeviceInfoSoftwareVersionField(
-            size=self.__get_field_size(definition_message, DeviceInfoSoftwareVersionField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DeviceInfoHardwareVersionField(
-            size=self.__get_field_size(definition_message, DeviceInfoHardwareVersionField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DeviceInfoCumOperatingTimeField(
-            size=self.__get_field_size(definition_message, DeviceInfoCumOperatingTimeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DeviceInfoBatteryVoltageField(
-            size=self.__get_field_size(definition_message, DeviceInfoBatteryVoltageField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DeviceInfoBatteryStatusField(
-            size=self.__get_field_size(definition_message, DeviceInfoBatteryStatusField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DeviceInfoSensorPositionField(
-            size=self.__get_field_size(definition_message, DeviceInfoSensorPositionField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DeviceInfoDescriptorField(
-            size=self.__get_field_size(definition_message, DeviceInfoDescriptorField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DeviceInfoAntTransmissionTypeField(
-            size=self.__get_field_size(definition_message, DeviceInfoAntTransmissionTypeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DeviceInfoAntDeviceNumberField(
-            size=self.__get_field_size(definition_message, DeviceInfoAntDeviceNumberField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DeviceInfoAntNetworkField(
-            size=self.__get_field_size(definition_message, DeviceInfoAntNetworkField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DeviceInfoSourceTypeField(
-            size=self.__get_field_size(definition_message, DeviceInfoSourceTypeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DeviceInfoProductNameField(
-            size=self.__get_field_size(definition_message, DeviceInfoProductNameField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DeviceInfoBatteryLevelField(
-            size=self.__get_field_size(definition_message, DeviceInfoBatteryLevelField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        TimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampField.ID),
+            growable=False), 
+        DeviceInfoDeviceIndexField(
+            size=cls._field_size_from_definition(
+                definition_message, DeviceInfoDeviceIndexField.ID),
+            growable=False), 
+        DeviceInfoDeviceTypeField(
+            size=cls._field_size_from_definition(
+                definition_message, DeviceInfoDeviceTypeField.ID),
+            growable=False), 
+        DeviceInfoManufacturerField(
+            size=cls._field_size_from_definition(
+                definition_message, DeviceInfoManufacturerField.ID),
+            growable=False), 
+        DeviceInfoSerialNumberField(
+            size=cls._field_size_from_definition(
+                definition_message, DeviceInfoSerialNumberField.ID),
+            growable=False), 
+        DeviceInfoProductField(
+            size=cls._field_size_from_definition(
+                definition_message, DeviceInfoProductField.ID),
+            growable=False), 
+        DeviceInfoSoftwareVersionField(
+            size=cls._field_size_from_definition(
+                definition_message, DeviceInfoSoftwareVersionField.ID),
+            growable=False), 
+        DeviceInfoHardwareVersionField(
+            size=cls._field_size_from_definition(
+                definition_message, DeviceInfoHardwareVersionField.ID),
+            growable=False), 
+        DeviceInfoCumOperatingTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, DeviceInfoCumOperatingTimeField.ID),
+            growable=False), 
+        DeviceInfoBatteryVoltageField(
+            size=cls._field_size_from_definition(
+                definition_message, DeviceInfoBatteryVoltageField.ID),
+            growable=False), 
+        DeviceInfoBatteryStatusField(
+            size=cls._field_size_from_definition(
+                definition_message, DeviceInfoBatteryStatusField.ID),
+            growable=False), 
+        DeviceInfoSensorPositionField(
+            size=cls._field_size_from_definition(
+                definition_message, DeviceInfoSensorPositionField.ID),
+            growable=False), 
+        DeviceInfoDescriptorField(
+            size=cls._field_size_from_definition(
+                definition_message, DeviceInfoDescriptorField.ID),
+            growable=False), 
+        DeviceInfoAntTransmissionTypeField(
+            size=cls._field_size_from_definition(
+                definition_message, DeviceInfoAntTransmissionTypeField.ID),
+            growable=False), 
+        DeviceInfoAntDeviceNumberField(
+            size=cls._field_size_from_definition(
+                definition_message, DeviceInfoAntDeviceNumberField.ID),
+            growable=False), 
+        DeviceInfoAntNetworkField(
+            size=cls._field_size_from_definition(
+                definition_message, DeviceInfoAntNetworkField.ID),
+            growable=False), 
+        DeviceInfoSourceTypeField(
+            size=cls._field_size_from_definition(
+                definition_message, DeviceInfoSourceTypeField.ID),
+            growable=False), 
+        DeviceInfoProductNameField(
+            size=cls._field_size_from_definition(
+                definition_message, DeviceInfoProductNameField.ID),
+            growable=False), 
+        DeviceInfoBatteryLevelField(
+            size=cls._field_size_from_definition(
+                definition_message, DeviceInfoBatteryLevelField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/device_settings_message.py
+++ b/fit_tool/profile/messages/device_settings_message.py
@@ -17,108 +17,231 @@ from typing import Dict as dict
 
 
 class DeviceSettingsMessage(DataMessage):
+    """DeviceSettingsMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``DeviceSettingsMessage()`` — create path: growable fields, no wire definition.
+    * ``DeviceSettingsMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 2
     NAME = 'device_settings'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=DeviceSettingsMessage.NAME,
                          global_id=DeviceSettingsMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         DeviceSettingsActiveTimeZoneField(
-            size=self.__get_field_size(definition_message, DeviceSettingsActiveTimeZoneField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DeviceSettingsUtcOffsetField(
-            size=self.__get_field_size(definition_message, DeviceSettingsUtcOffsetField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DeviceSettingsTimeOffsetField(
-            size=self.__get_field_size(definition_message, DeviceSettingsTimeOffsetField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DeviceSettingsTimeModeField(
-            size=self.__get_field_size(definition_message, DeviceSettingsTimeModeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DeviceSettingsTimeZoneOffsetField(
-            size=self.__get_field_size(definition_message, DeviceSettingsTimeZoneOffsetField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DeviceSettingsBacklightModeField(
-            size=self.__get_field_size(definition_message, DeviceSettingsBacklightModeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DeviceSettingsActivityTrackerEnabledField(
-            size=self.__get_field_size(definition_message, DeviceSettingsActivityTrackerEnabledField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DeviceSettingsClockTimeField(
-            size=self.__get_field_size(definition_message, DeviceSettingsClockTimeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DeviceSettingsPagesEnabledField(
-            size=self.__get_field_size(definition_message, DeviceSettingsPagesEnabledField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DeviceSettingsMoveAlertEnabledField(
-            size=self.__get_field_size(definition_message, DeviceSettingsMoveAlertEnabledField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DeviceSettingsDateModeField(
-            size=self.__get_field_size(definition_message, DeviceSettingsDateModeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DeviceSettingsDisplayOrientationField(
-            size=self.__get_field_size(definition_message, DeviceSettingsDisplayOrientationField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DeviceSettingsMountingSideField(
-            size=self.__get_field_size(definition_message, DeviceSettingsMountingSideField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DeviceSettingsDefaultPageField(
-            size=self.__get_field_size(definition_message, DeviceSettingsDefaultPageField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DeviceSettingsAutosyncMinStepsField(
-            size=self.__get_field_size(definition_message, DeviceSettingsAutosyncMinStepsField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DeviceSettingsAutosyncMinTimeField(
-            size=self.__get_field_size(definition_message, DeviceSettingsAutosyncMinTimeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DeviceSettingsLactateThresholdAutodetectEnabledField(
-            size=self.__get_field_size(definition_message, DeviceSettingsLactateThresholdAutodetectEnabledField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DeviceSettingsBleAutoUploadEnabledField(
-            size=self.__get_field_size(definition_message, DeviceSettingsBleAutoUploadEnabledField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DeviceSettingsAutoSyncFrequencyField(
-            size=self.__get_field_size(definition_message, DeviceSettingsAutoSyncFrequencyField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DeviceSettingsAutoActivityDetectField(
-            size=self.__get_field_size(definition_message, DeviceSettingsAutoActivityDetectField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DeviceSettingsNumberOfScreensField(
-            size=self.__get_field_size(definition_message, DeviceSettingsNumberOfScreensField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DeviceSettingsSmartNotificationDisplayOrientationField(
-            size=self.__get_field_size(definition_message, DeviceSettingsSmartNotificationDisplayOrientationField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DeviceSettingsTapInterfaceField(
-            size=self.__get_field_size(definition_message, DeviceSettingsTapInterfaceField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DeviceSettingsTapSensitivityField(
-            size=self.__get_field_size(definition_message, DeviceSettingsTapSensitivityField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        DeviceSettingsActiveTimeZoneField(
+            size=cls._field_size_from_definition(
+                definition_message, DeviceSettingsActiveTimeZoneField.ID),
+            growable=False), 
+        DeviceSettingsUtcOffsetField(
+            size=cls._field_size_from_definition(
+                definition_message, DeviceSettingsUtcOffsetField.ID),
+            growable=False), 
+        DeviceSettingsTimeOffsetField(
+            size=cls._field_size_from_definition(
+                definition_message, DeviceSettingsTimeOffsetField.ID),
+            growable=False), 
+        DeviceSettingsTimeModeField(
+            size=cls._field_size_from_definition(
+                definition_message, DeviceSettingsTimeModeField.ID),
+            growable=False), 
+        DeviceSettingsTimeZoneOffsetField(
+            size=cls._field_size_from_definition(
+                definition_message, DeviceSettingsTimeZoneOffsetField.ID),
+            growable=False), 
+        DeviceSettingsBacklightModeField(
+            size=cls._field_size_from_definition(
+                definition_message, DeviceSettingsBacklightModeField.ID),
+            growable=False), 
+        DeviceSettingsActivityTrackerEnabledField(
+            size=cls._field_size_from_definition(
+                definition_message, DeviceSettingsActivityTrackerEnabledField.ID),
+            growable=False), 
+        DeviceSettingsClockTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, DeviceSettingsClockTimeField.ID),
+            growable=False), 
+        DeviceSettingsPagesEnabledField(
+            size=cls._field_size_from_definition(
+                definition_message, DeviceSettingsPagesEnabledField.ID),
+            growable=False), 
+        DeviceSettingsMoveAlertEnabledField(
+            size=cls._field_size_from_definition(
+                definition_message, DeviceSettingsMoveAlertEnabledField.ID),
+            growable=False), 
+        DeviceSettingsDateModeField(
+            size=cls._field_size_from_definition(
+                definition_message, DeviceSettingsDateModeField.ID),
+            growable=False), 
+        DeviceSettingsDisplayOrientationField(
+            size=cls._field_size_from_definition(
+                definition_message, DeviceSettingsDisplayOrientationField.ID),
+            growable=False), 
+        DeviceSettingsMountingSideField(
+            size=cls._field_size_from_definition(
+                definition_message, DeviceSettingsMountingSideField.ID),
+            growable=False), 
+        DeviceSettingsDefaultPageField(
+            size=cls._field_size_from_definition(
+                definition_message, DeviceSettingsDefaultPageField.ID),
+            growable=False), 
+        DeviceSettingsAutosyncMinStepsField(
+            size=cls._field_size_from_definition(
+                definition_message, DeviceSettingsAutosyncMinStepsField.ID),
+            growable=False), 
+        DeviceSettingsAutosyncMinTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, DeviceSettingsAutosyncMinTimeField.ID),
+            growable=False), 
+        DeviceSettingsLactateThresholdAutodetectEnabledField(
+            size=cls._field_size_from_definition(
+                definition_message, DeviceSettingsLactateThresholdAutodetectEnabledField.ID),
+            growable=False), 
+        DeviceSettingsBleAutoUploadEnabledField(
+            size=cls._field_size_from_definition(
+                definition_message, DeviceSettingsBleAutoUploadEnabledField.ID),
+            growable=False), 
+        DeviceSettingsAutoSyncFrequencyField(
+            size=cls._field_size_from_definition(
+                definition_message, DeviceSettingsAutoSyncFrequencyField.ID),
+            growable=False), 
+        DeviceSettingsAutoActivityDetectField(
+            size=cls._field_size_from_definition(
+                definition_message, DeviceSettingsAutoActivityDetectField.ID),
+            growable=False), 
+        DeviceSettingsNumberOfScreensField(
+            size=cls._field_size_from_definition(
+                definition_message, DeviceSettingsNumberOfScreensField.ID),
+            growable=False), 
+        DeviceSettingsSmartNotificationDisplayOrientationField(
+            size=cls._field_size_from_definition(
+                definition_message, DeviceSettingsSmartNotificationDisplayOrientationField.ID),
+            growable=False), 
+        DeviceSettingsTapInterfaceField(
+            size=cls._field_size_from_definition(
+                definition_message, DeviceSettingsTapInterfaceField.ID),
+            growable=False), 
+        DeviceSettingsTapSensitivityField(
+            size=cls._field_size_from_definition(
+                definition_message, DeviceSettingsTapSensitivityField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/dive_alarm_message.py
+++ b/fit_tool/profile/messages/dive_alarm_message.py
@@ -17,75 +17,154 @@ from typing import Dict as dict
 
 
 class DiveAlarmMessage(DataMessage):
+    """DiveAlarmMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``DiveAlarmMessage()`` — create path: growable fields, no wire definition.
+    * ``DiveAlarmMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 262
     NAME = 'dive_alarm'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=DiveAlarmMessage.NAME,
                          global_id=DiveAlarmMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         MessageIndexField(
-            size=self.__get_field_size(definition_message, MessageIndexField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveAlarmDepthField(
-            size=self.__get_field_size(definition_message, DiveAlarmDepthField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveAlarmTimeField(
-            size=self.__get_field_size(definition_message, DiveAlarmTimeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveAlarmEnabledField(
-            size=self.__get_field_size(definition_message, DiveAlarmEnabledField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveAlarmAlarmTypeField(
-            size=self.__get_field_size(definition_message, DiveAlarmAlarmTypeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveAlarmSoundField(
-            size=self.__get_field_size(definition_message, DiveAlarmSoundField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveAlarmDiveTypesField(
-            size=self.__get_field_size(definition_message, DiveAlarmDiveTypesField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveAlarmIdField(
-            size=self.__get_field_size(definition_message, DiveAlarmIdField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveAlarmPopupEnabledField(
-            size=self.__get_field_size(definition_message, DiveAlarmPopupEnabledField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveAlarmTriggerOnDescentField(
-            size=self.__get_field_size(definition_message, DiveAlarmTriggerOnDescentField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveAlarmTriggerOnAscentField(
-            size=self.__get_field_size(definition_message, DiveAlarmTriggerOnAscentField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveAlarmRepeatingField(
-            size=self.__get_field_size(definition_message, DiveAlarmRepeatingField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveAlarmSpeedField(
-            size=self.__get_field_size(definition_message, DiveAlarmSpeedField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        MessageIndexField(
+            size=cls._field_size_from_definition(
+                definition_message, MessageIndexField.ID),
+            growable=False), 
+        DiveAlarmDepthField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveAlarmDepthField.ID),
+            growable=False), 
+        DiveAlarmTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveAlarmTimeField.ID),
+            growable=False), 
+        DiveAlarmEnabledField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveAlarmEnabledField.ID),
+            growable=False), 
+        DiveAlarmAlarmTypeField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveAlarmAlarmTypeField.ID),
+            growable=False), 
+        DiveAlarmSoundField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveAlarmSoundField.ID),
+            growable=False), 
+        DiveAlarmDiveTypesField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveAlarmDiveTypesField.ID),
+            growable=False), 
+        DiveAlarmIdField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveAlarmIdField.ID),
+            growable=False), 
+        DiveAlarmPopupEnabledField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveAlarmPopupEnabledField.ID),
+            growable=False), 
+        DiveAlarmTriggerOnDescentField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveAlarmTriggerOnDescentField.ID),
+            growable=False), 
+        DiveAlarmTriggerOnAscentField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveAlarmTriggerOnAscentField.ID),
+            growable=False), 
+        DiveAlarmRepeatingField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveAlarmRepeatingField.ID),
+            growable=False), 
+        DiveAlarmSpeedField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveAlarmSpeedField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/dive_apnea_alarm_message.py
+++ b/fit_tool/profile/messages/dive_apnea_alarm_message.py
@@ -17,75 +17,154 @@ from typing import Dict as dict
 
 
 class DiveApneaAlarmMessage(DataMessage):
+    """DiveApneaAlarmMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``DiveApneaAlarmMessage()`` — create path: growable fields, no wire definition.
+    * ``DiveApneaAlarmMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 393
     NAME = 'dive_apnea_alarm'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=DiveApneaAlarmMessage.NAME,
                          global_id=DiveApneaAlarmMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         MessageIndexField(
-            size=self.__get_field_size(definition_message, MessageIndexField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveApneaAlarmDepthField(
-            size=self.__get_field_size(definition_message, DiveApneaAlarmDepthField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveApneaAlarmTimeField(
-            size=self.__get_field_size(definition_message, DiveApneaAlarmTimeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveApneaAlarmEnabledField(
-            size=self.__get_field_size(definition_message, DiveApneaAlarmEnabledField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveApneaAlarmAlarmTypeField(
-            size=self.__get_field_size(definition_message, DiveApneaAlarmAlarmTypeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveApneaAlarmSoundField(
-            size=self.__get_field_size(definition_message, DiveApneaAlarmSoundField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveApneaAlarmDiveTypesField(
-            size=self.__get_field_size(definition_message, DiveApneaAlarmDiveTypesField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveApneaAlarmIdField(
-            size=self.__get_field_size(definition_message, DiveApneaAlarmIdField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveApneaAlarmPopupEnabledField(
-            size=self.__get_field_size(definition_message, DiveApneaAlarmPopupEnabledField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveApneaAlarmTriggerOnDescentField(
-            size=self.__get_field_size(definition_message, DiveApneaAlarmTriggerOnDescentField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveApneaAlarmTriggerOnAscentField(
-            size=self.__get_field_size(definition_message, DiveApneaAlarmTriggerOnAscentField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveApneaAlarmRepeatingField(
-            size=self.__get_field_size(definition_message, DiveApneaAlarmRepeatingField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveApneaAlarmSpeedField(
-            size=self.__get_field_size(definition_message, DiveApneaAlarmSpeedField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        MessageIndexField(
+            size=cls._field_size_from_definition(
+                definition_message, MessageIndexField.ID),
+            growable=False), 
+        DiveApneaAlarmDepthField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveApneaAlarmDepthField.ID),
+            growable=False), 
+        DiveApneaAlarmTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveApneaAlarmTimeField.ID),
+            growable=False), 
+        DiveApneaAlarmEnabledField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveApneaAlarmEnabledField.ID),
+            growable=False), 
+        DiveApneaAlarmAlarmTypeField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveApneaAlarmAlarmTypeField.ID),
+            growable=False), 
+        DiveApneaAlarmSoundField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveApneaAlarmSoundField.ID),
+            growable=False), 
+        DiveApneaAlarmDiveTypesField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveApneaAlarmDiveTypesField.ID),
+            growable=False), 
+        DiveApneaAlarmIdField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveApneaAlarmIdField.ID),
+            growable=False), 
+        DiveApneaAlarmPopupEnabledField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveApneaAlarmPopupEnabledField.ID),
+            growable=False), 
+        DiveApneaAlarmTriggerOnDescentField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveApneaAlarmTriggerOnDescentField.ID),
+            growable=False), 
+        DiveApneaAlarmTriggerOnAscentField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveApneaAlarmTriggerOnAscentField.ID),
+            growable=False), 
+        DiveApneaAlarmRepeatingField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveApneaAlarmRepeatingField.ID),
+            growable=False), 
+        DiveApneaAlarmSpeedField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveApneaAlarmSpeedField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/dive_gas_message.py
+++ b/fit_tool/profile/messages/dive_gas_message.py
@@ -17,51 +17,98 @@ from typing import Dict as dict
 
 
 class DiveGasMessage(DataMessage):
+    """DiveGasMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``DiveGasMessage()`` — create path: growable fields, no wire definition.
+    * ``DiveGasMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 259
     NAME = 'dive_gas'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=DiveGasMessage.NAME,
                          global_id=DiveGasMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         MessageIndexField(
-            size=self.__get_field_size(definition_message, MessageIndexField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveGasHeliumContentField(
-            size=self.__get_field_size(definition_message, DiveGasHeliumContentField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveGasOxygenContentField(
-            size=self.__get_field_size(definition_message, DiveGasOxygenContentField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveGasStatusField(
-            size=self.__get_field_size(definition_message, DiveGasStatusField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveGasModeField(
-            size=self.__get_field_size(definition_message, DiveGasModeField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        MessageIndexField(
+            size=cls._field_size_from_definition(
+                definition_message, MessageIndexField.ID),
+            growable=False), 
+        DiveGasHeliumContentField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveGasHeliumContentField.ID),
+            growable=False), 
+        DiveGasOxygenContentField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveGasOxygenContentField.ID),
+            growable=False), 
+        DiveGasStatusField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveGasStatusField.ID),
+            growable=False), 
+        DiveGasModeField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveGasModeField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/dive_settings_message.py
+++ b/fit_tool/profile/messages/dive_settings_message.py
@@ -17,141 +17,308 @@ from typing import Dict as dict
 
 
 class DiveSettingsMessage(DataMessage):
+    """DiveSettingsMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``DiveSettingsMessage()`` — create path: growable fields, no wire definition.
+    * ``DiveSettingsMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 258
     NAME = 'dive_settings'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=DiveSettingsMessage.NAME,
                          global_id=DiveSettingsMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         TimestampField(
-            size=self.__get_field_size(definition_message, TimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         MessageIndexField(
-            size=self.__get_field_size(definition_message, MessageIndexField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveSettingsNameField(
-            size=self.__get_field_size(definition_message, DiveSettingsNameField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveSettingsModelField(
-            size=self.__get_field_size(definition_message, DiveSettingsModelField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveSettingsGfLowField(
-            size=self.__get_field_size(definition_message, DiveSettingsGfLowField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveSettingsGfHighField(
-            size=self.__get_field_size(definition_message, DiveSettingsGfHighField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveSettingsWaterTypeField(
-            size=self.__get_field_size(definition_message, DiveSettingsWaterTypeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveSettingsWaterDensityField(
-            size=self.__get_field_size(definition_message, DiveSettingsWaterDensityField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveSettingsPo2WarnField(
-            size=self.__get_field_size(definition_message, DiveSettingsPo2WarnField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveSettingsPo2CriticalField(
-            size=self.__get_field_size(definition_message, DiveSettingsPo2CriticalField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveSettingsPo2DecoField(
-            size=self.__get_field_size(definition_message, DiveSettingsPo2DecoField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveSettingsSafetyStopEnabledField(
-            size=self.__get_field_size(definition_message, DiveSettingsSafetyStopEnabledField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveSettingsBottomDepthField(
-            size=self.__get_field_size(definition_message, DiveSettingsBottomDepthField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveSettingsBottomTimeField(
-            size=self.__get_field_size(definition_message, DiveSettingsBottomTimeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveSettingsApneaCountdownEnabledField(
-            size=self.__get_field_size(definition_message, DiveSettingsApneaCountdownEnabledField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveSettingsApneaCountdownTimeField(
-            size=self.__get_field_size(definition_message, DiveSettingsApneaCountdownTimeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveSettingsBacklightModeField(
-            size=self.__get_field_size(definition_message, DiveSettingsBacklightModeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveSettingsBacklightBrightnessField(
-            size=self.__get_field_size(definition_message, DiveSettingsBacklightBrightnessField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveSettingsBacklightTimeoutField(
-            size=self.__get_field_size(definition_message, DiveSettingsBacklightTimeoutField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveSettingsRepeatDiveIntervalField(
-            size=self.__get_field_size(definition_message, DiveSettingsRepeatDiveIntervalField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveSettingsSafetyStopTimeField(
-            size=self.__get_field_size(definition_message, DiveSettingsSafetyStopTimeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveSettingsHeartRateSourceTypeField(
-            size=self.__get_field_size(definition_message, DiveSettingsHeartRateSourceTypeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveSettingsHeartRateSourceField(
-            size=self.__get_field_size(definition_message, DiveSettingsHeartRateSourceField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveSettingsTravelGasField(
-            size=self.__get_field_size(definition_message, DiveSettingsTravelGasField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveSettingsCcrLowSetpointSwitchModeField(
-            size=self.__get_field_size(definition_message, DiveSettingsCcrLowSetpointSwitchModeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveSettingsCcrLowSetpointField(
-            size=self.__get_field_size(definition_message, DiveSettingsCcrLowSetpointField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveSettingsCcrLowSetpointDepthField(
-            size=self.__get_field_size(definition_message, DiveSettingsCcrLowSetpointDepthField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveSettingsCcrHighSetpointSwitchModeField(
-            size=self.__get_field_size(definition_message, DiveSettingsCcrHighSetpointSwitchModeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveSettingsCcrHighSetpointField(
-            size=self.__get_field_size(definition_message, DiveSettingsCcrHighSetpointField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveSettingsCcrHighSetpointDepthField(
-            size=self.__get_field_size(definition_message, DiveSettingsCcrHighSetpointDepthField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveSettingsGasConsumptionDisplayField(
-            size=self.__get_field_size(definition_message, DiveSettingsGasConsumptionDisplayField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveSettingsUpKeyEnabledField(
-            size=self.__get_field_size(definition_message, DiveSettingsUpKeyEnabledField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveSettingsDiveSoundsField(
-            size=self.__get_field_size(definition_message, DiveSettingsDiveSoundsField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveSettingsLastStopMultipleField(
-            size=self.__get_field_size(definition_message, DiveSettingsLastStopMultipleField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveSettingsNoFlyTimeModeField(
-            size=self.__get_field_size(definition_message, DiveSettingsNoFlyTimeModeField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        TimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampField.ID),
+            growable=False), 
+        MessageIndexField(
+            size=cls._field_size_from_definition(
+                definition_message, MessageIndexField.ID),
+            growable=False), 
+        DiveSettingsNameField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveSettingsNameField.ID),
+            growable=False), 
+        DiveSettingsModelField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveSettingsModelField.ID),
+            growable=False), 
+        DiveSettingsGfLowField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveSettingsGfLowField.ID),
+            growable=False), 
+        DiveSettingsGfHighField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveSettingsGfHighField.ID),
+            growable=False), 
+        DiveSettingsWaterTypeField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveSettingsWaterTypeField.ID),
+            growable=False), 
+        DiveSettingsWaterDensityField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveSettingsWaterDensityField.ID),
+            growable=False), 
+        DiveSettingsPo2WarnField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveSettingsPo2WarnField.ID),
+            growable=False), 
+        DiveSettingsPo2CriticalField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveSettingsPo2CriticalField.ID),
+            growable=False), 
+        DiveSettingsPo2DecoField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveSettingsPo2DecoField.ID),
+            growable=False), 
+        DiveSettingsSafetyStopEnabledField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveSettingsSafetyStopEnabledField.ID),
+            growable=False), 
+        DiveSettingsBottomDepthField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveSettingsBottomDepthField.ID),
+            growable=False), 
+        DiveSettingsBottomTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveSettingsBottomTimeField.ID),
+            growable=False), 
+        DiveSettingsApneaCountdownEnabledField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveSettingsApneaCountdownEnabledField.ID),
+            growable=False), 
+        DiveSettingsApneaCountdownTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveSettingsApneaCountdownTimeField.ID),
+            growable=False), 
+        DiveSettingsBacklightModeField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveSettingsBacklightModeField.ID),
+            growable=False), 
+        DiveSettingsBacklightBrightnessField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveSettingsBacklightBrightnessField.ID),
+            growable=False), 
+        DiveSettingsBacklightTimeoutField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveSettingsBacklightTimeoutField.ID),
+            growable=False), 
+        DiveSettingsRepeatDiveIntervalField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveSettingsRepeatDiveIntervalField.ID),
+            growable=False), 
+        DiveSettingsSafetyStopTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveSettingsSafetyStopTimeField.ID),
+            growable=False), 
+        DiveSettingsHeartRateSourceTypeField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveSettingsHeartRateSourceTypeField.ID),
+            growable=False), 
+        DiveSettingsHeartRateSourceField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveSettingsHeartRateSourceField.ID),
+            growable=False), 
+        DiveSettingsTravelGasField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveSettingsTravelGasField.ID),
+            growable=False), 
+        DiveSettingsCcrLowSetpointSwitchModeField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveSettingsCcrLowSetpointSwitchModeField.ID),
+            growable=False), 
+        DiveSettingsCcrLowSetpointField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveSettingsCcrLowSetpointField.ID),
+            growable=False), 
+        DiveSettingsCcrLowSetpointDepthField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveSettingsCcrLowSetpointDepthField.ID),
+            growable=False), 
+        DiveSettingsCcrHighSetpointSwitchModeField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveSettingsCcrHighSetpointSwitchModeField.ID),
+            growable=False), 
+        DiveSettingsCcrHighSetpointField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveSettingsCcrHighSetpointField.ID),
+            growable=False), 
+        DiveSettingsCcrHighSetpointDepthField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveSettingsCcrHighSetpointDepthField.ID),
+            growable=False), 
+        DiveSettingsGasConsumptionDisplayField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveSettingsGasConsumptionDisplayField.ID),
+            growable=False), 
+        DiveSettingsUpKeyEnabledField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveSettingsUpKeyEnabledField.ID),
+            growable=False), 
+        DiveSettingsDiveSoundsField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveSettingsDiveSoundsField.ID),
+            growable=False), 
+        DiveSettingsLastStopMultipleField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveSettingsLastStopMultipleField.ID),
+            growable=False), 
+        DiveSettingsNoFlyTimeModeField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveSettingsNoFlyTimeModeField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/dive_summary_message.py
+++ b/fit_tool/profile/messages/dive_summary_message.py
@@ -17,105 +17,224 @@ from typing import Dict as dict
 
 
 class DiveSummaryMessage(DataMessage):
+    """DiveSummaryMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``DiveSummaryMessage()`` — create path: growable fields, no wire definition.
+    * ``DiveSummaryMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 268
     NAME = 'dive_summary'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=DiveSummaryMessage.NAME,
                          global_id=DiveSummaryMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         TimestampField(
-            size=self.__get_field_size(definition_message, TimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveSummaryReferenceMesgField(
-            size=self.__get_field_size(definition_message, DiveSummaryReferenceMesgField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveSummaryReferenceIndexField(
-            size=self.__get_field_size(definition_message, DiveSummaryReferenceIndexField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveSummaryAvgDepthField(
-            size=self.__get_field_size(definition_message, DiveSummaryAvgDepthField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveSummaryMaxDepthField(
-            size=self.__get_field_size(definition_message, DiveSummaryMaxDepthField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveSummarySurfaceIntervalField(
-            size=self.__get_field_size(definition_message, DiveSummarySurfaceIntervalField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveSummaryStartCnsField(
-            size=self.__get_field_size(definition_message, DiveSummaryStartCnsField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveSummaryEndCnsField(
-            size=self.__get_field_size(definition_message, DiveSummaryEndCnsField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveSummaryStartN2Field(
-            size=self.__get_field_size(definition_message, DiveSummaryStartN2Field.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveSummaryEndN2Field(
-            size=self.__get_field_size(definition_message, DiveSummaryEndN2Field.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveSummaryO2ToxicityField(
-            size=self.__get_field_size(definition_message, DiveSummaryO2ToxicityField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveSummaryDiveNumberField(
-            size=self.__get_field_size(definition_message, DiveSummaryDiveNumberField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveSummaryBottomTimeField(
-            size=self.__get_field_size(definition_message, DiveSummaryBottomTimeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveSummaryAvgPressureSacField(
-            size=self.__get_field_size(definition_message, DiveSummaryAvgPressureSacField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveSummaryAvgVolumeSacField(
-            size=self.__get_field_size(definition_message, DiveSummaryAvgVolumeSacField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveSummaryAvgRmvField(
-            size=self.__get_field_size(definition_message, DiveSummaryAvgRmvField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveSummaryDescentTimeField(
-            size=self.__get_field_size(definition_message, DiveSummaryDescentTimeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveSummaryAscentTimeField(
-            size=self.__get_field_size(definition_message, DiveSummaryAscentTimeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveSummaryAvgAscentRateField(
-            size=self.__get_field_size(definition_message, DiveSummaryAvgAscentRateField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveSummaryAvgDescentRateField(
-            size=self.__get_field_size(definition_message, DiveSummaryAvgDescentRateField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveSummaryMaxAscentRateField(
-            size=self.__get_field_size(definition_message, DiveSummaryMaxAscentRateField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveSummaryMaxDescentRateField(
-            size=self.__get_field_size(definition_message, DiveSummaryMaxDescentRateField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         DiveSummaryHangTimeField(
-            size=self.__get_field_size(definition_message, DiveSummaryHangTimeField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        TimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampField.ID),
+            growable=False), 
+        DiveSummaryReferenceMesgField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveSummaryReferenceMesgField.ID),
+            growable=False), 
+        DiveSummaryReferenceIndexField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveSummaryReferenceIndexField.ID),
+            growable=False), 
+        DiveSummaryAvgDepthField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveSummaryAvgDepthField.ID),
+            growable=False), 
+        DiveSummaryMaxDepthField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveSummaryMaxDepthField.ID),
+            growable=False), 
+        DiveSummarySurfaceIntervalField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveSummarySurfaceIntervalField.ID),
+            growable=False), 
+        DiveSummaryStartCnsField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveSummaryStartCnsField.ID),
+            growable=False), 
+        DiveSummaryEndCnsField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveSummaryEndCnsField.ID),
+            growable=False), 
+        DiveSummaryStartN2Field(
+            size=cls._field_size_from_definition(
+                definition_message, DiveSummaryStartN2Field.ID),
+            growable=False), 
+        DiveSummaryEndN2Field(
+            size=cls._field_size_from_definition(
+                definition_message, DiveSummaryEndN2Field.ID),
+            growable=False), 
+        DiveSummaryO2ToxicityField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveSummaryO2ToxicityField.ID),
+            growable=False), 
+        DiveSummaryDiveNumberField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveSummaryDiveNumberField.ID),
+            growable=False), 
+        DiveSummaryBottomTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveSummaryBottomTimeField.ID),
+            growable=False), 
+        DiveSummaryAvgPressureSacField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveSummaryAvgPressureSacField.ID),
+            growable=False), 
+        DiveSummaryAvgVolumeSacField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveSummaryAvgVolumeSacField.ID),
+            growable=False), 
+        DiveSummaryAvgRmvField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveSummaryAvgRmvField.ID),
+            growable=False), 
+        DiveSummaryDescentTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveSummaryDescentTimeField.ID),
+            growable=False), 
+        DiveSummaryAscentTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveSummaryAscentTimeField.ID),
+            growable=False), 
+        DiveSummaryAvgAscentRateField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveSummaryAvgAscentRateField.ID),
+            growable=False), 
+        DiveSummaryAvgDescentRateField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveSummaryAvgDescentRateField.ID),
+            growable=False), 
+        DiveSummaryMaxAscentRateField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveSummaryMaxAscentRateField.ID),
+            growable=False), 
+        DiveSummaryMaxDescentRateField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveSummaryMaxDescentRateField.ID),
+            growable=False), 
+        DiveSummaryHangTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, DiveSummaryHangTimeField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/event_message.py
+++ b/fit_tool/profile/messages/event_message.py
@@ -17,93 +17,196 @@ from typing import Dict as dict
 
 
 class EventMessage(DataMessage):
+    """EventMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``EventMessage()`` — create path: growable fields, no wire definition.
+    * ``EventMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 21
     NAME = 'event'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=EventMessage.NAME,
                          global_id=EventMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         TimestampField(
-            size=self.__get_field_size(definition_message, TimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         EventEventField(
-            size=self.__get_field_size(definition_message, EventEventField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         EventEventTypeField(
-            size=self.__get_field_size(definition_message, EventEventTypeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         EventData16Field(
-            size=self.__get_field_size(definition_message, EventData16Field.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         EventDataField(
-            size=self.__get_field_size(definition_message, EventDataField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         EventEventGroupField(
-            size=self.__get_field_size(definition_message, EventEventGroupField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         EventScoreField(
-            size=self.__get_field_size(definition_message, EventScoreField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         EventOpponentScoreField(
-            size=self.__get_field_size(definition_message, EventOpponentScoreField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         EventFrontGearNumField(
-            size=self.__get_field_size(definition_message, EventFrontGearNumField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         EventFrontGearField(
-            size=self.__get_field_size(definition_message, EventFrontGearField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         EventRearGearNumField(
-            size=self.__get_field_size(definition_message, EventRearGearNumField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         EventRearGearField(
-            size=self.__get_field_size(definition_message, EventRearGearField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         EventDeviceIndexField(
-            size=self.__get_field_size(definition_message, EventDeviceIndexField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         EventActivityTypeField(
-            size=self.__get_field_size(definition_message, EventActivityTypeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         EventStartTimestampField(
-            size=self.__get_field_size(definition_message, EventStartTimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         EventRadarThreatLevelMaxField(
-            size=self.__get_field_size(definition_message, EventRadarThreatLevelMaxField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         EventRadarThreatCountField(
-            size=self.__get_field_size(definition_message, EventRadarThreatCountField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         EventRadarThreatAvgApproachSpeedField(
-            size=self.__get_field_size(definition_message, EventRadarThreatAvgApproachSpeedField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         EventRadarThreatMaxApproachSpeedField(
-            size=self.__get_field_size(definition_message, EventRadarThreatMaxApproachSpeedField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        TimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampField.ID),
+            growable=False), 
+        EventEventField(
+            size=cls._field_size_from_definition(
+                definition_message, EventEventField.ID),
+            growable=False), 
+        EventEventTypeField(
+            size=cls._field_size_from_definition(
+                definition_message, EventEventTypeField.ID),
+            growable=False), 
+        EventData16Field(
+            size=cls._field_size_from_definition(
+                definition_message, EventData16Field.ID),
+            growable=False), 
+        EventDataField(
+            size=cls._field_size_from_definition(
+                definition_message, EventDataField.ID),
+            growable=False), 
+        EventEventGroupField(
+            size=cls._field_size_from_definition(
+                definition_message, EventEventGroupField.ID),
+            growable=False), 
+        EventScoreField(
+            size=cls._field_size_from_definition(
+                definition_message, EventScoreField.ID),
+            growable=False), 
+        EventOpponentScoreField(
+            size=cls._field_size_from_definition(
+                definition_message, EventOpponentScoreField.ID),
+            growable=False), 
+        EventFrontGearNumField(
+            size=cls._field_size_from_definition(
+                definition_message, EventFrontGearNumField.ID),
+            growable=False), 
+        EventFrontGearField(
+            size=cls._field_size_from_definition(
+                definition_message, EventFrontGearField.ID),
+            growable=False), 
+        EventRearGearNumField(
+            size=cls._field_size_from_definition(
+                definition_message, EventRearGearNumField.ID),
+            growable=False), 
+        EventRearGearField(
+            size=cls._field_size_from_definition(
+                definition_message, EventRearGearField.ID),
+            growable=False), 
+        EventDeviceIndexField(
+            size=cls._field_size_from_definition(
+                definition_message, EventDeviceIndexField.ID),
+            growable=False), 
+        EventActivityTypeField(
+            size=cls._field_size_from_definition(
+                definition_message, EventActivityTypeField.ID),
+            growable=False), 
+        EventStartTimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, EventStartTimestampField.ID),
+            growable=False), 
+        EventRadarThreatLevelMaxField(
+            size=cls._field_size_from_definition(
+                definition_message, EventRadarThreatLevelMaxField.ID),
+            growable=False), 
+        EventRadarThreatCountField(
+            size=cls._field_size_from_definition(
+                definition_message, EventRadarThreatCountField.ID),
+            growable=False), 
+        EventRadarThreatAvgApproachSpeedField(
+            size=cls._field_size_from_definition(
+                definition_message, EventRadarThreatAvgApproachSpeedField.ID),
+            growable=False), 
+        EventRadarThreatMaxApproachSpeedField(
+            size=cls._field_size_from_definition(
+                definition_message, EventRadarThreatMaxApproachSpeedField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/exd_data_concept_configuration_message.py
+++ b/fit_tool/profile/messages/exd_data_concept_configuration_message.py
@@ -17,69 +17,140 @@ from typing import Dict as dict
 
 
 class ExdDataConceptConfigurationMessage(DataMessage):
+    """ExdDataConceptConfigurationMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``ExdDataConceptConfigurationMessage()`` — create path: growable fields, no wire definition.
+    * ``ExdDataConceptConfigurationMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 202
     NAME = 'exd_data_concept_configuration'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=ExdDataConceptConfigurationMessage.NAME,
                          global_id=ExdDataConceptConfigurationMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         ExdDataConceptConfigurationScreenIndexField(
-            size=self.__get_field_size(definition_message, ExdDataConceptConfigurationScreenIndexField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ExdDataConceptConfigurationConceptField(
-            size=self.__get_field_size(definition_message, ExdDataConceptConfigurationConceptField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ExdDataConceptConfigurationFieldIdField(
-            size=self.__get_field_size(definition_message, ExdDataConceptConfigurationFieldIdField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ExdDataConceptConfigurationConceptIndexField(
-            size=self.__get_field_size(definition_message, ExdDataConceptConfigurationConceptIndexField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ExdDataConceptConfigurationDataPageField(
-            size=self.__get_field_size(definition_message, ExdDataConceptConfigurationDataPageField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ExdDataConceptConfigurationConceptKeyField(
-            size=self.__get_field_size(definition_message, ExdDataConceptConfigurationConceptKeyField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ExdDataConceptConfigurationScalingField(
-            size=self.__get_field_size(definition_message, ExdDataConceptConfigurationScalingField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ExdDataConceptConfigurationDataUnitsField(
-            size=self.__get_field_size(definition_message, ExdDataConceptConfigurationDataUnitsField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ExdDataConceptConfigurationQualifierField(
-            size=self.__get_field_size(definition_message, ExdDataConceptConfigurationQualifierField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ExdDataConceptConfigurationDescriptorField(
-            size=self.__get_field_size(definition_message, ExdDataConceptConfigurationDescriptorField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ExdDataConceptConfigurationIsSignedField(
-            size=self.__get_field_size(definition_message, ExdDataConceptConfigurationIsSignedField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        ExdDataConceptConfigurationScreenIndexField(
+            size=cls._field_size_from_definition(
+                definition_message, ExdDataConceptConfigurationScreenIndexField.ID),
+            growable=False), 
+        ExdDataConceptConfigurationConceptField(
+            size=cls._field_size_from_definition(
+                definition_message, ExdDataConceptConfigurationConceptField.ID),
+            growable=False), 
+        ExdDataConceptConfigurationFieldIdField(
+            size=cls._field_size_from_definition(
+                definition_message, ExdDataConceptConfigurationFieldIdField.ID),
+            growable=False), 
+        ExdDataConceptConfigurationConceptIndexField(
+            size=cls._field_size_from_definition(
+                definition_message, ExdDataConceptConfigurationConceptIndexField.ID),
+            growable=False), 
+        ExdDataConceptConfigurationDataPageField(
+            size=cls._field_size_from_definition(
+                definition_message, ExdDataConceptConfigurationDataPageField.ID),
+            growable=False), 
+        ExdDataConceptConfigurationConceptKeyField(
+            size=cls._field_size_from_definition(
+                definition_message, ExdDataConceptConfigurationConceptKeyField.ID),
+            growable=False), 
+        ExdDataConceptConfigurationScalingField(
+            size=cls._field_size_from_definition(
+                definition_message, ExdDataConceptConfigurationScalingField.ID),
+            growable=False), 
+        ExdDataConceptConfigurationDataUnitsField(
+            size=cls._field_size_from_definition(
+                definition_message, ExdDataConceptConfigurationDataUnitsField.ID),
+            growable=False), 
+        ExdDataConceptConfigurationQualifierField(
+            size=cls._field_size_from_definition(
+                definition_message, ExdDataConceptConfigurationQualifierField.ID),
+            growable=False), 
+        ExdDataConceptConfigurationDescriptorField(
+            size=cls._field_size_from_definition(
+                definition_message, ExdDataConceptConfigurationDescriptorField.ID),
+            growable=False), 
+        ExdDataConceptConfigurationIsSignedField(
+            size=cls._field_size_from_definition(
+                definition_message, ExdDataConceptConfigurationIsSignedField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/exd_data_field_configuration_message.py
+++ b/fit_tool/profile/messages/exd_data_field_configuration_message.py
@@ -17,54 +17,105 @@ from typing import Dict as dict
 
 
 class ExdDataFieldConfigurationMessage(DataMessage):
+    """ExdDataFieldConfigurationMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``ExdDataFieldConfigurationMessage()`` — create path: growable fields, no wire definition.
+    * ``ExdDataFieldConfigurationMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 201
     NAME = 'exd_data_field_configuration'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=ExdDataFieldConfigurationMessage.NAME,
                          global_id=ExdDataFieldConfigurationMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         ExdDataFieldConfigurationScreenIndexField(
-            size=self.__get_field_size(definition_message, ExdDataFieldConfigurationScreenIndexField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ExdDataFieldConfigurationConceptField(
-            size=self.__get_field_size(definition_message, ExdDataFieldConfigurationConceptField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ExdDataFieldConfigurationFieldIdField(
-            size=self.__get_field_size(definition_message, ExdDataFieldConfigurationFieldIdField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ExdDataFieldConfigurationConceptCountField(
-            size=self.__get_field_size(definition_message, ExdDataFieldConfigurationConceptCountField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ExdDataFieldConfigurationDisplayTypeField(
-            size=self.__get_field_size(definition_message, ExdDataFieldConfigurationDisplayTypeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ExdDataFieldConfigurationTitleField(
-            size=self.__get_field_size(definition_message, ExdDataFieldConfigurationTitleField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        ExdDataFieldConfigurationScreenIndexField(
+            size=cls._field_size_from_definition(
+                definition_message, ExdDataFieldConfigurationScreenIndexField.ID),
+            growable=False), 
+        ExdDataFieldConfigurationConceptField(
+            size=cls._field_size_from_definition(
+                definition_message, ExdDataFieldConfigurationConceptField.ID),
+            growable=False), 
+        ExdDataFieldConfigurationFieldIdField(
+            size=cls._field_size_from_definition(
+                definition_message, ExdDataFieldConfigurationFieldIdField.ID),
+            growable=False), 
+        ExdDataFieldConfigurationConceptCountField(
+            size=cls._field_size_from_definition(
+                definition_message, ExdDataFieldConfigurationConceptCountField.ID),
+            growable=False), 
+        ExdDataFieldConfigurationDisplayTypeField(
+            size=cls._field_size_from_definition(
+                definition_message, ExdDataFieldConfigurationDisplayTypeField.ID),
+            growable=False), 
+        ExdDataFieldConfigurationTitleField(
+            size=cls._field_size_from_definition(
+                definition_message, ExdDataFieldConfigurationTitleField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/exd_screen_configuration_message.py
+++ b/fit_tool/profile/messages/exd_screen_configuration_message.py
@@ -17,48 +17,91 @@ from typing import Dict as dict
 
 
 class ExdScreenConfigurationMessage(DataMessage):
+    """ExdScreenConfigurationMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``ExdScreenConfigurationMessage()`` — create path: growable fields, no wire definition.
+    * ``ExdScreenConfigurationMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 200
     NAME = 'exd_screen_configuration'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=ExdScreenConfigurationMessage.NAME,
                          global_id=ExdScreenConfigurationMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         ExdScreenConfigurationScreenIndexField(
-            size=self.__get_field_size(definition_message, ExdScreenConfigurationScreenIndexField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ExdScreenConfigurationFieldCountField(
-            size=self.__get_field_size(definition_message, ExdScreenConfigurationFieldCountField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ExdScreenConfigurationLayoutField(
-            size=self.__get_field_size(definition_message, ExdScreenConfigurationLayoutField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ExdScreenConfigurationScreenEnabledField(
-            size=self.__get_field_size(definition_message, ExdScreenConfigurationScreenEnabledField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        ExdScreenConfigurationScreenIndexField(
+            size=cls._field_size_from_definition(
+                definition_message, ExdScreenConfigurationScreenIndexField.ID),
+            growable=False), 
+        ExdScreenConfigurationFieldCountField(
+            size=cls._field_size_from_definition(
+                definition_message, ExdScreenConfigurationFieldCountField.ID),
+            growable=False), 
+        ExdScreenConfigurationLayoutField(
+            size=cls._field_size_from_definition(
+                definition_message, ExdScreenConfigurationLayoutField.ID),
+            growable=False), 
+        ExdScreenConfigurationScreenEnabledField(
+            size=cls._field_size_from_definition(
+                definition_message, ExdScreenConfigurationScreenEnabledField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/exercise_title_message.py
+++ b/fit_tool/profile/messages/exercise_title_message.py
@@ -17,48 +17,91 @@ from typing import Dict as dict
 
 
 class ExerciseTitleMessage(DataMessage):
+    """ExerciseTitleMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``ExerciseTitleMessage()`` — create path: growable fields, no wire definition.
+    * ``ExerciseTitleMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 264
     NAME = 'exercise_title'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=ExerciseTitleMessage.NAME,
                          global_id=ExerciseTitleMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         MessageIndexField(
-            size=self.__get_field_size(definition_message, MessageIndexField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ExerciseTitleExerciseCategoryField(
-            size=self.__get_field_size(definition_message, ExerciseTitleExerciseCategoryField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ExerciseTitleExerciseNameField(
-            size=self.__get_field_size(definition_message, ExerciseTitleExerciseNameField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ExerciseTitleWorkoutStepNameField(
-            size=self.__get_field_size(definition_message, ExerciseTitleWorkoutStepNameField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        MessageIndexField(
+            size=cls._field_size_from_definition(
+                definition_message, MessageIndexField.ID),
+            growable=False), 
+        ExerciseTitleExerciseCategoryField(
+            size=cls._field_size_from_definition(
+                definition_message, ExerciseTitleExerciseCategoryField.ID),
+            growable=False), 
+        ExerciseTitleExerciseNameField(
+            size=cls._field_size_from_definition(
+                definition_message, ExerciseTitleExerciseNameField.ID),
+            growable=False), 
+        ExerciseTitleWorkoutStepNameField(
+            size=cls._field_size_from_definition(
+                definition_message, ExerciseTitleWorkoutStepNameField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/field_capabilities_message.py
+++ b/fit_tool/profile/messages/field_capabilities_message.py
@@ -17,51 +17,98 @@ from typing import Dict as dict
 
 
 class FieldCapabilitiesMessage(DataMessage):
+    """FieldCapabilitiesMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``FieldCapabilitiesMessage()`` — create path: growable fields, no wire definition.
+    * ``FieldCapabilitiesMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 39
     NAME = 'field_capabilities'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=FieldCapabilitiesMessage.NAME,
                          global_id=FieldCapabilitiesMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         MessageIndexField(
-            size=self.__get_field_size(definition_message, MessageIndexField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         FieldCapabilitiesFileField(
-            size=self.__get_field_size(definition_message, FieldCapabilitiesFileField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         FieldCapabilitiesMesgNumField(
-            size=self.__get_field_size(definition_message, FieldCapabilitiesMesgNumField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         FieldCapabilitiesFieldNumField(
-            size=self.__get_field_size(definition_message, FieldCapabilitiesFieldNumField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         FieldCapabilitiesCountField(
-            size=self.__get_field_size(definition_message, FieldCapabilitiesCountField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        MessageIndexField(
+            size=cls._field_size_from_definition(
+                definition_message, MessageIndexField.ID),
+            growable=False), 
+        FieldCapabilitiesFileField(
+            size=cls._field_size_from_definition(
+                definition_message, FieldCapabilitiesFileField.ID),
+            growable=False), 
+        FieldCapabilitiesMesgNumField(
+            size=cls._field_size_from_definition(
+                definition_message, FieldCapabilitiesMesgNumField.ID),
+            growable=False), 
+        FieldCapabilitiesFieldNumField(
+            size=cls._field_size_from_definition(
+                definition_message, FieldCapabilitiesFieldNumField.ID),
+            growable=False), 
+        FieldCapabilitiesCountField(
+            size=cls._field_size_from_definition(
+                definition_message, FieldCapabilitiesCountField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/field_description_message.py
+++ b/fit_tool/profile/messages/field_description_message.py
@@ -17,78 +17,161 @@ from typing import Dict as dict
 
 
 class FieldDescriptionMessage(DataMessage):
+    """FieldDescriptionMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``FieldDescriptionMessage()`` — create path: growable fields, no wire definition.
+    * ``FieldDescriptionMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 206
     NAME = 'field_description'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=FieldDescriptionMessage.NAME,
                          global_id=FieldDescriptionMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         FieldDescriptionDeveloperDataIndexField(
-            size=self.__get_field_size(definition_message, FieldDescriptionDeveloperDataIndexField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         FieldDescriptionFieldDefinitionNumberField(
-            size=self.__get_field_size(definition_message, FieldDescriptionFieldDefinitionNumberField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         FieldDescriptionFitBaseTypeIdField(
-            size=self.__get_field_size(definition_message, FieldDescriptionFitBaseTypeIdField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         FieldDescriptionFieldNameField(
-            size=self.__get_field_size(definition_message, FieldDescriptionFieldNameField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         FieldDescriptionArrayField(
-            size=self.__get_field_size(definition_message, FieldDescriptionArrayField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         FieldDescriptionComponentsField(
-            size=self.__get_field_size(definition_message, FieldDescriptionComponentsField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         FieldDescriptionScaleField(
-            size=self.__get_field_size(definition_message, FieldDescriptionScaleField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         FieldDescriptionOffsetField(
-            size=self.__get_field_size(definition_message, FieldDescriptionOffsetField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         FieldDescriptionUnitsField(
-            size=self.__get_field_size(definition_message, FieldDescriptionUnitsField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         FieldDescriptionBitsField(
-            size=self.__get_field_size(definition_message, FieldDescriptionBitsField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         FieldDescriptionAccumulateField(
-            size=self.__get_field_size(definition_message, FieldDescriptionAccumulateField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         FieldDescriptionFitBaseUnitIdField(
-            size=self.__get_field_size(definition_message, FieldDescriptionFitBaseUnitIdField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         FieldDescriptionNativeMesgNumField(
-            size=self.__get_field_size(definition_message, FieldDescriptionNativeMesgNumField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         FieldDescriptionNativeFieldNumField(
-            size=self.__get_field_size(definition_message, FieldDescriptionNativeFieldNumField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        FieldDescriptionDeveloperDataIndexField(
+            size=cls._field_size_from_definition(
+                definition_message, FieldDescriptionDeveloperDataIndexField.ID),
+            growable=False), 
+        FieldDescriptionFieldDefinitionNumberField(
+            size=cls._field_size_from_definition(
+                definition_message, FieldDescriptionFieldDefinitionNumberField.ID),
+            growable=False), 
+        FieldDescriptionFitBaseTypeIdField(
+            size=cls._field_size_from_definition(
+                definition_message, FieldDescriptionFitBaseTypeIdField.ID),
+            growable=False), 
+        FieldDescriptionFieldNameField(
+            size=cls._field_size_from_definition(
+                definition_message, FieldDescriptionFieldNameField.ID),
+            growable=False), 
+        FieldDescriptionArrayField(
+            size=cls._field_size_from_definition(
+                definition_message, FieldDescriptionArrayField.ID),
+            growable=False), 
+        FieldDescriptionComponentsField(
+            size=cls._field_size_from_definition(
+                definition_message, FieldDescriptionComponentsField.ID),
+            growable=False), 
+        FieldDescriptionScaleField(
+            size=cls._field_size_from_definition(
+                definition_message, FieldDescriptionScaleField.ID),
+            growable=False), 
+        FieldDescriptionOffsetField(
+            size=cls._field_size_from_definition(
+                definition_message, FieldDescriptionOffsetField.ID),
+            growable=False), 
+        FieldDescriptionUnitsField(
+            size=cls._field_size_from_definition(
+                definition_message, FieldDescriptionUnitsField.ID),
+            growable=False), 
+        FieldDescriptionBitsField(
+            size=cls._field_size_from_definition(
+                definition_message, FieldDescriptionBitsField.ID),
+            growable=False), 
+        FieldDescriptionAccumulateField(
+            size=cls._field_size_from_definition(
+                definition_message, FieldDescriptionAccumulateField.ID),
+            growable=False), 
+        FieldDescriptionFitBaseUnitIdField(
+            size=cls._field_size_from_definition(
+                definition_message, FieldDescriptionFitBaseUnitIdField.ID),
+            growable=False), 
+        FieldDescriptionNativeMesgNumField(
+            size=cls._field_size_from_definition(
+                definition_message, FieldDescriptionNativeMesgNumField.ID),
+            growable=False), 
+        FieldDescriptionNativeFieldNumField(
+            size=cls._field_size_from_definition(
+                definition_message, FieldDescriptionNativeFieldNumField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/file_capabilities_message.py
+++ b/fit_tool/profile/messages/file_capabilities_message.py
@@ -17,54 +17,105 @@ from typing import Dict as dict
 
 
 class FileCapabilitiesMessage(DataMessage):
+    """FileCapabilitiesMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``FileCapabilitiesMessage()`` — create path: growable fields, no wire definition.
+    * ``FileCapabilitiesMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 37
     NAME = 'file_capabilities'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=FileCapabilitiesMessage.NAME,
                          global_id=FileCapabilitiesMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         MessageIndexField(
-            size=self.__get_field_size(definition_message, MessageIndexField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         FileCapabilitiesTypeField(
-            size=self.__get_field_size(definition_message, FileCapabilitiesTypeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         FileCapabilitiesFlagsField(
-            size=self.__get_field_size(definition_message, FileCapabilitiesFlagsField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         FileCapabilitiesDirectoryField(
-            size=self.__get_field_size(definition_message, FileCapabilitiesDirectoryField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         FileCapabilitiesMaxCountField(
-            size=self.__get_field_size(definition_message, FileCapabilitiesMaxCountField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         FileCapabilitiesMaxSizeField(
-            size=self.__get_field_size(definition_message, FileCapabilitiesMaxSizeField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        MessageIndexField(
+            size=cls._field_size_from_definition(
+                definition_message, MessageIndexField.ID),
+            growable=False), 
+        FileCapabilitiesTypeField(
+            size=cls._field_size_from_definition(
+                definition_message, FileCapabilitiesTypeField.ID),
+            growable=False), 
+        FileCapabilitiesFlagsField(
+            size=cls._field_size_from_definition(
+                definition_message, FileCapabilitiesFlagsField.ID),
+            growable=False), 
+        FileCapabilitiesDirectoryField(
+            size=cls._field_size_from_definition(
+                definition_message, FileCapabilitiesDirectoryField.ID),
+            growable=False), 
+        FileCapabilitiesMaxCountField(
+            size=cls._field_size_from_definition(
+                definition_message, FileCapabilitiesMaxCountField.ID),
+            growable=False), 
+        FileCapabilitiesMaxSizeField(
+            size=cls._field_size_from_definition(
+                definition_message, FileCapabilitiesMaxSizeField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/file_creator_message.py
+++ b/fit_tool/profile/messages/file_creator_message.py
@@ -17,42 +17,77 @@ from typing import Dict as dict
 
 
 class FileCreatorMessage(DataMessage):
+    """FileCreatorMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``FileCreatorMessage()`` — create path: growable fields, no wire definition.
+    * ``FileCreatorMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 49
     NAME = 'file_creator'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=FileCreatorMessage.NAME,
                          global_id=FileCreatorMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         FileCreatorSoftwareVersionField(
-            size=self.__get_field_size(definition_message, FileCreatorSoftwareVersionField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         FileCreatorHardwareVersionField(
-            size=self.__get_field_size(definition_message, FileCreatorHardwareVersionField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        FileCreatorSoftwareVersionField(
+            size=cls._field_size_from_definition(
+                definition_message, FileCreatorSoftwareVersionField.ID),
+            growable=False), 
+        FileCreatorHardwareVersionField(
+            size=cls._field_size_from_definition(
+                definition_message, FileCreatorHardwareVersionField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/file_id_message.py
+++ b/fit_tool/profile/messages/file_id_message.py
@@ -17,57 +17,112 @@ from typing import Dict as dict
 
 
 class FileIdMessage(DataMessage):
+    """FileIdMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``FileIdMessage()`` — create path: growable fields, no wire definition.
+    * ``FileIdMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 0
     NAME = 'file_id'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=FileIdMessage.NAME,
                          global_id=FileIdMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         FileIdTypeField(
-            size=self.__get_field_size(definition_message, FileIdTypeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         FileIdManufacturerField(
-            size=self.__get_field_size(definition_message, FileIdManufacturerField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         FileIdProductField(
-            size=self.__get_field_size(definition_message, FileIdProductField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         FileIdSerialNumberField(
-            size=self.__get_field_size(definition_message, FileIdSerialNumberField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         FileIdTimeCreatedField(
-            size=self.__get_field_size(definition_message, FileIdTimeCreatedField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         FileIdNumberField(
-            size=self.__get_field_size(definition_message, FileIdNumberField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         FileIdProductNameField(
-            size=self.__get_field_size(definition_message, FileIdProductNameField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        FileIdTypeField(
+            size=cls._field_size_from_definition(
+                definition_message, FileIdTypeField.ID),
+            growable=False), 
+        FileIdManufacturerField(
+            size=cls._field_size_from_definition(
+                definition_message, FileIdManufacturerField.ID),
+            growable=False), 
+        FileIdProductField(
+            size=cls._field_size_from_definition(
+                definition_message, FileIdProductField.ID),
+            growable=False), 
+        FileIdSerialNumberField(
+            size=cls._field_size_from_definition(
+                definition_message, FileIdSerialNumberField.ID),
+            growable=False), 
+        FileIdTimeCreatedField(
+            size=cls._field_size_from_definition(
+                definition_message, FileIdTimeCreatedField.ID),
+            growable=False), 
+        FileIdNumberField(
+            size=cls._field_size_from_definition(
+                definition_message, FileIdNumberField.ID),
+            growable=False), 
+        FileIdProductNameField(
+            size=cls._field_size_from_definition(
+                definition_message, FileIdProductNameField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/goal_message.py
+++ b/fit_tool/profile/messages/goal_message.py
@@ -17,75 +17,154 @@ from typing import Dict as dict
 
 
 class GoalMessage(DataMessage):
+    """GoalMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``GoalMessage()`` — create path: growable fields, no wire definition.
+    * ``GoalMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 15
     NAME = 'goal'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=GoalMessage.NAME,
                          global_id=GoalMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         MessageIndexField(
-            size=self.__get_field_size(definition_message, MessageIndexField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         GoalSportField(
-            size=self.__get_field_size(definition_message, GoalSportField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         GoalSubSportField(
-            size=self.__get_field_size(definition_message, GoalSubSportField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         GoalStartDateField(
-            size=self.__get_field_size(definition_message, GoalStartDateField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         GoalEndDateField(
-            size=self.__get_field_size(definition_message, GoalEndDateField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         GoalTypeField(
-            size=self.__get_field_size(definition_message, GoalTypeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         GoalValueField(
-            size=self.__get_field_size(definition_message, GoalValueField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         GoalRepeatField(
-            size=self.__get_field_size(definition_message, GoalRepeatField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         GoalTargetValueField(
-            size=self.__get_field_size(definition_message, GoalTargetValueField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         GoalRecurrenceField(
-            size=self.__get_field_size(definition_message, GoalRecurrenceField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         GoalRecurrenceValueField(
-            size=self.__get_field_size(definition_message, GoalRecurrenceValueField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         GoalEnabledField(
-            size=self.__get_field_size(definition_message, GoalEnabledField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         GoalSourceField(
-            size=self.__get_field_size(definition_message, GoalSourceField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        MessageIndexField(
+            size=cls._field_size_from_definition(
+                definition_message, MessageIndexField.ID),
+            growable=False), 
+        GoalSportField(
+            size=cls._field_size_from_definition(
+                definition_message, GoalSportField.ID),
+            growable=False), 
+        GoalSubSportField(
+            size=cls._field_size_from_definition(
+                definition_message, GoalSubSportField.ID),
+            growable=False), 
+        GoalStartDateField(
+            size=cls._field_size_from_definition(
+                definition_message, GoalStartDateField.ID),
+            growable=False), 
+        GoalEndDateField(
+            size=cls._field_size_from_definition(
+                definition_message, GoalEndDateField.ID),
+            growable=False), 
+        GoalTypeField(
+            size=cls._field_size_from_definition(
+                definition_message, GoalTypeField.ID),
+            growable=False), 
+        GoalValueField(
+            size=cls._field_size_from_definition(
+                definition_message, GoalValueField.ID),
+            growable=False), 
+        GoalRepeatField(
+            size=cls._field_size_from_definition(
+                definition_message, GoalRepeatField.ID),
+            growable=False), 
+        GoalTargetValueField(
+            size=cls._field_size_from_definition(
+                definition_message, GoalTargetValueField.ID),
+            growable=False), 
+        GoalRecurrenceField(
+            size=cls._field_size_from_definition(
+                definition_message, GoalRecurrenceField.ID),
+            growable=False), 
+        GoalRecurrenceValueField(
+            size=cls._field_size_from_definition(
+                definition_message, GoalRecurrenceValueField.ID),
+            growable=False), 
+        GoalEnabledField(
+            size=cls._field_size_from_definition(
+                definition_message, GoalEnabledField.ID),
+            growable=False), 
+        GoalSourceField(
+            size=cls._field_size_from_definition(
+                definition_message, GoalSourceField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/gps_metadata_message.py
+++ b/fit_tool/profile/messages/gps_metadata_message.py
@@ -17,63 +17,126 @@ from typing import Dict as dict
 
 
 class GpsMetadataMessage(DataMessage):
+    """GpsMetadataMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``GpsMetadataMessage()`` — create path: growable fields, no wire definition.
+    * ``GpsMetadataMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 160
     NAME = 'gps_metadata'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=GpsMetadataMessage.NAME,
                          global_id=GpsMetadataMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         TimestampField(
-            size=self.__get_field_size(definition_message, TimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         GpsMetadataTimestampMsField(
-            size=self.__get_field_size(definition_message, GpsMetadataTimestampMsField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         GpsMetadataPositionLatField(
-            size=self.__get_field_size(definition_message, GpsMetadataPositionLatField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         GpsMetadataPositionLongField(
-            size=self.__get_field_size(definition_message, GpsMetadataPositionLongField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         GpsMetadataEnhancedAltitudeField(
-            size=self.__get_field_size(definition_message, GpsMetadataEnhancedAltitudeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         GpsMetadataEnhancedSpeedField(
-            size=self.__get_field_size(definition_message, GpsMetadataEnhancedSpeedField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         GpsMetadataHeadingField(
-            size=self.__get_field_size(definition_message, GpsMetadataHeadingField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         GpsMetadataUtcTimestampField(
-            size=self.__get_field_size(definition_message, GpsMetadataUtcTimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         GpsMetadataVelocityField(
-            size=self.__get_field_size(definition_message, GpsMetadataVelocityField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        TimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampField.ID),
+            growable=False), 
+        GpsMetadataTimestampMsField(
+            size=cls._field_size_from_definition(
+                definition_message, GpsMetadataTimestampMsField.ID),
+            growable=False), 
+        GpsMetadataPositionLatField(
+            size=cls._field_size_from_definition(
+                definition_message, GpsMetadataPositionLatField.ID),
+            growable=False), 
+        GpsMetadataPositionLongField(
+            size=cls._field_size_from_definition(
+                definition_message, GpsMetadataPositionLongField.ID),
+            growable=False), 
+        GpsMetadataEnhancedAltitudeField(
+            size=cls._field_size_from_definition(
+                definition_message, GpsMetadataEnhancedAltitudeField.ID),
+            growable=False), 
+        GpsMetadataEnhancedSpeedField(
+            size=cls._field_size_from_definition(
+                definition_message, GpsMetadataEnhancedSpeedField.ID),
+            growable=False), 
+        GpsMetadataHeadingField(
+            size=cls._field_size_from_definition(
+                definition_message, GpsMetadataHeadingField.ID),
+            growable=False), 
+        GpsMetadataUtcTimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, GpsMetadataUtcTimestampField.ID),
+            growable=False), 
+        GpsMetadataVelocityField(
+            size=cls._field_size_from_definition(
+                definition_message, GpsMetadataVelocityField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/gyroscope_data_message.py
+++ b/fit_tool/profile/messages/gyroscope_data_message.py
@@ -17,63 +17,126 @@ from typing import Dict as dict
 
 
 class GyroscopeDataMessage(DataMessage):
+    """GyroscopeDataMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``GyroscopeDataMessage()`` — create path: growable fields, no wire definition.
+    * ``GyroscopeDataMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 164
     NAME = 'gyroscope_data'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=GyroscopeDataMessage.NAME,
                          global_id=GyroscopeDataMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         TimestampField(
-            size=self.__get_field_size(definition_message, TimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         GyroscopeDataTimestampMsField(
-            size=self.__get_field_size(definition_message, GyroscopeDataTimestampMsField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         GyroscopeDataSampleTimeOffsetField(
-            size=self.__get_field_size(definition_message, GyroscopeDataSampleTimeOffsetField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         GyroscopeDataGyroXField(
-            size=self.__get_field_size(definition_message, GyroscopeDataGyroXField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         GyroscopeDataGyroYField(
-            size=self.__get_field_size(definition_message, GyroscopeDataGyroYField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         GyroscopeDataGyroZField(
-            size=self.__get_field_size(definition_message, GyroscopeDataGyroZField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         GyroscopeDataCalibratedGyroXField(
-            size=self.__get_field_size(definition_message, GyroscopeDataCalibratedGyroXField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         GyroscopeDataCalibratedGyroYField(
-            size=self.__get_field_size(definition_message, GyroscopeDataCalibratedGyroYField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         GyroscopeDataCalibratedGyroZField(
-            size=self.__get_field_size(definition_message, GyroscopeDataCalibratedGyroZField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        TimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampField.ID),
+            growable=False), 
+        GyroscopeDataTimestampMsField(
+            size=cls._field_size_from_definition(
+                definition_message, GyroscopeDataTimestampMsField.ID),
+            growable=False), 
+        GyroscopeDataSampleTimeOffsetField(
+            size=cls._field_size_from_definition(
+                definition_message, GyroscopeDataSampleTimeOffsetField.ID),
+            growable=False), 
+        GyroscopeDataGyroXField(
+            size=cls._field_size_from_definition(
+                definition_message, GyroscopeDataGyroXField.ID),
+            growable=False), 
+        GyroscopeDataGyroYField(
+            size=cls._field_size_from_definition(
+                definition_message, GyroscopeDataGyroYField.ID),
+            growable=False), 
+        GyroscopeDataGyroZField(
+            size=cls._field_size_from_definition(
+                definition_message, GyroscopeDataGyroZField.ID),
+            growable=False), 
+        GyroscopeDataCalibratedGyroXField(
+            size=cls._field_size_from_definition(
+                definition_message, GyroscopeDataCalibratedGyroXField.ID),
+            growable=False), 
+        GyroscopeDataCalibratedGyroYField(
+            size=cls._field_size_from_definition(
+                definition_message, GyroscopeDataCalibratedGyroYField.ID),
+            growable=False), 
+        GyroscopeDataCalibratedGyroZField(
+            size=cls._field_size_from_definition(
+                definition_message, GyroscopeDataCalibratedGyroZField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/hr_message.py
+++ b/fit_tool/profile/messages/hr_message.py
@@ -17,54 +17,105 @@ from typing import Dict as dict
 
 
 class HrMessage(DataMessage):
+    """HrMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``HrMessage()`` — create path: growable fields, no wire definition.
+    * ``HrMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 132
     NAME = 'hr'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=HrMessage.NAME,
                          global_id=HrMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         TimestampField(
-            size=self.__get_field_size(definition_message, TimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         HrFractionalTimestampField(
-            size=self.__get_field_size(definition_message, HrFractionalTimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         HrTime256Field(
-            size=self.__get_field_size(definition_message, HrTime256Field.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         HrFilteredBpmField(
-            size=self.__get_field_size(definition_message, HrFilteredBpmField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         HrEventTimestampField(
-            size=self.__get_field_size(definition_message, HrEventTimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         HrEventTimestamp12Field(
-            size=self.__get_field_size(definition_message, HrEventTimestamp12Field.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        TimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampField.ID),
+            growable=False), 
+        HrFractionalTimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, HrFractionalTimestampField.ID),
+            growable=False), 
+        HrTime256Field(
+            size=cls._field_size_from_definition(
+                definition_message, HrTime256Field.ID),
+            growable=False), 
+        HrFilteredBpmField(
+            size=cls._field_size_from_definition(
+                definition_message, HrFilteredBpmField.ID),
+            growable=False), 
+        HrEventTimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, HrEventTimestampField.ID),
+            growable=False), 
+        HrEventTimestamp12Field(
+            size=cls._field_size_from_definition(
+                definition_message, HrEventTimestamp12Field.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/hr_zone_message.py
+++ b/fit_tool/profile/messages/hr_zone_message.py
@@ -17,45 +17,84 @@ from typing import Dict as dict
 
 
 class HrZoneMessage(DataMessage):
+    """HrZoneMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``HrZoneMessage()`` — create path: growable fields, no wire definition.
+    * ``HrZoneMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 8
     NAME = 'hr_zone'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=HrZoneMessage.NAME,
                          global_id=HrZoneMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         MessageIndexField(
-            size=self.__get_field_size(definition_message, MessageIndexField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         HrZoneHighBpmField(
-            size=self.__get_field_size(definition_message, HrZoneHighBpmField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         HrZoneNameField(
-            size=self.__get_field_size(definition_message, HrZoneNameField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        MessageIndexField(
+            size=cls._field_size_from_definition(
+                definition_message, MessageIndexField.ID),
+            growable=False), 
+        HrZoneHighBpmField(
+            size=cls._field_size_from_definition(
+                definition_message, HrZoneHighBpmField.ID),
+            growable=False), 
+        HrZoneNameField(
+            size=cls._field_size_from_definition(
+                definition_message, HrZoneNameField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/hrm_profile_message.py
+++ b/fit_tool/profile/messages/hrm_profile_message.py
@@ -17,51 +17,98 @@ from typing import Dict as dict
 
 
 class HrmProfileMessage(DataMessage):
+    """HrmProfileMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``HrmProfileMessage()`` — create path: growable fields, no wire definition.
+    * ``HrmProfileMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 4
     NAME = 'hrm_profile'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=HrmProfileMessage.NAME,
                          global_id=HrmProfileMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         MessageIndexField(
-            size=self.__get_field_size(definition_message, MessageIndexField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         HrmProfileEnabledField(
-            size=self.__get_field_size(definition_message, HrmProfileEnabledField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         HrmProfileHrmAntIdField(
-            size=self.__get_field_size(definition_message, HrmProfileHrmAntIdField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         HrmProfileLogHrvField(
-            size=self.__get_field_size(definition_message, HrmProfileLogHrvField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         HrmProfileHrmAntIdTransTypeField(
-            size=self.__get_field_size(definition_message, HrmProfileHrmAntIdTransTypeField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        MessageIndexField(
+            size=cls._field_size_from_definition(
+                definition_message, MessageIndexField.ID),
+            growable=False), 
+        HrmProfileEnabledField(
+            size=cls._field_size_from_definition(
+                definition_message, HrmProfileEnabledField.ID),
+            growable=False), 
+        HrmProfileHrmAntIdField(
+            size=cls._field_size_from_definition(
+                definition_message, HrmProfileHrmAntIdField.ID),
+            growable=False), 
+        HrmProfileLogHrvField(
+            size=cls._field_size_from_definition(
+                definition_message, HrmProfileLogHrvField.ID),
+            growable=False), 
+        HrmProfileHrmAntIdTransTypeField(
+            size=cls._field_size_from_definition(
+                definition_message, HrmProfileHrmAntIdTransTypeField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/hrv_message.py
+++ b/fit_tool/profile/messages/hrv_message.py
@@ -17,39 +17,70 @@ from typing import Dict as dict
 
 
 class HrvMessage(DataMessage):
+    """HrvMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``HrvMessage()`` — create path: growable fields, no wire definition.
+    * ``HrvMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 78
     NAME = 'hrv'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=HrvMessage.NAME,
                          global_id=HrvMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         HrvTimeField(
-            size=self.__get_field_size(definition_message, HrvTimeField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        HrvTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, HrvTimeField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/hrv_status_summary_message.py
+++ b/fit_tool/profile/messages/hrv_status_summary_message.py
@@ -17,60 +17,119 @@ from typing import Dict as dict
 
 
 class HrvStatusSummaryMessage(DataMessage):
+    """HrvStatusSummaryMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``HrvStatusSummaryMessage()`` — create path: growable fields, no wire definition.
+    * ``HrvStatusSummaryMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 370
     NAME = 'hrv_status_summary'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=HrvStatusSummaryMessage.NAME,
                          global_id=HrvStatusSummaryMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         TimestampField(
-            size=self.__get_field_size(definition_message, TimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         HrvStatusSummaryWeeklyAverageField(
-            size=self.__get_field_size(definition_message, HrvStatusSummaryWeeklyAverageField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         HrvStatusSummaryLastNightAverageField(
-            size=self.__get_field_size(definition_message, HrvStatusSummaryLastNightAverageField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         HrvStatusSummaryLastNight5MinHighField(
-            size=self.__get_field_size(definition_message, HrvStatusSummaryLastNight5MinHighField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         HrvStatusSummaryBaselineLowUpperField(
-            size=self.__get_field_size(definition_message, HrvStatusSummaryBaselineLowUpperField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         HrvStatusSummaryBaselineBalancedLowerField(
-            size=self.__get_field_size(definition_message, HrvStatusSummaryBaselineBalancedLowerField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         HrvStatusSummaryBaselineBalancedUpperField(
-            size=self.__get_field_size(definition_message, HrvStatusSummaryBaselineBalancedUpperField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         HrvStatusSummaryStatusField(
-            size=self.__get_field_size(definition_message, HrvStatusSummaryStatusField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        TimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampField.ID),
+            growable=False), 
+        HrvStatusSummaryWeeklyAverageField(
+            size=cls._field_size_from_definition(
+                definition_message, HrvStatusSummaryWeeklyAverageField.ID),
+            growable=False), 
+        HrvStatusSummaryLastNightAverageField(
+            size=cls._field_size_from_definition(
+                definition_message, HrvStatusSummaryLastNightAverageField.ID),
+            growable=False), 
+        HrvStatusSummaryLastNight5MinHighField(
+            size=cls._field_size_from_definition(
+                definition_message, HrvStatusSummaryLastNight5MinHighField.ID),
+            growable=False), 
+        HrvStatusSummaryBaselineLowUpperField(
+            size=cls._field_size_from_definition(
+                definition_message, HrvStatusSummaryBaselineLowUpperField.ID),
+            growable=False), 
+        HrvStatusSummaryBaselineBalancedLowerField(
+            size=cls._field_size_from_definition(
+                definition_message, HrvStatusSummaryBaselineBalancedLowerField.ID),
+            growable=False), 
+        HrvStatusSummaryBaselineBalancedUpperField(
+            size=cls._field_size_from_definition(
+                definition_message, HrvStatusSummaryBaselineBalancedUpperField.ID),
+            growable=False), 
+        HrvStatusSummaryStatusField(
+            size=cls._field_size_from_definition(
+                definition_message, HrvStatusSummaryStatusField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/hrv_value_message.py
+++ b/fit_tool/profile/messages/hrv_value_message.py
@@ -17,42 +17,77 @@ from typing import Dict as dict
 
 
 class HrvValueMessage(DataMessage):
+    """HrvValueMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``HrvValueMessage()`` — create path: growable fields, no wire definition.
+    * ``HrvValueMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 371
     NAME = 'hrv_value'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=HrvValueMessage.NAME,
                          global_id=HrvValueMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         TimestampField(
-            size=self.__get_field_size(definition_message, TimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         HrvValueValueField(
-            size=self.__get_field_size(definition_message, HrvValueValueField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        TimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampField.ID),
+            growable=False), 
+        HrvValueValueField(
+            size=cls._field_size_from_definition(
+                definition_message, HrvValueValueField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/hsa_accelerometer_data_message.py
+++ b/fit_tool/profile/messages/hsa_accelerometer_data_message.py
@@ -17,57 +17,112 @@ from typing import Dict as dict
 
 
 class HsaAccelerometerDataMessage(DataMessage):
+    """HsaAccelerometerDataMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``HsaAccelerometerDataMessage()`` — create path: growable fields, no wire definition.
+    * ``HsaAccelerometerDataMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 302
     NAME = 'hsa_accelerometer_data'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=HsaAccelerometerDataMessage.NAME,
                          global_id=HsaAccelerometerDataMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         TimestampField(
-            size=self.__get_field_size(definition_message, TimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         HsaAccelerometerDataTimestampMsField(
-            size=self.__get_field_size(definition_message, HsaAccelerometerDataTimestampMsField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         HsaAccelerometerDataSamplingIntervalField(
-            size=self.__get_field_size(definition_message, HsaAccelerometerDataSamplingIntervalField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         HsaAccelerometerDataAccelXField(
-            size=self.__get_field_size(definition_message, HsaAccelerometerDataAccelXField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         HsaAccelerometerDataAccelYField(
-            size=self.__get_field_size(definition_message, HsaAccelerometerDataAccelYField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         HsaAccelerometerDataAccelZField(
-            size=self.__get_field_size(definition_message, HsaAccelerometerDataAccelZField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         HsaAccelerometerDataTimestamp32kField(
-            size=self.__get_field_size(definition_message, HsaAccelerometerDataTimestamp32kField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        TimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampField.ID),
+            growable=False), 
+        HsaAccelerometerDataTimestampMsField(
+            size=cls._field_size_from_definition(
+                definition_message, HsaAccelerometerDataTimestampMsField.ID),
+            growable=False), 
+        HsaAccelerometerDataSamplingIntervalField(
+            size=cls._field_size_from_definition(
+                definition_message, HsaAccelerometerDataSamplingIntervalField.ID),
+            growable=False), 
+        HsaAccelerometerDataAccelXField(
+            size=cls._field_size_from_definition(
+                definition_message, HsaAccelerometerDataAccelXField.ID),
+            growable=False), 
+        HsaAccelerometerDataAccelYField(
+            size=cls._field_size_from_definition(
+                definition_message, HsaAccelerometerDataAccelYField.ID),
+            growable=False), 
+        HsaAccelerometerDataAccelZField(
+            size=cls._field_size_from_definition(
+                definition_message, HsaAccelerometerDataAccelZField.ID),
+            growable=False), 
+        HsaAccelerometerDataTimestamp32kField(
+            size=cls._field_size_from_definition(
+                definition_message, HsaAccelerometerDataTimestamp32kField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/hsa_body_battery_data_message.py
+++ b/fit_tool/profile/messages/hsa_body_battery_data_message.py
@@ -17,51 +17,98 @@ from typing import Dict as dict
 
 
 class HsaBodyBatteryDataMessage(DataMessage):
+    """HsaBodyBatteryDataMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``HsaBodyBatteryDataMessage()`` — create path: growable fields, no wire definition.
+    * ``HsaBodyBatteryDataMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 314
     NAME = 'hsa_body_battery_data'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=HsaBodyBatteryDataMessage.NAME,
                          global_id=HsaBodyBatteryDataMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         TimestampField(
-            size=self.__get_field_size(definition_message, TimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         HsaBodyBatteryDataProcessingIntervalField(
-            size=self.__get_field_size(definition_message, HsaBodyBatteryDataProcessingIntervalField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         HsaBodyBatteryDataLevelField(
-            size=self.__get_field_size(definition_message, HsaBodyBatteryDataLevelField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         HsaBodyBatteryDataChargedField(
-            size=self.__get_field_size(definition_message, HsaBodyBatteryDataChargedField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         HsaBodyBatteryDataUnchargedField(
-            size=self.__get_field_size(definition_message, HsaBodyBatteryDataUnchargedField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        TimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampField.ID),
+            growable=False), 
+        HsaBodyBatteryDataProcessingIntervalField(
+            size=cls._field_size_from_definition(
+                definition_message, HsaBodyBatteryDataProcessingIntervalField.ID),
+            growable=False), 
+        HsaBodyBatteryDataLevelField(
+            size=cls._field_size_from_definition(
+                definition_message, HsaBodyBatteryDataLevelField.ID),
+            growable=False), 
+        HsaBodyBatteryDataChargedField(
+            size=cls._field_size_from_definition(
+                definition_message, HsaBodyBatteryDataChargedField.ID),
+            growable=False), 
+        HsaBodyBatteryDataUnchargedField(
+            size=cls._field_size_from_definition(
+                definition_message, HsaBodyBatteryDataUnchargedField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/hsa_configuration_data_message.py
+++ b/fit_tool/profile/messages/hsa_configuration_data_message.py
@@ -17,45 +17,84 @@ from typing import Dict as dict
 
 
 class HsaConfigurationDataMessage(DataMessage):
+    """HsaConfigurationDataMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``HsaConfigurationDataMessage()`` — create path: growable fields, no wire definition.
+    * ``HsaConfigurationDataMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 389
     NAME = 'hsa_configuration_data'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=HsaConfigurationDataMessage.NAME,
                          global_id=HsaConfigurationDataMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         TimestampField(
-            size=self.__get_field_size(definition_message, TimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         HsaConfigurationDataDataField(
-            size=self.__get_field_size(definition_message, HsaConfigurationDataDataField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         HsaConfigurationDataDataSizeField(
-            size=self.__get_field_size(definition_message, HsaConfigurationDataDataSizeField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        TimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampField.ID),
+            growable=False), 
+        HsaConfigurationDataDataField(
+            size=cls._field_size_from_definition(
+                definition_message, HsaConfigurationDataDataField.ID),
+            growable=False), 
+        HsaConfigurationDataDataSizeField(
+            size=cls._field_size_from_definition(
+                definition_message, HsaConfigurationDataDataSizeField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/hsa_event_message.py
+++ b/fit_tool/profile/messages/hsa_event_message.py
@@ -17,42 +17,77 @@ from typing import Dict as dict
 
 
 class HsaEventMessage(DataMessage):
+    """HsaEventMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``HsaEventMessage()`` — create path: growable fields, no wire definition.
+    * ``HsaEventMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 315
     NAME = 'hsa_event'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=HsaEventMessage.NAME,
                          global_id=HsaEventMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         TimestampField(
-            size=self.__get_field_size(definition_message, TimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         HsaEventEventIdField(
-            size=self.__get_field_size(definition_message, HsaEventEventIdField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        TimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampField.ID),
+            growable=False), 
+        HsaEventEventIdField(
+            size=cls._field_size_from_definition(
+                definition_message, HsaEventEventIdField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/hsa_gyroscope_data_message.py
+++ b/fit_tool/profile/messages/hsa_gyroscope_data_message.py
@@ -17,57 +17,112 @@ from typing import Dict as dict
 
 
 class HsaGyroscopeDataMessage(DataMessage):
+    """HsaGyroscopeDataMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``HsaGyroscopeDataMessage()`` — create path: growable fields, no wire definition.
+    * ``HsaGyroscopeDataMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 376
     NAME = 'hsa_gyroscope_data'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=HsaGyroscopeDataMessage.NAME,
                          global_id=HsaGyroscopeDataMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         TimestampField(
-            size=self.__get_field_size(definition_message, TimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         HsaGyroscopeDataTimestampMsField(
-            size=self.__get_field_size(definition_message, HsaGyroscopeDataTimestampMsField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         HsaGyroscopeDataSamplingIntervalField(
-            size=self.__get_field_size(definition_message, HsaGyroscopeDataSamplingIntervalField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         HsaGyroscopeDataGyroXField(
-            size=self.__get_field_size(definition_message, HsaGyroscopeDataGyroXField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         HsaGyroscopeDataGyroYField(
-            size=self.__get_field_size(definition_message, HsaGyroscopeDataGyroYField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         HsaGyroscopeDataGyroZField(
-            size=self.__get_field_size(definition_message, HsaGyroscopeDataGyroZField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         HsaGyroscopeDataTimestamp32kField(
-            size=self.__get_field_size(definition_message, HsaGyroscopeDataTimestamp32kField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        TimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampField.ID),
+            growable=False), 
+        HsaGyroscopeDataTimestampMsField(
+            size=cls._field_size_from_definition(
+                definition_message, HsaGyroscopeDataTimestampMsField.ID),
+            growable=False), 
+        HsaGyroscopeDataSamplingIntervalField(
+            size=cls._field_size_from_definition(
+                definition_message, HsaGyroscopeDataSamplingIntervalField.ID),
+            growable=False), 
+        HsaGyroscopeDataGyroXField(
+            size=cls._field_size_from_definition(
+                definition_message, HsaGyroscopeDataGyroXField.ID),
+            growable=False), 
+        HsaGyroscopeDataGyroYField(
+            size=cls._field_size_from_definition(
+                definition_message, HsaGyroscopeDataGyroYField.ID),
+            growable=False), 
+        HsaGyroscopeDataGyroZField(
+            size=cls._field_size_from_definition(
+                definition_message, HsaGyroscopeDataGyroZField.ID),
+            growable=False), 
+        HsaGyroscopeDataTimestamp32kField(
+            size=cls._field_size_from_definition(
+                definition_message, HsaGyroscopeDataTimestamp32kField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/hsa_heart_rate_data_message.py
+++ b/fit_tool/profile/messages/hsa_heart_rate_data_message.py
@@ -17,48 +17,91 @@ from typing import Dict as dict
 
 
 class HsaHeartRateDataMessage(DataMessage):
+    """HsaHeartRateDataMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``HsaHeartRateDataMessage()`` — create path: growable fields, no wire definition.
+    * ``HsaHeartRateDataMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 308
     NAME = 'hsa_heart_rate_data'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=HsaHeartRateDataMessage.NAME,
                          global_id=HsaHeartRateDataMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         TimestampField(
-            size=self.__get_field_size(definition_message, TimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         HsaHeartRateDataProcessingIntervalField(
-            size=self.__get_field_size(definition_message, HsaHeartRateDataProcessingIntervalField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         HsaHeartRateDataStatusField(
-            size=self.__get_field_size(definition_message, HsaHeartRateDataStatusField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         HsaHeartRateDataHeartRateField(
-            size=self.__get_field_size(definition_message, HsaHeartRateDataHeartRateField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        TimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampField.ID),
+            growable=False), 
+        HsaHeartRateDataProcessingIntervalField(
+            size=cls._field_size_from_definition(
+                definition_message, HsaHeartRateDataProcessingIntervalField.ID),
+            growable=False), 
+        HsaHeartRateDataStatusField(
+            size=cls._field_size_from_definition(
+                definition_message, HsaHeartRateDataStatusField.ID),
+            growable=False), 
+        HsaHeartRateDataHeartRateField(
+            size=cls._field_size_from_definition(
+                definition_message, HsaHeartRateDataHeartRateField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/hsa_respiration_data_message.py
+++ b/fit_tool/profile/messages/hsa_respiration_data_message.py
@@ -17,45 +17,84 @@ from typing import Dict as dict
 
 
 class HsaRespirationDataMessage(DataMessage):
+    """HsaRespirationDataMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``HsaRespirationDataMessage()`` — create path: growable fields, no wire definition.
+    * ``HsaRespirationDataMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 307
     NAME = 'hsa_respiration_data'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=HsaRespirationDataMessage.NAME,
                          global_id=HsaRespirationDataMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         TimestampField(
-            size=self.__get_field_size(definition_message, TimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         HsaRespirationDataProcessingIntervalField(
-            size=self.__get_field_size(definition_message, HsaRespirationDataProcessingIntervalField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         HsaRespirationDataRespirationRateField(
-            size=self.__get_field_size(definition_message, HsaRespirationDataRespirationRateField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        TimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampField.ID),
+            growable=False), 
+        HsaRespirationDataProcessingIntervalField(
+            size=cls._field_size_from_definition(
+                definition_message, HsaRespirationDataProcessingIntervalField.ID),
+            growable=False), 
+        HsaRespirationDataRespirationRateField(
+            size=cls._field_size_from_definition(
+                definition_message, HsaRespirationDataRespirationRateField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/hsa_spo2_data_message.py
+++ b/fit_tool/profile/messages/hsa_spo2_data_message.py
@@ -17,48 +17,91 @@ from typing import Dict as dict
 
 
 class HsaSpo2DataMessage(DataMessage):
+    """HsaSpo2DataMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``HsaSpo2DataMessage()`` — create path: growable fields, no wire definition.
+    * ``HsaSpo2DataMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 305
     NAME = 'hsa_spo2_data'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=HsaSpo2DataMessage.NAME,
                          global_id=HsaSpo2DataMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         TimestampField(
-            size=self.__get_field_size(definition_message, TimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         HsaSpo2DataProcessingIntervalField(
-            size=self.__get_field_size(definition_message, HsaSpo2DataProcessingIntervalField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         HsaSpo2DataReadingSpo2Field(
-            size=self.__get_field_size(definition_message, HsaSpo2DataReadingSpo2Field.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         HsaSpo2DataConfidenceField(
-            size=self.__get_field_size(definition_message, HsaSpo2DataConfidenceField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        TimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampField.ID),
+            growable=False), 
+        HsaSpo2DataProcessingIntervalField(
+            size=cls._field_size_from_definition(
+                definition_message, HsaSpo2DataProcessingIntervalField.ID),
+            growable=False), 
+        HsaSpo2DataReadingSpo2Field(
+            size=cls._field_size_from_definition(
+                definition_message, HsaSpo2DataReadingSpo2Field.ID),
+            growable=False), 
+        HsaSpo2DataConfidenceField(
+            size=cls._field_size_from_definition(
+                definition_message, HsaSpo2DataConfidenceField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/hsa_step_data_message.py
+++ b/fit_tool/profile/messages/hsa_step_data_message.py
@@ -17,45 +17,84 @@ from typing import Dict as dict
 
 
 class HsaStepDataMessage(DataMessage):
+    """HsaStepDataMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``HsaStepDataMessage()`` — create path: growable fields, no wire definition.
+    * ``HsaStepDataMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 304
     NAME = 'hsa_step_data'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=HsaStepDataMessage.NAME,
                          global_id=HsaStepDataMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         TimestampField(
-            size=self.__get_field_size(definition_message, TimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         HsaStepDataProcessingIntervalField(
-            size=self.__get_field_size(definition_message, HsaStepDataProcessingIntervalField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         HsaStepDataStepsField(
-            size=self.__get_field_size(definition_message, HsaStepDataStepsField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        TimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampField.ID),
+            growable=False), 
+        HsaStepDataProcessingIntervalField(
+            size=cls._field_size_from_definition(
+                definition_message, HsaStepDataProcessingIntervalField.ID),
+            growable=False), 
+        HsaStepDataStepsField(
+            size=cls._field_size_from_definition(
+                definition_message, HsaStepDataStepsField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/hsa_stress_data_message.py
+++ b/fit_tool/profile/messages/hsa_stress_data_message.py
@@ -17,45 +17,84 @@ from typing import Dict as dict
 
 
 class HsaStressDataMessage(DataMessage):
+    """HsaStressDataMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``HsaStressDataMessage()`` — create path: growable fields, no wire definition.
+    * ``HsaStressDataMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 306
     NAME = 'hsa_stress_data'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=HsaStressDataMessage.NAME,
                          global_id=HsaStressDataMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         TimestampField(
-            size=self.__get_field_size(definition_message, TimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         HsaStressDataProcessingIntervalField(
-            size=self.__get_field_size(definition_message, HsaStressDataProcessingIntervalField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         HsaStressDataStressLevelField(
-            size=self.__get_field_size(definition_message, HsaStressDataStressLevelField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        TimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampField.ID),
+            growable=False), 
+        HsaStressDataProcessingIntervalField(
+            size=cls._field_size_from_definition(
+                definition_message, HsaStressDataProcessingIntervalField.ID),
+            growable=False), 
+        HsaStressDataStressLevelField(
+            size=cls._field_size_from_definition(
+                definition_message, HsaStressDataStressLevelField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/hsa_wrist_temperature_data_message.py
+++ b/fit_tool/profile/messages/hsa_wrist_temperature_data_message.py
@@ -17,45 +17,84 @@ from typing import Dict as dict
 
 
 class HsaWristTemperatureDataMessage(DataMessage):
+    """HsaWristTemperatureDataMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``HsaWristTemperatureDataMessage()`` — create path: growable fields, no wire definition.
+    * ``HsaWristTemperatureDataMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 409
     NAME = 'hsa_wrist_temperature_data'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=HsaWristTemperatureDataMessage.NAME,
                          global_id=HsaWristTemperatureDataMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         TimestampField(
-            size=self.__get_field_size(definition_message, TimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         HsaWristTemperatureDataProcessingIntervalField(
-            size=self.__get_field_size(definition_message, HsaWristTemperatureDataProcessingIntervalField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         HsaWristTemperatureDataValueField(
-            size=self.__get_field_size(definition_message, HsaWristTemperatureDataValueField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        TimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampField.ID),
+            growable=False), 
+        HsaWristTemperatureDataProcessingIntervalField(
+            size=cls._field_size_from_definition(
+                definition_message, HsaWristTemperatureDataProcessingIntervalField.ID),
+            growable=False), 
+        HsaWristTemperatureDataValueField(
+            size=cls._field_size_from_definition(
+                definition_message, HsaWristTemperatureDataValueField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/jump_message.py
+++ b/fit_tool/profile/messages/jump_message.py
@@ -17,66 +17,133 @@ from typing import Dict as dict
 
 
 class JumpMessage(DataMessage):
+    """JumpMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``JumpMessage()`` — create path: growable fields, no wire definition.
+    * ``JumpMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 285
     NAME = 'jump'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=JumpMessage.NAME,
                          global_id=JumpMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         TimestampField(
-            size=self.__get_field_size(definition_message, TimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         JumpDistanceField(
-            size=self.__get_field_size(definition_message, JumpDistanceField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         JumpHeightField(
-            size=self.__get_field_size(definition_message, JumpHeightField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         JumpRotationsField(
-            size=self.__get_field_size(definition_message, JumpRotationsField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         JumpHangTimeField(
-            size=self.__get_field_size(definition_message, JumpHangTimeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         JumpScoreField(
-            size=self.__get_field_size(definition_message, JumpScoreField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         JumpPositionLatField(
-            size=self.__get_field_size(definition_message, JumpPositionLatField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         JumpPositionLongField(
-            size=self.__get_field_size(definition_message, JumpPositionLongField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         JumpSpeedField(
-            size=self.__get_field_size(definition_message, JumpSpeedField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         JumpEnhancedSpeedField(
-            size=self.__get_field_size(definition_message, JumpEnhancedSpeedField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        TimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampField.ID),
+            growable=False), 
+        JumpDistanceField(
+            size=cls._field_size_from_definition(
+                definition_message, JumpDistanceField.ID),
+            growable=False), 
+        JumpHeightField(
+            size=cls._field_size_from_definition(
+                definition_message, JumpHeightField.ID),
+            growable=False), 
+        JumpRotationsField(
+            size=cls._field_size_from_definition(
+                definition_message, JumpRotationsField.ID),
+            growable=False), 
+        JumpHangTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, JumpHangTimeField.ID),
+            growable=False), 
+        JumpScoreField(
+            size=cls._field_size_from_definition(
+                definition_message, JumpScoreField.ID),
+            growable=False), 
+        JumpPositionLatField(
+            size=cls._field_size_from_definition(
+                definition_message, JumpPositionLatField.ID),
+            growable=False), 
+        JumpPositionLongField(
+            size=cls._field_size_from_definition(
+                definition_message, JumpPositionLongField.ID),
+            growable=False), 
+        JumpSpeedField(
+            size=cls._field_size_from_definition(
+                definition_message, JumpSpeedField.ID),
+            growable=False), 
+        JumpEnhancedSpeedField(
+            size=cls._field_size_from_definition(
+                definition_message, JumpEnhancedSpeedField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/lap_message.py
+++ b/fit_tool/profile/messages/lap_message.py
@@ -17,408 +17,931 @@ from typing import Dict as dict
 
 
 class LapMessage(DataMessage):
+    """LapMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``LapMessage()`` — create path: growable fields, no wire definition.
+    * ``LapMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 19
     NAME = 'lap'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=LapMessage.NAME,
                          global_id=LapMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         MessageIndexField(
-            size=self.__get_field_size(definition_message, MessageIndexField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         TimestampField(
-            size=self.__get_field_size(definition_message, TimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapEventField(
-            size=self.__get_field_size(definition_message, LapEventField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapEventTypeField(
-            size=self.__get_field_size(definition_message, LapEventTypeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapStartTimeField(
-            size=self.__get_field_size(definition_message, LapStartTimeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapStartPositionLatField(
-            size=self.__get_field_size(definition_message, LapStartPositionLatField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapStartPositionLongField(
-            size=self.__get_field_size(definition_message, LapStartPositionLongField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapEndPositionLatField(
-            size=self.__get_field_size(definition_message, LapEndPositionLatField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapEndPositionLongField(
-            size=self.__get_field_size(definition_message, LapEndPositionLongField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapTotalElapsedTimeField(
-            size=self.__get_field_size(definition_message, LapTotalElapsedTimeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapTotalTimerTimeField(
-            size=self.__get_field_size(definition_message, LapTotalTimerTimeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapTotalDistanceField(
-            size=self.__get_field_size(definition_message, LapTotalDistanceField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapTotalCyclesField(
-            size=self.__get_field_size(definition_message, LapTotalCyclesField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapTotalCaloriesField(
-            size=self.__get_field_size(definition_message, LapTotalCaloriesField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapTotalFatCaloriesField(
-            size=self.__get_field_size(definition_message, LapTotalFatCaloriesField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapAvgSpeedField(
-            size=self.__get_field_size(definition_message, LapAvgSpeedField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapMaxSpeedField(
-            size=self.__get_field_size(definition_message, LapMaxSpeedField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapAvgHeartRateField(
-            size=self.__get_field_size(definition_message, LapAvgHeartRateField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapMaxHeartRateField(
-            size=self.__get_field_size(definition_message, LapMaxHeartRateField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapAvgCadenceField(
-            size=self.__get_field_size(definition_message, LapAvgCadenceField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapMaxCadenceField(
-            size=self.__get_field_size(definition_message, LapMaxCadenceField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapAvgPowerField(
-            size=self.__get_field_size(definition_message, LapAvgPowerField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapMaxPowerField(
-            size=self.__get_field_size(definition_message, LapMaxPowerField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapTotalAscentField(
-            size=self.__get_field_size(definition_message, LapTotalAscentField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapTotalDescentField(
-            size=self.__get_field_size(definition_message, LapTotalDescentField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapIntensityField(
-            size=self.__get_field_size(definition_message, LapIntensityField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapLapTriggerField(
-            size=self.__get_field_size(definition_message, LapLapTriggerField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapSportField(
-            size=self.__get_field_size(definition_message, LapSportField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapEventGroupField(
-            size=self.__get_field_size(definition_message, LapEventGroupField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapNumLengthsField(
-            size=self.__get_field_size(definition_message, LapNumLengthsField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapNormalizedPowerField(
-            size=self.__get_field_size(definition_message, LapNormalizedPowerField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapLeftRightBalanceField(
-            size=self.__get_field_size(definition_message, LapLeftRightBalanceField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapFirstLengthIndexField(
-            size=self.__get_field_size(definition_message, LapFirstLengthIndexField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapAvgStrokeDistanceField(
-            size=self.__get_field_size(definition_message, LapAvgStrokeDistanceField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapSwimStrokeField(
-            size=self.__get_field_size(definition_message, LapSwimStrokeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapSubSportField(
-            size=self.__get_field_size(definition_message, LapSubSportField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapNumActiveLengthsField(
-            size=self.__get_field_size(definition_message, LapNumActiveLengthsField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapTotalWorkField(
-            size=self.__get_field_size(definition_message, LapTotalWorkField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapAvgAltitudeField(
-            size=self.__get_field_size(definition_message, LapAvgAltitudeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapMaxAltitudeField(
-            size=self.__get_field_size(definition_message, LapMaxAltitudeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapGpsAccuracyField(
-            size=self.__get_field_size(definition_message, LapGpsAccuracyField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapAvgGradeField(
-            size=self.__get_field_size(definition_message, LapAvgGradeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapAvgPosGradeField(
-            size=self.__get_field_size(definition_message, LapAvgPosGradeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapAvgNegGradeField(
-            size=self.__get_field_size(definition_message, LapAvgNegGradeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapMaxPosGradeField(
-            size=self.__get_field_size(definition_message, LapMaxPosGradeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapMaxNegGradeField(
-            size=self.__get_field_size(definition_message, LapMaxNegGradeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapAvgTemperatureField(
-            size=self.__get_field_size(definition_message, LapAvgTemperatureField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapMaxTemperatureField(
-            size=self.__get_field_size(definition_message, LapMaxTemperatureField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapTotalMovingTimeField(
-            size=self.__get_field_size(definition_message, LapTotalMovingTimeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapAvgPosVerticalSpeedField(
-            size=self.__get_field_size(definition_message, LapAvgPosVerticalSpeedField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapAvgNegVerticalSpeedField(
-            size=self.__get_field_size(definition_message, LapAvgNegVerticalSpeedField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapMaxPosVerticalSpeedField(
-            size=self.__get_field_size(definition_message, LapMaxPosVerticalSpeedField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapMaxNegVerticalSpeedField(
-            size=self.__get_field_size(definition_message, LapMaxNegVerticalSpeedField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapTimeInHrZoneField(
-            size=self.__get_field_size(definition_message, LapTimeInHrZoneField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapTimeInSpeedZoneField(
-            size=self.__get_field_size(definition_message, LapTimeInSpeedZoneField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapTimeInCadenceZoneField(
-            size=self.__get_field_size(definition_message, LapTimeInCadenceZoneField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapTimeInPowerZoneField(
-            size=self.__get_field_size(definition_message, LapTimeInPowerZoneField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapRepetitionNumField(
-            size=self.__get_field_size(definition_message, LapRepetitionNumField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapMinAltitudeField(
-            size=self.__get_field_size(definition_message, LapMinAltitudeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapMinHeartRateField(
-            size=self.__get_field_size(definition_message, LapMinHeartRateField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapActiveTimeField(
-            size=self.__get_field_size(definition_message, LapActiveTimeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapWorkoutStepIndexField(
-            size=self.__get_field_size(definition_message, LapWorkoutStepIndexField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapOpponentScoreField(
-            size=self.__get_field_size(definition_message, LapOpponentScoreField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapStrokeCountField(
-            size=self.__get_field_size(definition_message, LapStrokeCountField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapZoneCountField(
-            size=self.__get_field_size(definition_message, LapZoneCountField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapAvgVerticalOscillationField(
-            size=self.__get_field_size(definition_message, LapAvgVerticalOscillationField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapAvgStanceTimePercentField(
-            size=self.__get_field_size(definition_message, LapAvgStanceTimePercentField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapAvgStanceTimeField(
-            size=self.__get_field_size(definition_message, LapAvgStanceTimeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapAvgFractionalCadenceField(
-            size=self.__get_field_size(definition_message, LapAvgFractionalCadenceField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapMaxFractionalCadenceField(
-            size=self.__get_field_size(definition_message, LapMaxFractionalCadenceField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapTotalFractionalCyclesField(
-            size=self.__get_field_size(definition_message, LapTotalFractionalCyclesField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapPlayerScoreField(
-            size=self.__get_field_size(definition_message, LapPlayerScoreField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapAvgTotalHemoglobinConcField(
-            size=self.__get_field_size(definition_message, LapAvgTotalHemoglobinConcField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapMinTotalHemoglobinConcField(
-            size=self.__get_field_size(definition_message, LapMinTotalHemoglobinConcField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapMaxTotalHemoglobinConcField(
-            size=self.__get_field_size(definition_message, LapMaxTotalHemoglobinConcField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapAvgSaturatedHemoglobinPercentField(
-            size=self.__get_field_size(definition_message, LapAvgSaturatedHemoglobinPercentField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapMinSaturatedHemoglobinPercentField(
-            size=self.__get_field_size(definition_message, LapMinSaturatedHemoglobinPercentField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapMaxSaturatedHemoglobinPercentField(
-            size=self.__get_field_size(definition_message, LapMaxSaturatedHemoglobinPercentField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapAvgLeftTorqueEffectivenessField(
-            size=self.__get_field_size(definition_message, LapAvgLeftTorqueEffectivenessField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapAvgRightTorqueEffectivenessField(
-            size=self.__get_field_size(definition_message, LapAvgRightTorqueEffectivenessField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapAvgLeftPedalSmoothnessField(
-            size=self.__get_field_size(definition_message, LapAvgLeftPedalSmoothnessField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapAvgRightPedalSmoothnessField(
-            size=self.__get_field_size(definition_message, LapAvgRightPedalSmoothnessField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapAvgCombinedPedalSmoothnessField(
-            size=self.__get_field_size(definition_message, LapAvgCombinedPedalSmoothnessField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapTimeStandingField(
-            size=self.__get_field_size(definition_message, LapTimeStandingField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapStandCountField(
-            size=self.__get_field_size(definition_message, LapStandCountField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapAvgLeftPcoField(
-            size=self.__get_field_size(definition_message, LapAvgLeftPcoField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapAvgRightPcoField(
-            size=self.__get_field_size(definition_message, LapAvgRightPcoField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapAvgLeftPowerPhaseField(
-            size=self.__get_field_size(definition_message, LapAvgLeftPowerPhaseField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapAvgLeftPowerPhasePeakField(
-            size=self.__get_field_size(definition_message, LapAvgLeftPowerPhasePeakField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapAvgRightPowerPhaseField(
-            size=self.__get_field_size(definition_message, LapAvgRightPowerPhaseField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapAvgRightPowerPhasePeakField(
-            size=self.__get_field_size(definition_message, LapAvgRightPowerPhasePeakField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapAvgPowerPositionField(
-            size=self.__get_field_size(definition_message, LapAvgPowerPositionField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapMaxPowerPositionField(
-            size=self.__get_field_size(definition_message, LapMaxPowerPositionField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapAvgCadencePositionField(
-            size=self.__get_field_size(definition_message, LapAvgCadencePositionField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapMaxCadencePositionField(
-            size=self.__get_field_size(definition_message, LapMaxCadencePositionField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapEnhancedAvgSpeedField(
-            size=self.__get_field_size(definition_message, LapEnhancedAvgSpeedField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapEnhancedMaxSpeedField(
-            size=self.__get_field_size(definition_message, LapEnhancedMaxSpeedField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapEnhancedAvgAltitudeField(
-            size=self.__get_field_size(definition_message, LapEnhancedAvgAltitudeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapEnhancedMinAltitudeField(
-            size=self.__get_field_size(definition_message, LapEnhancedMinAltitudeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapEnhancedMaxAltitudeField(
-            size=self.__get_field_size(definition_message, LapEnhancedMaxAltitudeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapAvgLevMotorPowerField(
-            size=self.__get_field_size(definition_message, LapAvgLevMotorPowerField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapMaxLevMotorPowerField(
-            size=self.__get_field_size(definition_message, LapMaxLevMotorPowerField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapLevBatteryConsumptionField(
-            size=self.__get_field_size(definition_message, LapLevBatteryConsumptionField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapAvgVerticalRatioField(
-            size=self.__get_field_size(definition_message, LapAvgVerticalRatioField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapAvgStanceTimeBalanceField(
-            size=self.__get_field_size(definition_message, LapAvgStanceTimeBalanceField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapAvgStepLengthField(
-            size=self.__get_field_size(definition_message, LapAvgStepLengthField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapAvgVamField(
-            size=self.__get_field_size(definition_message, LapAvgVamField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapAvgDepthField(
-            size=self.__get_field_size(definition_message, LapAvgDepthField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapMaxDepthField(
-            size=self.__get_field_size(definition_message, LapMaxDepthField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapMinTemperatureField(
-            size=self.__get_field_size(definition_message, LapMinTemperatureField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapEnhancedAvgRespirationRateField(
-            size=self.__get_field_size(definition_message, LapEnhancedAvgRespirationRateField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapEnhancedMaxRespirationRateField(
-            size=self.__get_field_size(definition_message, LapEnhancedMaxRespirationRateField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapAvgRespirationRateField(
-            size=self.__get_field_size(definition_message, LapAvgRespirationRateField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapMaxRespirationRateField(
-            size=self.__get_field_size(definition_message, LapMaxRespirationRateField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapTotalGritField(
-            size=self.__get_field_size(definition_message, LapTotalGritField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapTotalFlowField(
-            size=self.__get_field_size(definition_message, LapTotalFlowField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapJumpCountField(
-            size=self.__get_field_size(definition_message, LapJumpCountField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapAvgGritField(
-            size=self.__get_field_size(definition_message, LapAvgGritField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapAvgFlowField(
-            size=self.__get_field_size(definition_message, LapAvgFlowField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapTotalFractionalAscentField(
-            size=self.__get_field_size(definition_message, LapTotalFractionalAscentField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapTotalFractionalDescentField(
-            size=self.__get_field_size(definition_message, LapTotalFractionalDescentField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapAvgCoreTemperatureField(
-            size=self.__get_field_size(definition_message, LapAvgCoreTemperatureField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapMinCoreTemperatureField(
-            size=self.__get_field_size(definition_message, LapMinCoreTemperatureField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LapMaxCoreTemperatureField(
-            size=self.__get_field_size(definition_message, LapMaxCoreTemperatureField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        MessageIndexField(
+            size=cls._field_size_from_definition(
+                definition_message, MessageIndexField.ID),
+            growable=False), 
+        TimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampField.ID),
+            growable=False), 
+        LapEventField(
+            size=cls._field_size_from_definition(
+                definition_message, LapEventField.ID),
+            growable=False), 
+        LapEventTypeField(
+            size=cls._field_size_from_definition(
+                definition_message, LapEventTypeField.ID),
+            growable=False), 
+        LapStartTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, LapStartTimeField.ID),
+            growable=False), 
+        LapStartPositionLatField(
+            size=cls._field_size_from_definition(
+                definition_message, LapStartPositionLatField.ID),
+            growable=False), 
+        LapStartPositionLongField(
+            size=cls._field_size_from_definition(
+                definition_message, LapStartPositionLongField.ID),
+            growable=False), 
+        LapEndPositionLatField(
+            size=cls._field_size_from_definition(
+                definition_message, LapEndPositionLatField.ID),
+            growable=False), 
+        LapEndPositionLongField(
+            size=cls._field_size_from_definition(
+                definition_message, LapEndPositionLongField.ID),
+            growable=False), 
+        LapTotalElapsedTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, LapTotalElapsedTimeField.ID),
+            growable=False), 
+        LapTotalTimerTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, LapTotalTimerTimeField.ID),
+            growable=False), 
+        LapTotalDistanceField(
+            size=cls._field_size_from_definition(
+                definition_message, LapTotalDistanceField.ID),
+            growable=False), 
+        LapTotalCyclesField(
+            size=cls._field_size_from_definition(
+                definition_message, LapTotalCyclesField.ID),
+            growable=False), 
+        LapTotalCaloriesField(
+            size=cls._field_size_from_definition(
+                definition_message, LapTotalCaloriesField.ID),
+            growable=False), 
+        LapTotalFatCaloriesField(
+            size=cls._field_size_from_definition(
+                definition_message, LapTotalFatCaloriesField.ID),
+            growable=False), 
+        LapAvgSpeedField(
+            size=cls._field_size_from_definition(
+                definition_message, LapAvgSpeedField.ID),
+            growable=False), 
+        LapMaxSpeedField(
+            size=cls._field_size_from_definition(
+                definition_message, LapMaxSpeedField.ID),
+            growable=False), 
+        LapAvgHeartRateField(
+            size=cls._field_size_from_definition(
+                definition_message, LapAvgHeartRateField.ID),
+            growable=False), 
+        LapMaxHeartRateField(
+            size=cls._field_size_from_definition(
+                definition_message, LapMaxHeartRateField.ID),
+            growable=False), 
+        LapAvgCadenceField(
+            size=cls._field_size_from_definition(
+                definition_message, LapAvgCadenceField.ID),
+            growable=False), 
+        LapMaxCadenceField(
+            size=cls._field_size_from_definition(
+                definition_message, LapMaxCadenceField.ID),
+            growable=False), 
+        LapAvgPowerField(
+            size=cls._field_size_from_definition(
+                definition_message, LapAvgPowerField.ID),
+            growable=False), 
+        LapMaxPowerField(
+            size=cls._field_size_from_definition(
+                definition_message, LapMaxPowerField.ID),
+            growable=False), 
+        LapTotalAscentField(
+            size=cls._field_size_from_definition(
+                definition_message, LapTotalAscentField.ID),
+            growable=False), 
+        LapTotalDescentField(
+            size=cls._field_size_from_definition(
+                definition_message, LapTotalDescentField.ID),
+            growable=False), 
+        LapIntensityField(
+            size=cls._field_size_from_definition(
+                definition_message, LapIntensityField.ID),
+            growable=False), 
+        LapLapTriggerField(
+            size=cls._field_size_from_definition(
+                definition_message, LapLapTriggerField.ID),
+            growable=False), 
+        LapSportField(
+            size=cls._field_size_from_definition(
+                definition_message, LapSportField.ID),
+            growable=False), 
+        LapEventGroupField(
+            size=cls._field_size_from_definition(
+                definition_message, LapEventGroupField.ID),
+            growable=False), 
+        LapNumLengthsField(
+            size=cls._field_size_from_definition(
+                definition_message, LapNumLengthsField.ID),
+            growable=False), 
+        LapNormalizedPowerField(
+            size=cls._field_size_from_definition(
+                definition_message, LapNormalizedPowerField.ID),
+            growable=False), 
+        LapLeftRightBalanceField(
+            size=cls._field_size_from_definition(
+                definition_message, LapLeftRightBalanceField.ID),
+            growable=False), 
+        LapFirstLengthIndexField(
+            size=cls._field_size_from_definition(
+                definition_message, LapFirstLengthIndexField.ID),
+            growable=False), 
+        LapAvgStrokeDistanceField(
+            size=cls._field_size_from_definition(
+                definition_message, LapAvgStrokeDistanceField.ID),
+            growable=False), 
+        LapSwimStrokeField(
+            size=cls._field_size_from_definition(
+                definition_message, LapSwimStrokeField.ID),
+            growable=False), 
+        LapSubSportField(
+            size=cls._field_size_from_definition(
+                definition_message, LapSubSportField.ID),
+            growable=False), 
+        LapNumActiveLengthsField(
+            size=cls._field_size_from_definition(
+                definition_message, LapNumActiveLengthsField.ID),
+            growable=False), 
+        LapTotalWorkField(
+            size=cls._field_size_from_definition(
+                definition_message, LapTotalWorkField.ID),
+            growable=False), 
+        LapAvgAltitudeField(
+            size=cls._field_size_from_definition(
+                definition_message, LapAvgAltitudeField.ID),
+            growable=False), 
+        LapMaxAltitudeField(
+            size=cls._field_size_from_definition(
+                definition_message, LapMaxAltitudeField.ID),
+            growable=False), 
+        LapGpsAccuracyField(
+            size=cls._field_size_from_definition(
+                definition_message, LapGpsAccuracyField.ID),
+            growable=False), 
+        LapAvgGradeField(
+            size=cls._field_size_from_definition(
+                definition_message, LapAvgGradeField.ID),
+            growable=False), 
+        LapAvgPosGradeField(
+            size=cls._field_size_from_definition(
+                definition_message, LapAvgPosGradeField.ID),
+            growable=False), 
+        LapAvgNegGradeField(
+            size=cls._field_size_from_definition(
+                definition_message, LapAvgNegGradeField.ID),
+            growable=False), 
+        LapMaxPosGradeField(
+            size=cls._field_size_from_definition(
+                definition_message, LapMaxPosGradeField.ID),
+            growable=False), 
+        LapMaxNegGradeField(
+            size=cls._field_size_from_definition(
+                definition_message, LapMaxNegGradeField.ID),
+            growable=False), 
+        LapAvgTemperatureField(
+            size=cls._field_size_from_definition(
+                definition_message, LapAvgTemperatureField.ID),
+            growable=False), 
+        LapMaxTemperatureField(
+            size=cls._field_size_from_definition(
+                definition_message, LapMaxTemperatureField.ID),
+            growable=False), 
+        LapTotalMovingTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, LapTotalMovingTimeField.ID),
+            growable=False), 
+        LapAvgPosVerticalSpeedField(
+            size=cls._field_size_from_definition(
+                definition_message, LapAvgPosVerticalSpeedField.ID),
+            growable=False), 
+        LapAvgNegVerticalSpeedField(
+            size=cls._field_size_from_definition(
+                definition_message, LapAvgNegVerticalSpeedField.ID),
+            growable=False), 
+        LapMaxPosVerticalSpeedField(
+            size=cls._field_size_from_definition(
+                definition_message, LapMaxPosVerticalSpeedField.ID),
+            growable=False), 
+        LapMaxNegVerticalSpeedField(
+            size=cls._field_size_from_definition(
+                definition_message, LapMaxNegVerticalSpeedField.ID),
+            growable=False), 
+        LapTimeInHrZoneField(
+            size=cls._field_size_from_definition(
+                definition_message, LapTimeInHrZoneField.ID),
+            growable=False), 
+        LapTimeInSpeedZoneField(
+            size=cls._field_size_from_definition(
+                definition_message, LapTimeInSpeedZoneField.ID),
+            growable=False), 
+        LapTimeInCadenceZoneField(
+            size=cls._field_size_from_definition(
+                definition_message, LapTimeInCadenceZoneField.ID),
+            growable=False), 
+        LapTimeInPowerZoneField(
+            size=cls._field_size_from_definition(
+                definition_message, LapTimeInPowerZoneField.ID),
+            growable=False), 
+        LapRepetitionNumField(
+            size=cls._field_size_from_definition(
+                definition_message, LapRepetitionNumField.ID),
+            growable=False), 
+        LapMinAltitudeField(
+            size=cls._field_size_from_definition(
+                definition_message, LapMinAltitudeField.ID),
+            growable=False), 
+        LapMinHeartRateField(
+            size=cls._field_size_from_definition(
+                definition_message, LapMinHeartRateField.ID),
+            growable=False), 
+        LapActiveTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, LapActiveTimeField.ID),
+            growable=False), 
+        LapWorkoutStepIndexField(
+            size=cls._field_size_from_definition(
+                definition_message, LapWorkoutStepIndexField.ID),
+            growable=False), 
+        LapOpponentScoreField(
+            size=cls._field_size_from_definition(
+                definition_message, LapOpponentScoreField.ID),
+            growable=False), 
+        LapStrokeCountField(
+            size=cls._field_size_from_definition(
+                definition_message, LapStrokeCountField.ID),
+            growable=False), 
+        LapZoneCountField(
+            size=cls._field_size_from_definition(
+                definition_message, LapZoneCountField.ID),
+            growable=False), 
+        LapAvgVerticalOscillationField(
+            size=cls._field_size_from_definition(
+                definition_message, LapAvgVerticalOscillationField.ID),
+            growable=False), 
+        LapAvgStanceTimePercentField(
+            size=cls._field_size_from_definition(
+                definition_message, LapAvgStanceTimePercentField.ID),
+            growable=False), 
+        LapAvgStanceTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, LapAvgStanceTimeField.ID),
+            growable=False), 
+        LapAvgFractionalCadenceField(
+            size=cls._field_size_from_definition(
+                definition_message, LapAvgFractionalCadenceField.ID),
+            growable=False), 
+        LapMaxFractionalCadenceField(
+            size=cls._field_size_from_definition(
+                definition_message, LapMaxFractionalCadenceField.ID),
+            growable=False), 
+        LapTotalFractionalCyclesField(
+            size=cls._field_size_from_definition(
+                definition_message, LapTotalFractionalCyclesField.ID),
+            growable=False), 
+        LapPlayerScoreField(
+            size=cls._field_size_from_definition(
+                definition_message, LapPlayerScoreField.ID),
+            growable=False), 
+        LapAvgTotalHemoglobinConcField(
+            size=cls._field_size_from_definition(
+                definition_message, LapAvgTotalHemoglobinConcField.ID),
+            growable=False), 
+        LapMinTotalHemoglobinConcField(
+            size=cls._field_size_from_definition(
+                definition_message, LapMinTotalHemoglobinConcField.ID),
+            growable=False), 
+        LapMaxTotalHemoglobinConcField(
+            size=cls._field_size_from_definition(
+                definition_message, LapMaxTotalHemoglobinConcField.ID),
+            growable=False), 
+        LapAvgSaturatedHemoglobinPercentField(
+            size=cls._field_size_from_definition(
+                definition_message, LapAvgSaturatedHemoglobinPercentField.ID),
+            growable=False), 
+        LapMinSaturatedHemoglobinPercentField(
+            size=cls._field_size_from_definition(
+                definition_message, LapMinSaturatedHemoglobinPercentField.ID),
+            growable=False), 
+        LapMaxSaturatedHemoglobinPercentField(
+            size=cls._field_size_from_definition(
+                definition_message, LapMaxSaturatedHemoglobinPercentField.ID),
+            growable=False), 
+        LapAvgLeftTorqueEffectivenessField(
+            size=cls._field_size_from_definition(
+                definition_message, LapAvgLeftTorqueEffectivenessField.ID),
+            growable=False), 
+        LapAvgRightTorqueEffectivenessField(
+            size=cls._field_size_from_definition(
+                definition_message, LapAvgRightTorqueEffectivenessField.ID),
+            growable=False), 
+        LapAvgLeftPedalSmoothnessField(
+            size=cls._field_size_from_definition(
+                definition_message, LapAvgLeftPedalSmoothnessField.ID),
+            growable=False), 
+        LapAvgRightPedalSmoothnessField(
+            size=cls._field_size_from_definition(
+                definition_message, LapAvgRightPedalSmoothnessField.ID),
+            growable=False), 
+        LapAvgCombinedPedalSmoothnessField(
+            size=cls._field_size_from_definition(
+                definition_message, LapAvgCombinedPedalSmoothnessField.ID),
+            growable=False), 
+        LapTimeStandingField(
+            size=cls._field_size_from_definition(
+                definition_message, LapTimeStandingField.ID),
+            growable=False), 
+        LapStandCountField(
+            size=cls._field_size_from_definition(
+                definition_message, LapStandCountField.ID),
+            growable=False), 
+        LapAvgLeftPcoField(
+            size=cls._field_size_from_definition(
+                definition_message, LapAvgLeftPcoField.ID),
+            growable=False), 
+        LapAvgRightPcoField(
+            size=cls._field_size_from_definition(
+                definition_message, LapAvgRightPcoField.ID),
+            growable=False), 
+        LapAvgLeftPowerPhaseField(
+            size=cls._field_size_from_definition(
+                definition_message, LapAvgLeftPowerPhaseField.ID),
+            growable=False), 
+        LapAvgLeftPowerPhasePeakField(
+            size=cls._field_size_from_definition(
+                definition_message, LapAvgLeftPowerPhasePeakField.ID),
+            growable=False), 
+        LapAvgRightPowerPhaseField(
+            size=cls._field_size_from_definition(
+                definition_message, LapAvgRightPowerPhaseField.ID),
+            growable=False), 
+        LapAvgRightPowerPhasePeakField(
+            size=cls._field_size_from_definition(
+                definition_message, LapAvgRightPowerPhasePeakField.ID),
+            growable=False), 
+        LapAvgPowerPositionField(
+            size=cls._field_size_from_definition(
+                definition_message, LapAvgPowerPositionField.ID),
+            growable=False), 
+        LapMaxPowerPositionField(
+            size=cls._field_size_from_definition(
+                definition_message, LapMaxPowerPositionField.ID),
+            growable=False), 
+        LapAvgCadencePositionField(
+            size=cls._field_size_from_definition(
+                definition_message, LapAvgCadencePositionField.ID),
+            growable=False), 
+        LapMaxCadencePositionField(
+            size=cls._field_size_from_definition(
+                definition_message, LapMaxCadencePositionField.ID),
+            growable=False), 
+        LapEnhancedAvgSpeedField(
+            size=cls._field_size_from_definition(
+                definition_message, LapEnhancedAvgSpeedField.ID),
+            growable=False), 
+        LapEnhancedMaxSpeedField(
+            size=cls._field_size_from_definition(
+                definition_message, LapEnhancedMaxSpeedField.ID),
+            growable=False), 
+        LapEnhancedAvgAltitudeField(
+            size=cls._field_size_from_definition(
+                definition_message, LapEnhancedAvgAltitudeField.ID),
+            growable=False), 
+        LapEnhancedMinAltitudeField(
+            size=cls._field_size_from_definition(
+                definition_message, LapEnhancedMinAltitudeField.ID),
+            growable=False), 
+        LapEnhancedMaxAltitudeField(
+            size=cls._field_size_from_definition(
+                definition_message, LapEnhancedMaxAltitudeField.ID),
+            growable=False), 
+        LapAvgLevMotorPowerField(
+            size=cls._field_size_from_definition(
+                definition_message, LapAvgLevMotorPowerField.ID),
+            growable=False), 
+        LapMaxLevMotorPowerField(
+            size=cls._field_size_from_definition(
+                definition_message, LapMaxLevMotorPowerField.ID),
+            growable=False), 
+        LapLevBatteryConsumptionField(
+            size=cls._field_size_from_definition(
+                definition_message, LapLevBatteryConsumptionField.ID),
+            growable=False), 
+        LapAvgVerticalRatioField(
+            size=cls._field_size_from_definition(
+                definition_message, LapAvgVerticalRatioField.ID),
+            growable=False), 
+        LapAvgStanceTimeBalanceField(
+            size=cls._field_size_from_definition(
+                definition_message, LapAvgStanceTimeBalanceField.ID),
+            growable=False), 
+        LapAvgStepLengthField(
+            size=cls._field_size_from_definition(
+                definition_message, LapAvgStepLengthField.ID),
+            growable=False), 
+        LapAvgVamField(
+            size=cls._field_size_from_definition(
+                definition_message, LapAvgVamField.ID),
+            growable=False), 
+        LapAvgDepthField(
+            size=cls._field_size_from_definition(
+                definition_message, LapAvgDepthField.ID),
+            growable=False), 
+        LapMaxDepthField(
+            size=cls._field_size_from_definition(
+                definition_message, LapMaxDepthField.ID),
+            growable=False), 
+        LapMinTemperatureField(
+            size=cls._field_size_from_definition(
+                definition_message, LapMinTemperatureField.ID),
+            growable=False), 
+        LapEnhancedAvgRespirationRateField(
+            size=cls._field_size_from_definition(
+                definition_message, LapEnhancedAvgRespirationRateField.ID),
+            growable=False), 
+        LapEnhancedMaxRespirationRateField(
+            size=cls._field_size_from_definition(
+                definition_message, LapEnhancedMaxRespirationRateField.ID),
+            growable=False), 
+        LapAvgRespirationRateField(
+            size=cls._field_size_from_definition(
+                definition_message, LapAvgRespirationRateField.ID),
+            growable=False), 
+        LapMaxRespirationRateField(
+            size=cls._field_size_from_definition(
+                definition_message, LapMaxRespirationRateField.ID),
+            growable=False), 
+        LapTotalGritField(
+            size=cls._field_size_from_definition(
+                definition_message, LapTotalGritField.ID),
+            growable=False), 
+        LapTotalFlowField(
+            size=cls._field_size_from_definition(
+                definition_message, LapTotalFlowField.ID),
+            growable=False), 
+        LapJumpCountField(
+            size=cls._field_size_from_definition(
+                definition_message, LapJumpCountField.ID),
+            growable=False), 
+        LapAvgGritField(
+            size=cls._field_size_from_definition(
+                definition_message, LapAvgGritField.ID),
+            growable=False), 
+        LapAvgFlowField(
+            size=cls._field_size_from_definition(
+                definition_message, LapAvgFlowField.ID),
+            growable=False), 
+        LapTotalFractionalAscentField(
+            size=cls._field_size_from_definition(
+                definition_message, LapTotalFractionalAscentField.ID),
+            growable=False), 
+        LapTotalFractionalDescentField(
+            size=cls._field_size_from_definition(
+                definition_message, LapTotalFractionalDescentField.ID),
+            growable=False), 
+        LapAvgCoreTemperatureField(
+            size=cls._field_size_from_definition(
+                definition_message, LapAvgCoreTemperatureField.ID),
+            growable=False), 
+        LapMinCoreTemperatureField(
+            size=cls._field_size_from_definition(
+                definition_message, LapMinCoreTemperatureField.ID),
+            growable=False), 
+        LapMaxCoreTemperatureField(
+            size=cls._field_size_from_definition(
+                definition_message, LapMaxCoreTemperatureField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/length_message.py
+++ b/fit_tool/profile/messages/length_message.py
@@ -17,102 +17,217 @@ from typing import Dict as dict
 
 
 class LengthMessage(DataMessage):
+    """LengthMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``LengthMessage()`` — create path: growable fields, no wire definition.
+    * ``LengthMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 101
     NAME = 'length'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=LengthMessage.NAME,
                          global_id=LengthMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         MessageIndexField(
-            size=self.__get_field_size(definition_message, MessageIndexField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         TimestampField(
-            size=self.__get_field_size(definition_message, TimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LengthEventField(
-            size=self.__get_field_size(definition_message, LengthEventField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LengthEventTypeField(
-            size=self.__get_field_size(definition_message, LengthEventTypeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LengthStartTimeField(
-            size=self.__get_field_size(definition_message, LengthStartTimeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LengthTotalElapsedTimeField(
-            size=self.__get_field_size(definition_message, LengthTotalElapsedTimeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LengthTotalTimerTimeField(
-            size=self.__get_field_size(definition_message, LengthTotalTimerTimeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LengthTotalStrokesField(
-            size=self.__get_field_size(definition_message, LengthTotalStrokesField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LengthAvgSpeedField(
-            size=self.__get_field_size(definition_message, LengthAvgSpeedField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LengthSwimStrokeField(
-            size=self.__get_field_size(definition_message, LengthSwimStrokeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LengthAvgSwimmingCadenceField(
-            size=self.__get_field_size(definition_message, LengthAvgSwimmingCadenceField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LengthEventGroupField(
-            size=self.__get_field_size(definition_message, LengthEventGroupField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LengthTotalCaloriesField(
-            size=self.__get_field_size(definition_message, LengthTotalCaloriesField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LengthLengthTypeField(
-            size=self.__get_field_size(definition_message, LengthLengthTypeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LengthPlayerScoreField(
-            size=self.__get_field_size(definition_message, LengthPlayerScoreField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LengthOpponentScoreField(
-            size=self.__get_field_size(definition_message, LengthOpponentScoreField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LengthStrokeCountField(
-            size=self.__get_field_size(definition_message, LengthStrokeCountField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LengthZoneCountField(
-            size=self.__get_field_size(definition_message, LengthZoneCountField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LengthEnhancedAvgRespirationRateField(
-            size=self.__get_field_size(definition_message, LengthEnhancedAvgRespirationRateField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LengthEnhancedMaxRespirationRateField(
-            size=self.__get_field_size(definition_message, LengthEnhancedMaxRespirationRateField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LengthAvgRespirationRateField(
-            size=self.__get_field_size(definition_message, LengthAvgRespirationRateField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         LengthMaxRespirationRateField(
-            size=self.__get_field_size(definition_message, LengthMaxRespirationRateField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        MessageIndexField(
+            size=cls._field_size_from_definition(
+                definition_message, MessageIndexField.ID),
+            growable=False), 
+        TimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampField.ID),
+            growable=False), 
+        LengthEventField(
+            size=cls._field_size_from_definition(
+                definition_message, LengthEventField.ID),
+            growable=False), 
+        LengthEventTypeField(
+            size=cls._field_size_from_definition(
+                definition_message, LengthEventTypeField.ID),
+            growable=False), 
+        LengthStartTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, LengthStartTimeField.ID),
+            growable=False), 
+        LengthTotalElapsedTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, LengthTotalElapsedTimeField.ID),
+            growable=False), 
+        LengthTotalTimerTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, LengthTotalTimerTimeField.ID),
+            growable=False), 
+        LengthTotalStrokesField(
+            size=cls._field_size_from_definition(
+                definition_message, LengthTotalStrokesField.ID),
+            growable=False), 
+        LengthAvgSpeedField(
+            size=cls._field_size_from_definition(
+                definition_message, LengthAvgSpeedField.ID),
+            growable=False), 
+        LengthSwimStrokeField(
+            size=cls._field_size_from_definition(
+                definition_message, LengthSwimStrokeField.ID),
+            growable=False), 
+        LengthAvgSwimmingCadenceField(
+            size=cls._field_size_from_definition(
+                definition_message, LengthAvgSwimmingCadenceField.ID),
+            growable=False), 
+        LengthEventGroupField(
+            size=cls._field_size_from_definition(
+                definition_message, LengthEventGroupField.ID),
+            growable=False), 
+        LengthTotalCaloriesField(
+            size=cls._field_size_from_definition(
+                definition_message, LengthTotalCaloriesField.ID),
+            growable=False), 
+        LengthLengthTypeField(
+            size=cls._field_size_from_definition(
+                definition_message, LengthLengthTypeField.ID),
+            growable=False), 
+        LengthPlayerScoreField(
+            size=cls._field_size_from_definition(
+                definition_message, LengthPlayerScoreField.ID),
+            growable=False), 
+        LengthOpponentScoreField(
+            size=cls._field_size_from_definition(
+                definition_message, LengthOpponentScoreField.ID),
+            growable=False), 
+        LengthStrokeCountField(
+            size=cls._field_size_from_definition(
+                definition_message, LengthStrokeCountField.ID),
+            growable=False), 
+        LengthZoneCountField(
+            size=cls._field_size_from_definition(
+                definition_message, LengthZoneCountField.ID),
+            growable=False), 
+        LengthEnhancedAvgRespirationRateField(
+            size=cls._field_size_from_definition(
+                definition_message, LengthEnhancedAvgRespirationRateField.ID),
+            growable=False), 
+        LengthEnhancedMaxRespirationRateField(
+            size=cls._field_size_from_definition(
+                definition_message, LengthEnhancedMaxRespirationRateField.ID),
+            growable=False), 
+        LengthAvgRespirationRateField(
+            size=cls._field_size_from_definition(
+                definition_message, LengthAvgRespirationRateField.ID),
+            growable=False), 
+        LengthMaxRespirationRateField(
+            size=cls._field_size_from_definition(
+                definition_message, LengthMaxRespirationRateField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/magnetometer_data_message.py
+++ b/fit_tool/profile/messages/magnetometer_data_message.py
@@ -17,63 +17,126 @@ from typing import Dict as dict
 
 
 class MagnetometerDataMessage(DataMessage):
+    """MagnetometerDataMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``MagnetometerDataMessage()`` — create path: growable fields, no wire definition.
+    * ``MagnetometerDataMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 208
     NAME = 'magnetometer_data'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=MagnetometerDataMessage.NAME,
                          global_id=MagnetometerDataMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         TimestampField(
-            size=self.__get_field_size(definition_message, TimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         MagnetometerDataTimestampMsField(
-            size=self.__get_field_size(definition_message, MagnetometerDataTimestampMsField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         MagnetometerDataSampleTimeOffsetField(
-            size=self.__get_field_size(definition_message, MagnetometerDataSampleTimeOffsetField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         MagnetometerDataMagXField(
-            size=self.__get_field_size(definition_message, MagnetometerDataMagXField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         MagnetometerDataMagYField(
-            size=self.__get_field_size(definition_message, MagnetometerDataMagYField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         MagnetometerDataMagZField(
-            size=self.__get_field_size(definition_message, MagnetometerDataMagZField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         MagnetometerDataCalibratedMagXField(
-            size=self.__get_field_size(definition_message, MagnetometerDataCalibratedMagXField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         MagnetometerDataCalibratedMagYField(
-            size=self.__get_field_size(definition_message, MagnetometerDataCalibratedMagYField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         MagnetometerDataCalibratedMagZField(
-            size=self.__get_field_size(definition_message, MagnetometerDataCalibratedMagZField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        TimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampField.ID),
+            growable=False), 
+        MagnetometerDataTimestampMsField(
+            size=cls._field_size_from_definition(
+                definition_message, MagnetometerDataTimestampMsField.ID),
+            growable=False), 
+        MagnetometerDataSampleTimeOffsetField(
+            size=cls._field_size_from_definition(
+                definition_message, MagnetometerDataSampleTimeOffsetField.ID),
+            growable=False), 
+        MagnetometerDataMagXField(
+            size=cls._field_size_from_definition(
+                definition_message, MagnetometerDataMagXField.ID),
+            growable=False), 
+        MagnetometerDataMagYField(
+            size=cls._field_size_from_definition(
+                definition_message, MagnetometerDataMagYField.ID),
+            growable=False), 
+        MagnetometerDataMagZField(
+            size=cls._field_size_from_definition(
+                definition_message, MagnetometerDataMagZField.ID),
+            growable=False), 
+        MagnetometerDataCalibratedMagXField(
+            size=cls._field_size_from_definition(
+                definition_message, MagnetometerDataCalibratedMagXField.ID),
+            growable=False), 
+        MagnetometerDataCalibratedMagYField(
+            size=cls._field_size_from_definition(
+                definition_message, MagnetometerDataCalibratedMagYField.ID),
+            growable=False), 
+        MagnetometerDataCalibratedMagZField(
+            size=cls._field_size_from_definition(
+                definition_message, MagnetometerDataCalibratedMagZField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/max_met_data_message.py
+++ b/fit_tool/profile/messages/max_met_data_message.py
@@ -17,60 +17,119 @@ from typing import Dict as dict
 
 
 class MaxMetDataMessage(DataMessage):
+    """MaxMetDataMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``MaxMetDataMessage()`` — create path: growable fields, no wire definition.
+    * ``MaxMetDataMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 229
     NAME = 'max_met_data'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=MaxMetDataMessage.NAME,
                          global_id=MaxMetDataMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         MaxMetDataUpdateTimeField(
-            size=self.__get_field_size(definition_message, MaxMetDataUpdateTimeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         MaxMetDataVo2MaxField(
-            size=self.__get_field_size(definition_message, MaxMetDataVo2MaxField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         MaxMetDataSportField(
-            size=self.__get_field_size(definition_message, MaxMetDataSportField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         MaxMetDataSubSportField(
-            size=self.__get_field_size(definition_message, MaxMetDataSubSportField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         MaxMetDataMaxMetCategoryField(
-            size=self.__get_field_size(definition_message, MaxMetDataMaxMetCategoryField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         MaxMetDataCalibratedDataField(
-            size=self.__get_field_size(definition_message, MaxMetDataCalibratedDataField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         MaxMetDataHrSourceField(
-            size=self.__get_field_size(definition_message, MaxMetDataHrSourceField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         MaxMetDataSpeedSourceField(
-            size=self.__get_field_size(definition_message, MaxMetDataSpeedSourceField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        MaxMetDataUpdateTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, MaxMetDataUpdateTimeField.ID),
+            growable=False), 
+        MaxMetDataVo2MaxField(
+            size=cls._field_size_from_definition(
+                definition_message, MaxMetDataVo2MaxField.ID),
+            growable=False), 
+        MaxMetDataSportField(
+            size=cls._field_size_from_definition(
+                definition_message, MaxMetDataSportField.ID),
+            growable=False), 
+        MaxMetDataSubSportField(
+            size=cls._field_size_from_definition(
+                definition_message, MaxMetDataSubSportField.ID),
+            growable=False), 
+        MaxMetDataMaxMetCategoryField(
+            size=cls._field_size_from_definition(
+                definition_message, MaxMetDataMaxMetCategoryField.ID),
+            growable=False), 
+        MaxMetDataCalibratedDataField(
+            size=cls._field_size_from_definition(
+                definition_message, MaxMetDataCalibratedDataField.ID),
+            growable=False), 
+        MaxMetDataHrSourceField(
+            size=cls._field_size_from_definition(
+                definition_message, MaxMetDataHrSourceField.ID),
+            growable=False), 
+        MaxMetDataSpeedSourceField(
+            size=cls._field_size_from_definition(
+                definition_message, MaxMetDataSpeedSourceField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/memo_glob_message.py
+++ b/fit_tool/profile/messages/memo_glob_message.py
@@ -17,54 +17,105 @@ from typing import Dict as dict
 
 
 class MemoGlobMessage(DataMessage):
+    """MemoGlobMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``MemoGlobMessage()`` — create path: growable fields, no wire definition.
+    * ``MemoGlobMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 145
     NAME = 'memo_glob'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=MemoGlobMessage.NAME,
                          global_id=MemoGlobMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         MemoGlobPartIndexField(
-            size=self.__get_field_size(definition_message, MemoGlobPartIndexField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         MemoGlobMemoField(
-            size=self.__get_field_size(definition_message, MemoGlobMemoField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         MemoGlobMesgNumField(
-            size=self.__get_field_size(definition_message, MemoGlobMesgNumField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         MemoGlobParentIndexField(
-            size=self.__get_field_size(definition_message, MemoGlobParentIndexField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         MemoGlobFieldNumField(
-            size=self.__get_field_size(definition_message, MemoGlobFieldNumField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         MemoGlobDataField(
-            size=self.__get_field_size(definition_message, MemoGlobDataField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        MemoGlobPartIndexField(
+            size=cls._field_size_from_definition(
+                definition_message, MemoGlobPartIndexField.ID),
+            growable=False), 
+        MemoGlobMemoField(
+            size=cls._field_size_from_definition(
+                definition_message, MemoGlobMemoField.ID),
+            growable=False), 
+        MemoGlobMesgNumField(
+            size=cls._field_size_from_definition(
+                definition_message, MemoGlobMesgNumField.ID),
+            growable=False), 
+        MemoGlobParentIndexField(
+            size=cls._field_size_from_definition(
+                definition_message, MemoGlobParentIndexField.ID),
+            growable=False), 
+        MemoGlobFieldNumField(
+            size=cls._field_size_from_definition(
+                definition_message, MemoGlobFieldNumField.ID),
+            growable=False), 
+        MemoGlobDataField(
+            size=cls._field_size_from_definition(
+                definition_message, MemoGlobDataField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/mesg_capabilities_message.py
+++ b/fit_tool/profile/messages/mesg_capabilities_message.py
@@ -17,51 +17,98 @@ from typing import Dict as dict
 
 
 class MesgCapabilitiesMessage(DataMessage):
+    """MesgCapabilitiesMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``MesgCapabilitiesMessage()`` — create path: growable fields, no wire definition.
+    * ``MesgCapabilitiesMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 38
     NAME = 'mesg_capabilities'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=MesgCapabilitiesMessage.NAME,
                          global_id=MesgCapabilitiesMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         MessageIndexField(
-            size=self.__get_field_size(definition_message, MessageIndexField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         MesgCapabilitiesFileField(
-            size=self.__get_field_size(definition_message, MesgCapabilitiesFileField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         MesgCapabilitiesMesgNumField(
-            size=self.__get_field_size(definition_message, MesgCapabilitiesMesgNumField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         MesgCapabilitiesCountTypeField(
-            size=self.__get_field_size(definition_message, MesgCapabilitiesCountTypeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         MesgCapabilitiesCountField(
-            size=self.__get_field_size(definition_message, MesgCapabilitiesCountField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        MessageIndexField(
+            size=cls._field_size_from_definition(
+                definition_message, MessageIndexField.ID),
+            growable=False), 
+        MesgCapabilitiesFileField(
+            size=cls._field_size_from_definition(
+                definition_message, MesgCapabilitiesFileField.ID),
+            growable=False), 
+        MesgCapabilitiesMesgNumField(
+            size=cls._field_size_from_definition(
+                definition_message, MesgCapabilitiesMesgNumField.ID),
+            growable=False), 
+        MesgCapabilitiesCountTypeField(
+            size=cls._field_size_from_definition(
+                definition_message, MesgCapabilitiesCountTypeField.ID),
+            growable=False), 
+        MesgCapabilitiesCountField(
+            size=cls._field_size_from_definition(
+                definition_message, MesgCapabilitiesCountField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/message_factory.py
+++ b/fit_tool/profile/messages/message_factory.py
@@ -150,6 +150,7 @@ def _get_message_class(global_id: int) -> Optional[Type[DataMessage]]:
 
 
 class MessageFactory:
+    """Build typed data messages from wire definitions (decode projection)."""
 
     @staticmethod
     def from_definition(
@@ -157,6 +158,8 @@ class MessageFactory:
             developer_fields: List[DeveloperField]) -> DataMessage:
         message_class = _get_message_class(definition_message.global_id)
         if message_class is None:
-            return GenericMessage(definition_message=definition_message, developer_fields=developer_fields)
+            return GenericMessage.from_definition(
+                definition_message, developer_fields=developer_fields)
 
-        return message_class(definition_message=definition_message, developer_fields=developer_fields)
+        return message_class.from_definition(
+            definition_message, developer_fields=developer_fields)

--- a/fit_tool/profile/messages/met_zone_message.py
+++ b/fit_tool/profile/messages/met_zone_message.py
@@ -17,48 +17,91 @@ from typing import Dict as dict
 
 
 class MetZoneMessage(DataMessage):
+    """MetZoneMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``MetZoneMessage()`` — create path: growable fields, no wire definition.
+    * ``MetZoneMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 10
     NAME = 'met_zone'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=MetZoneMessage.NAME,
                          global_id=MetZoneMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         MessageIndexField(
-            size=self.__get_field_size(definition_message, MessageIndexField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         MetZoneHighBpmField(
-            size=self.__get_field_size(definition_message, MetZoneHighBpmField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         MetZoneCaloriesField(
-            size=self.__get_field_size(definition_message, MetZoneCaloriesField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         MetZoneFatCaloriesField(
-            size=self.__get_field_size(definition_message, MetZoneFatCaloriesField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        MessageIndexField(
+            size=cls._field_size_from_definition(
+                definition_message, MessageIndexField.ID),
+            growable=False), 
+        MetZoneHighBpmField(
+            size=cls._field_size_from_definition(
+                definition_message, MetZoneHighBpmField.ID),
+            growable=False), 
+        MetZoneCaloriesField(
+            size=cls._field_size_from_definition(
+                definition_message, MetZoneCaloriesField.ID),
+            growable=False), 
+        MetZoneFatCaloriesField(
+            size=cls._field_size_from_definition(
+                definition_message, MetZoneFatCaloriesField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/monitoring_hr_data_message.py
+++ b/fit_tool/profile/messages/monitoring_hr_data_message.py
@@ -17,45 +17,84 @@ from typing import Dict as dict
 
 
 class MonitoringHrDataMessage(DataMessage):
+    """MonitoringHrDataMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``MonitoringHrDataMessage()`` — create path: growable fields, no wire definition.
+    * ``MonitoringHrDataMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 211
     NAME = 'monitoring_hr_data'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=MonitoringHrDataMessage.NAME,
                          global_id=MonitoringHrDataMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         TimestampField(
-            size=self.__get_field_size(definition_message, TimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         MonitoringHrDataRestingHeartRateField(
-            size=self.__get_field_size(definition_message, MonitoringHrDataRestingHeartRateField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         MonitoringHrDataCurrentDayRestingHeartRateField(
-            size=self.__get_field_size(definition_message, MonitoringHrDataCurrentDayRestingHeartRateField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        TimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampField.ID),
+            growable=False), 
+        MonitoringHrDataRestingHeartRateField(
+            size=cls._field_size_from_definition(
+                definition_message, MonitoringHrDataRestingHeartRateField.ID),
+            growable=False), 
+        MonitoringHrDataCurrentDayRestingHeartRateField(
+            size=cls._field_size_from_definition(
+                definition_message, MonitoringHrDataCurrentDayRestingHeartRateField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/monitoring_info_message.py
+++ b/fit_tool/profile/messages/monitoring_info_message.py
@@ -17,54 +17,105 @@ from typing import Dict as dict
 
 
 class MonitoringInfoMessage(DataMessage):
+    """MonitoringInfoMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``MonitoringInfoMessage()`` — create path: growable fields, no wire definition.
+    * ``MonitoringInfoMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 103
     NAME = 'monitoring_info'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=MonitoringInfoMessage.NAME,
                          global_id=MonitoringInfoMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         TimestampField(
-            size=self.__get_field_size(definition_message, TimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         MonitoringInfoLocalTimestampField(
-            size=self.__get_field_size(definition_message, MonitoringInfoLocalTimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         MonitoringInfoActivityTypeField(
-            size=self.__get_field_size(definition_message, MonitoringInfoActivityTypeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         MonitoringInfoCyclesToDistanceField(
-            size=self.__get_field_size(definition_message, MonitoringInfoCyclesToDistanceField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         MonitoringInfoCyclesToCaloriesField(
-            size=self.__get_field_size(definition_message, MonitoringInfoCyclesToCaloriesField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         MonitoringInfoRestingMetabolicRateField(
-            size=self.__get_field_size(definition_message, MonitoringInfoRestingMetabolicRateField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        TimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampField.ID),
+            growable=False), 
+        MonitoringInfoLocalTimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, MonitoringInfoLocalTimestampField.ID),
+            growable=False), 
+        MonitoringInfoActivityTypeField(
+            size=cls._field_size_from_definition(
+                definition_message, MonitoringInfoActivityTypeField.ID),
+            growable=False), 
+        MonitoringInfoCyclesToDistanceField(
+            size=cls._field_size_from_definition(
+                definition_message, MonitoringInfoCyclesToDistanceField.ID),
+            growable=False), 
+        MonitoringInfoCyclesToCaloriesField(
+            size=cls._field_size_from_definition(
+                definition_message, MonitoringInfoCyclesToCaloriesField.ID),
+            growable=False), 
+        MonitoringInfoRestingMetabolicRateField(
+            size=cls._field_size_from_definition(
+                definition_message, MonitoringInfoRestingMetabolicRateField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/monitoring_message.py
+++ b/fit_tool/profile/messages/monitoring_message.py
@@ -17,123 +17,266 @@ from typing import Dict as dict
 
 
 class MonitoringMessage(DataMessage):
+    """MonitoringMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``MonitoringMessage()`` — create path: growable fields, no wire definition.
+    * ``MonitoringMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 55
     NAME = 'monitoring'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=MonitoringMessage.NAME,
                          global_id=MonitoringMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         TimestampField(
-            size=self.__get_field_size(definition_message, TimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         MonitoringDeviceIndexField(
-            size=self.__get_field_size(definition_message, MonitoringDeviceIndexField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         MonitoringCaloriesField(
-            size=self.__get_field_size(definition_message, MonitoringCaloriesField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         MonitoringDistanceField(
-            size=self.__get_field_size(definition_message, MonitoringDistanceField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         MonitoringCyclesField(
-            size=self.__get_field_size(definition_message, MonitoringCyclesField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         MonitoringActiveTimeField(
-            size=self.__get_field_size(definition_message, MonitoringActiveTimeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         MonitoringActivityTypeField(
-            size=self.__get_field_size(definition_message, MonitoringActivityTypeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         MonitoringActivitySubtypeField(
-            size=self.__get_field_size(definition_message, MonitoringActivitySubtypeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         MonitoringActivityLevelField(
-            size=self.__get_field_size(definition_message, MonitoringActivityLevelField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         MonitoringDistance16Field(
-            size=self.__get_field_size(definition_message, MonitoringDistance16Field.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         MonitoringCycles16Field(
-            size=self.__get_field_size(definition_message, MonitoringCycles16Field.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         MonitoringActiveTime16Field(
-            size=self.__get_field_size(definition_message, MonitoringActiveTime16Field.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         MonitoringLocalTimestampField(
-            size=self.__get_field_size(definition_message, MonitoringLocalTimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         MonitoringTemperatureField(
-            size=self.__get_field_size(definition_message, MonitoringTemperatureField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         MonitoringTemperatureMinField(
-            size=self.__get_field_size(definition_message, MonitoringTemperatureMinField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         MonitoringTemperatureMaxField(
-            size=self.__get_field_size(definition_message, MonitoringTemperatureMaxField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         MonitoringActivityTimeField(
-            size=self.__get_field_size(definition_message, MonitoringActivityTimeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         MonitoringActiveCaloriesField(
-            size=self.__get_field_size(definition_message, MonitoringActiveCaloriesField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         MonitoringCurrentActivityTypeIntensityField(
-            size=self.__get_field_size(definition_message, MonitoringCurrentActivityTypeIntensityField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         MonitoringTimestampMin8Field(
-            size=self.__get_field_size(definition_message, MonitoringTimestampMin8Field.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         MonitoringTimestamp16Field(
-            size=self.__get_field_size(definition_message, MonitoringTimestamp16Field.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         MonitoringHeartRateField(
-            size=self.__get_field_size(definition_message, MonitoringHeartRateField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         MonitoringIntensityField(
-            size=self.__get_field_size(definition_message, MonitoringIntensityField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         MonitoringDurationMinField(
-            size=self.__get_field_size(definition_message, MonitoringDurationMinField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         MonitoringDurationField(
-            size=self.__get_field_size(definition_message, MonitoringDurationField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         MonitoringAscentField(
-            size=self.__get_field_size(definition_message, MonitoringAscentField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         MonitoringDescentField(
-            size=self.__get_field_size(definition_message, MonitoringDescentField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         MonitoringModerateActivityMinutesField(
-            size=self.__get_field_size(definition_message, MonitoringModerateActivityMinutesField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         MonitoringVigorousActivityMinutesField(
-            size=self.__get_field_size(definition_message, MonitoringVigorousActivityMinutesField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        TimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampField.ID),
+            growable=False), 
+        MonitoringDeviceIndexField(
+            size=cls._field_size_from_definition(
+                definition_message, MonitoringDeviceIndexField.ID),
+            growable=False), 
+        MonitoringCaloriesField(
+            size=cls._field_size_from_definition(
+                definition_message, MonitoringCaloriesField.ID),
+            growable=False), 
+        MonitoringDistanceField(
+            size=cls._field_size_from_definition(
+                definition_message, MonitoringDistanceField.ID),
+            growable=False), 
+        MonitoringCyclesField(
+            size=cls._field_size_from_definition(
+                definition_message, MonitoringCyclesField.ID),
+            growable=False), 
+        MonitoringActiveTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, MonitoringActiveTimeField.ID),
+            growable=False), 
+        MonitoringActivityTypeField(
+            size=cls._field_size_from_definition(
+                definition_message, MonitoringActivityTypeField.ID),
+            growable=False), 
+        MonitoringActivitySubtypeField(
+            size=cls._field_size_from_definition(
+                definition_message, MonitoringActivitySubtypeField.ID),
+            growable=False), 
+        MonitoringActivityLevelField(
+            size=cls._field_size_from_definition(
+                definition_message, MonitoringActivityLevelField.ID),
+            growable=False), 
+        MonitoringDistance16Field(
+            size=cls._field_size_from_definition(
+                definition_message, MonitoringDistance16Field.ID),
+            growable=False), 
+        MonitoringCycles16Field(
+            size=cls._field_size_from_definition(
+                definition_message, MonitoringCycles16Field.ID),
+            growable=False), 
+        MonitoringActiveTime16Field(
+            size=cls._field_size_from_definition(
+                definition_message, MonitoringActiveTime16Field.ID),
+            growable=False), 
+        MonitoringLocalTimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, MonitoringLocalTimestampField.ID),
+            growable=False), 
+        MonitoringTemperatureField(
+            size=cls._field_size_from_definition(
+                definition_message, MonitoringTemperatureField.ID),
+            growable=False), 
+        MonitoringTemperatureMinField(
+            size=cls._field_size_from_definition(
+                definition_message, MonitoringTemperatureMinField.ID),
+            growable=False), 
+        MonitoringTemperatureMaxField(
+            size=cls._field_size_from_definition(
+                definition_message, MonitoringTemperatureMaxField.ID),
+            growable=False), 
+        MonitoringActivityTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, MonitoringActivityTimeField.ID),
+            growable=False), 
+        MonitoringActiveCaloriesField(
+            size=cls._field_size_from_definition(
+                definition_message, MonitoringActiveCaloriesField.ID),
+            growable=False), 
+        MonitoringCurrentActivityTypeIntensityField(
+            size=cls._field_size_from_definition(
+                definition_message, MonitoringCurrentActivityTypeIntensityField.ID),
+            growable=False), 
+        MonitoringTimestampMin8Field(
+            size=cls._field_size_from_definition(
+                definition_message, MonitoringTimestampMin8Field.ID),
+            growable=False), 
+        MonitoringTimestamp16Field(
+            size=cls._field_size_from_definition(
+                definition_message, MonitoringTimestamp16Field.ID),
+            growable=False), 
+        MonitoringHeartRateField(
+            size=cls._field_size_from_definition(
+                definition_message, MonitoringHeartRateField.ID),
+            growable=False), 
+        MonitoringIntensityField(
+            size=cls._field_size_from_definition(
+                definition_message, MonitoringIntensityField.ID),
+            growable=False), 
+        MonitoringDurationMinField(
+            size=cls._field_size_from_definition(
+                definition_message, MonitoringDurationMinField.ID),
+            growable=False), 
+        MonitoringDurationField(
+            size=cls._field_size_from_definition(
+                definition_message, MonitoringDurationField.ID),
+            growable=False), 
+        MonitoringAscentField(
+            size=cls._field_size_from_definition(
+                definition_message, MonitoringAscentField.ID),
+            growable=False), 
+        MonitoringDescentField(
+            size=cls._field_size_from_definition(
+                definition_message, MonitoringDescentField.ID),
+            growable=False), 
+        MonitoringModerateActivityMinutesField(
+            size=cls._field_size_from_definition(
+                definition_message, MonitoringModerateActivityMinutesField.ID),
+            growable=False), 
+        MonitoringVigorousActivityMinutesField(
+            size=cls._field_size_from_definition(
+                definition_message, MonitoringVigorousActivityMinutesField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/nap_event_message.py
+++ b/fit_tool/profile/messages/nap_event_message.py
@@ -17,66 +17,133 @@ from typing import Dict as dict
 
 
 class NapEventMessage(DataMessage):
+    """NapEventMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``NapEventMessage()`` — create path: growable fields, no wire definition.
+    * ``NapEventMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 412
     NAME = 'nap_event'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=NapEventMessage.NAME,
                          global_id=NapEventMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         MessageIndexField(
-            size=self.__get_field_size(definition_message, MessageIndexField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         TimestampField(
-            size=self.__get_field_size(definition_message, TimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         NapEventStartTimeField(
-            size=self.__get_field_size(definition_message, NapEventStartTimeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         NapEventStartTimezoneOffsetField(
-            size=self.__get_field_size(definition_message, NapEventStartTimezoneOffsetField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         NapEventEndTimeField(
-            size=self.__get_field_size(definition_message, NapEventEndTimeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         NapEventEndTimezoneOffsetField(
-            size=self.__get_field_size(definition_message, NapEventEndTimezoneOffsetField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         NapEventFeedbackField(
-            size=self.__get_field_size(definition_message, NapEventFeedbackField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         NapEventIsDeletedField(
-            size=self.__get_field_size(definition_message, NapEventIsDeletedField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         NapEventSourceField(
-            size=self.__get_field_size(definition_message, NapEventSourceField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         NapEventUpdateTimestampField(
-            size=self.__get_field_size(definition_message, NapEventUpdateTimestampField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        MessageIndexField(
+            size=cls._field_size_from_definition(
+                definition_message, MessageIndexField.ID),
+            growable=False), 
+        TimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampField.ID),
+            growable=False), 
+        NapEventStartTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, NapEventStartTimeField.ID),
+            growable=False), 
+        NapEventStartTimezoneOffsetField(
+            size=cls._field_size_from_definition(
+                definition_message, NapEventStartTimezoneOffsetField.ID),
+            growable=False), 
+        NapEventEndTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, NapEventEndTimeField.ID),
+            growable=False), 
+        NapEventEndTimezoneOffsetField(
+            size=cls._field_size_from_definition(
+                definition_message, NapEventEndTimezoneOffsetField.ID),
+            growable=False), 
+        NapEventFeedbackField(
+            size=cls._field_size_from_definition(
+                definition_message, NapEventFeedbackField.ID),
+            growable=False), 
+        NapEventIsDeletedField(
+            size=cls._field_size_from_definition(
+                definition_message, NapEventIsDeletedField.ID),
+            growable=False), 
+        NapEventSourceField(
+            size=cls._field_size_from_definition(
+                definition_message, NapEventSourceField.ID),
+            growable=False), 
+        NapEventUpdateTimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, NapEventUpdateTimestampField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/nmea_sentence_message.py
+++ b/fit_tool/profile/messages/nmea_sentence_message.py
@@ -17,45 +17,84 @@ from typing import Dict as dict
 
 
 class NmeaSentenceMessage(DataMessage):
+    """NmeaSentenceMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``NmeaSentenceMessage()`` — create path: growable fields, no wire definition.
+    * ``NmeaSentenceMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 177
     NAME = 'nmea_sentence'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=NmeaSentenceMessage.NAME,
                          global_id=NmeaSentenceMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         TimestampField(
-            size=self.__get_field_size(definition_message, TimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         NmeaSentenceTimestampMsField(
-            size=self.__get_field_size(definition_message, NmeaSentenceTimestampMsField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         NmeaSentenceSentenceField(
-            size=self.__get_field_size(definition_message, NmeaSentenceSentenceField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        TimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampField.ID),
+            growable=False), 
+        NmeaSentenceTimestampMsField(
+            size=cls._field_size_from_definition(
+                definition_message, NmeaSentenceTimestampMsField.ID),
+            growable=False), 
+        NmeaSentenceSentenceField(
+            size=cls._field_size_from_definition(
+                definition_message, NmeaSentenceSentenceField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/obdii_data_message.py
+++ b/fit_tool/profile/messages/obdii_data_message.py
@@ -17,63 +17,126 @@ from typing import Dict as dict
 
 
 class ObdiiDataMessage(DataMessage):
+    """ObdiiDataMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``ObdiiDataMessage()`` — create path: growable fields, no wire definition.
+    * ``ObdiiDataMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 174
     NAME = 'obdii_data'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=ObdiiDataMessage.NAME,
                          global_id=ObdiiDataMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         TimestampField(
-            size=self.__get_field_size(definition_message, TimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ObdiiDataTimestampMsField(
-            size=self.__get_field_size(definition_message, ObdiiDataTimestampMsField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ObdiiDataTimeOffsetField(
-            size=self.__get_field_size(definition_message, ObdiiDataTimeOffsetField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ObdiiDataPidField(
-            size=self.__get_field_size(definition_message, ObdiiDataPidField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ObdiiDataRawDataField(
-            size=self.__get_field_size(definition_message, ObdiiDataRawDataField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ObdiiDataPidDataSizeField(
-            size=self.__get_field_size(definition_message, ObdiiDataPidDataSizeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ObdiiDataSystemTimeField(
-            size=self.__get_field_size(definition_message, ObdiiDataSystemTimeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ObdiiDataStartTimestampField(
-            size=self.__get_field_size(definition_message, ObdiiDataStartTimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ObdiiDataStartTimestampMsField(
-            size=self.__get_field_size(definition_message, ObdiiDataStartTimestampMsField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        TimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampField.ID),
+            growable=False), 
+        ObdiiDataTimestampMsField(
+            size=cls._field_size_from_definition(
+                definition_message, ObdiiDataTimestampMsField.ID),
+            growable=False), 
+        ObdiiDataTimeOffsetField(
+            size=cls._field_size_from_definition(
+                definition_message, ObdiiDataTimeOffsetField.ID),
+            growable=False), 
+        ObdiiDataPidField(
+            size=cls._field_size_from_definition(
+                definition_message, ObdiiDataPidField.ID),
+            growable=False), 
+        ObdiiDataRawDataField(
+            size=cls._field_size_from_definition(
+                definition_message, ObdiiDataRawDataField.ID),
+            growable=False), 
+        ObdiiDataPidDataSizeField(
+            size=cls._field_size_from_definition(
+                definition_message, ObdiiDataPidDataSizeField.ID),
+            growable=False), 
+        ObdiiDataSystemTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, ObdiiDataSystemTimeField.ID),
+            growable=False), 
+        ObdiiDataStartTimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, ObdiiDataStartTimestampField.ID),
+            growable=False), 
+        ObdiiDataStartTimestampMsField(
+            size=cls._field_size_from_definition(
+                definition_message, ObdiiDataStartTimestampMsField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/ohr_settings_message.py
+++ b/fit_tool/profile/messages/ohr_settings_message.py
@@ -17,42 +17,77 @@ from typing import Dict as dict
 
 
 class OhrSettingsMessage(DataMessage):
+    """OhrSettingsMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``OhrSettingsMessage()`` — create path: growable fields, no wire definition.
+    * ``OhrSettingsMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 188
     NAME = 'ohr_settings'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=OhrSettingsMessage.NAME,
                          global_id=OhrSettingsMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         TimestampField(
-            size=self.__get_field_size(definition_message, TimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         OhrSettingsEnabledField(
-            size=self.__get_field_size(definition_message, OhrSettingsEnabledField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        TimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampField.ID),
+            growable=False), 
+        OhrSettingsEnabledField(
+            size=cls._field_size_from_definition(
+                definition_message, OhrSettingsEnabledField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/one_d_sensor_calibration_message.py
+++ b/fit_tool/profile/messages/one_d_sensor_calibration_message.py
@@ -17,54 +17,105 @@ from typing import Dict as dict
 
 
 class OneDSensorCalibrationMessage(DataMessage):
+    """OneDSensorCalibrationMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``OneDSensorCalibrationMessage()`` — create path: growable fields, no wire definition.
+    * ``OneDSensorCalibrationMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 210
     NAME = 'one_d_sensor_calibration'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=OneDSensorCalibrationMessage.NAME,
                          global_id=OneDSensorCalibrationMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         TimestampField(
-            size=self.__get_field_size(definition_message, TimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         OneDSensorCalibrationSensorTypeField(
-            size=self.__get_field_size(definition_message, OneDSensorCalibrationSensorTypeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         OneDSensorCalibrationCalibrationFactorField(
-            size=self.__get_field_size(definition_message, OneDSensorCalibrationCalibrationFactorField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         OneDSensorCalibrationCalibrationDivisorField(
-            size=self.__get_field_size(definition_message, OneDSensorCalibrationCalibrationDivisorField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         OneDSensorCalibrationLevelShiftField(
-            size=self.__get_field_size(definition_message, OneDSensorCalibrationLevelShiftField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         OneDSensorCalibrationOffsetCalField(
-            size=self.__get_field_size(definition_message, OneDSensorCalibrationOffsetCalField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        TimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampField.ID),
+            growable=False), 
+        OneDSensorCalibrationSensorTypeField(
+            size=cls._field_size_from_definition(
+                definition_message, OneDSensorCalibrationSensorTypeField.ID),
+            growable=False), 
+        OneDSensorCalibrationCalibrationFactorField(
+            size=cls._field_size_from_definition(
+                definition_message, OneDSensorCalibrationCalibrationFactorField.ID),
+            growable=False), 
+        OneDSensorCalibrationCalibrationDivisorField(
+            size=cls._field_size_from_definition(
+                definition_message, OneDSensorCalibrationCalibrationDivisorField.ID),
+            growable=False), 
+        OneDSensorCalibrationLevelShiftField(
+            size=cls._field_size_from_definition(
+                definition_message, OneDSensorCalibrationLevelShiftField.ID),
+            growable=False), 
+        OneDSensorCalibrationOffsetCalField(
+            size=cls._field_size_from_definition(
+                definition_message, OneDSensorCalibrationOffsetCalField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/power_zone_message.py
+++ b/fit_tool/profile/messages/power_zone_message.py
@@ -17,45 +17,84 @@ from typing import Dict as dict
 
 
 class PowerZoneMessage(DataMessage):
+    """PowerZoneMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``PowerZoneMessage()`` — create path: growable fields, no wire definition.
+    * ``PowerZoneMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 9
     NAME = 'power_zone'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=PowerZoneMessage.NAME,
                          global_id=PowerZoneMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         MessageIndexField(
-            size=self.__get_field_size(definition_message, MessageIndexField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         PowerZoneHighValueField(
-            size=self.__get_field_size(definition_message, PowerZoneHighValueField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         PowerZoneNameField(
-            size=self.__get_field_size(definition_message, PowerZoneNameField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        MessageIndexField(
+            size=cls._field_size_from_definition(
+                definition_message, MessageIndexField.ID),
+            growable=False), 
+        PowerZoneHighValueField(
+            size=cls._field_size_from_definition(
+                definition_message, PowerZoneHighValueField.ID),
+            growable=False), 
+        PowerZoneNameField(
+            size=cls._field_size_from_definition(
+                definition_message, PowerZoneNameField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/raw_bbi_message.py
+++ b/fit_tool/profile/messages/raw_bbi_message.py
@@ -17,54 +17,105 @@ from typing import Dict as dict
 
 
 class RawBbiMessage(DataMessage):
+    """RawBbiMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``RawBbiMessage()`` — create path: growable fields, no wire definition.
+    * ``RawBbiMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 372
     NAME = 'raw_bbi'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=RawBbiMessage.NAME,
                          global_id=RawBbiMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         TimestampField(
-            size=self.__get_field_size(definition_message, TimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RawBbiTimestampMsField(
-            size=self.__get_field_size(definition_message, RawBbiTimestampMsField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RawBbiDataField(
-            size=self.__get_field_size(definition_message, RawBbiDataField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RawBbiTimeField(
-            size=self.__get_field_size(definition_message, RawBbiTimeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RawBbiQualityField(
-            size=self.__get_field_size(definition_message, RawBbiQualityField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RawBbiGapField(
-            size=self.__get_field_size(definition_message, RawBbiGapField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        TimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampField.ID),
+            growable=False), 
+        RawBbiTimestampMsField(
+            size=cls._field_size_from_definition(
+                definition_message, RawBbiTimestampMsField.ID),
+            growable=False), 
+        RawBbiDataField(
+            size=cls._field_size_from_definition(
+                definition_message, RawBbiDataField.ID),
+            growable=False), 
+        RawBbiTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, RawBbiTimeField.ID),
+            growable=False), 
+        RawBbiQualityField(
+            size=cls._field_size_from_definition(
+                definition_message, RawBbiQualityField.ID),
+            growable=False), 
+        RawBbiGapField(
+            size=cls._field_size_from_definition(
+                definition_message, RawBbiGapField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/record_message.py
+++ b/fit_tool/profile/messages/record_message.py
@@ -17,288 +17,651 @@ from typing import Dict as dict
 
 
 class RecordMessage(DataMessage):
+    """RecordMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``RecordMessage()`` — create path: growable fields, no wire definition.
+    * ``RecordMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 20
     NAME = 'record'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=RecordMessage.NAME,
                          global_id=RecordMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         TimestampField(
-            size=self.__get_field_size(definition_message, TimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordPositionLatField(
-            size=self.__get_field_size(definition_message, RecordPositionLatField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordPositionLongField(
-            size=self.__get_field_size(definition_message, RecordPositionLongField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordAltitudeField(
-            size=self.__get_field_size(definition_message, RecordAltitudeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordHeartRateField(
-            size=self.__get_field_size(definition_message, RecordHeartRateField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordCadenceField(
-            size=self.__get_field_size(definition_message, RecordCadenceField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordDistanceField(
-            size=self.__get_field_size(definition_message, RecordDistanceField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordSpeedField(
-            size=self.__get_field_size(definition_message, RecordSpeedField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordPowerField(
-            size=self.__get_field_size(definition_message, RecordPowerField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordCompressedSpeedDistanceField(
-            size=self.__get_field_size(definition_message, RecordCompressedSpeedDistanceField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordGradeField(
-            size=self.__get_field_size(definition_message, RecordGradeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordResistanceField(
-            size=self.__get_field_size(definition_message, RecordResistanceField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordTimeFromCourseField(
-            size=self.__get_field_size(definition_message, RecordTimeFromCourseField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordCycleLengthField(
-            size=self.__get_field_size(definition_message, RecordCycleLengthField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordTemperatureField(
-            size=self.__get_field_size(definition_message, RecordTemperatureField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordSpeed1sField(
-            size=self.__get_field_size(definition_message, RecordSpeed1sField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordCyclesField(
-            size=self.__get_field_size(definition_message, RecordCyclesField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordTotalCyclesField(
-            size=self.__get_field_size(definition_message, RecordTotalCyclesField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordCompressedAccumulatedPowerField(
-            size=self.__get_field_size(definition_message, RecordCompressedAccumulatedPowerField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordAccumulatedPowerField(
-            size=self.__get_field_size(definition_message, RecordAccumulatedPowerField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordLeftRightBalanceField(
-            size=self.__get_field_size(definition_message, RecordLeftRightBalanceField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordGpsAccuracyField(
-            size=self.__get_field_size(definition_message, RecordGpsAccuracyField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordVerticalSpeedField(
-            size=self.__get_field_size(definition_message, RecordVerticalSpeedField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordCaloriesField(
-            size=self.__get_field_size(definition_message, RecordCaloriesField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordVerticalOscillationField(
-            size=self.__get_field_size(definition_message, RecordVerticalOscillationField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordStanceTimePercentField(
-            size=self.__get_field_size(definition_message, RecordStanceTimePercentField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordStanceTimeField(
-            size=self.__get_field_size(definition_message, RecordStanceTimeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordActivityTypeField(
-            size=self.__get_field_size(definition_message, RecordActivityTypeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordLeftTorqueEffectivenessField(
-            size=self.__get_field_size(definition_message, RecordLeftTorqueEffectivenessField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordRightTorqueEffectivenessField(
-            size=self.__get_field_size(definition_message, RecordRightTorqueEffectivenessField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordLeftPedalSmoothnessField(
-            size=self.__get_field_size(definition_message, RecordLeftPedalSmoothnessField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordRightPedalSmoothnessField(
-            size=self.__get_field_size(definition_message, RecordRightPedalSmoothnessField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordCombinedPedalSmoothnessField(
-            size=self.__get_field_size(definition_message, RecordCombinedPedalSmoothnessField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordTime128Field(
-            size=self.__get_field_size(definition_message, RecordTime128Field.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordStrokeTypeField(
-            size=self.__get_field_size(definition_message, RecordStrokeTypeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordZoneField(
-            size=self.__get_field_size(definition_message, RecordZoneField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordBallSpeedField(
-            size=self.__get_field_size(definition_message, RecordBallSpeedField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordCadence256Field(
-            size=self.__get_field_size(definition_message, RecordCadence256Field.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordFractionalCadenceField(
-            size=self.__get_field_size(definition_message, RecordFractionalCadenceField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordTotalHemoglobinConcField(
-            size=self.__get_field_size(definition_message, RecordTotalHemoglobinConcField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordTotalHemoglobinConcMinField(
-            size=self.__get_field_size(definition_message, RecordTotalHemoglobinConcMinField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordTotalHemoglobinConcMaxField(
-            size=self.__get_field_size(definition_message, RecordTotalHemoglobinConcMaxField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordSaturatedHemoglobinPercentField(
-            size=self.__get_field_size(definition_message, RecordSaturatedHemoglobinPercentField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordSaturatedHemoglobinPercentMinField(
-            size=self.__get_field_size(definition_message, RecordSaturatedHemoglobinPercentMinField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordSaturatedHemoglobinPercentMaxField(
-            size=self.__get_field_size(definition_message, RecordSaturatedHemoglobinPercentMaxField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordDeviceIndexField(
-            size=self.__get_field_size(definition_message, RecordDeviceIndexField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordLeftPcoField(
-            size=self.__get_field_size(definition_message, RecordLeftPcoField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordRightPcoField(
-            size=self.__get_field_size(definition_message, RecordRightPcoField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordLeftPowerPhaseField(
-            size=self.__get_field_size(definition_message, RecordLeftPowerPhaseField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordLeftPowerPhasePeakField(
-            size=self.__get_field_size(definition_message, RecordLeftPowerPhasePeakField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordRightPowerPhaseField(
-            size=self.__get_field_size(definition_message, RecordRightPowerPhaseField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordRightPowerPhasePeakField(
-            size=self.__get_field_size(definition_message, RecordRightPowerPhasePeakField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordEnhancedSpeedField(
-            size=self.__get_field_size(definition_message, RecordEnhancedSpeedField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordEnhancedAltitudeField(
-            size=self.__get_field_size(definition_message, RecordEnhancedAltitudeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordBatterySocField(
-            size=self.__get_field_size(definition_message, RecordBatterySocField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordMotorPowerField(
-            size=self.__get_field_size(definition_message, RecordMotorPowerField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordVerticalRatioField(
-            size=self.__get_field_size(definition_message, RecordVerticalRatioField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordStanceTimeBalanceField(
-            size=self.__get_field_size(definition_message, RecordStanceTimeBalanceField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordStepLengthField(
-            size=self.__get_field_size(definition_message, RecordStepLengthField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordCycleLength16Field(
-            size=self.__get_field_size(definition_message, RecordCycleLength16Field.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordAbsolutePressureField(
-            size=self.__get_field_size(definition_message, RecordAbsolutePressureField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordDepthField(
-            size=self.__get_field_size(definition_message, RecordDepthField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordNextStopDepthField(
-            size=self.__get_field_size(definition_message, RecordNextStopDepthField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordNextStopTimeField(
-            size=self.__get_field_size(definition_message, RecordNextStopTimeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordTimeToSurfaceField(
-            size=self.__get_field_size(definition_message, RecordTimeToSurfaceField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordNdlTimeField(
-            size=self.__get_field_size(definition_message, RecordNdlTimeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordCnsLoadField(
-            size=self.__get_field_size(definition_message, RecordCnsLoadField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordN2LoadField(
-            size=self.__get_field_size(definition_message, RecordN2LoadField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordRespirationRateField(
-            size=self.__get_field_size(definition_message, RecordRespirationRateField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordEnhancedRespirationRateField(
-            size=self.__get_field_size(definition_message, RecordEnhancedRespirationRateField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordGritField(
-            size=self.__get_field_size(definition_message, RecordGritField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordFlowField(
-            size=self.__get_field_size(definition_message, RecordFlowField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordCurrentStressField(
-            size=self.__get_field_size(definition_message, RecordCurrentStressField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordEbikeTravelRangeField(
-            size=self.__get_field_size(definition_message, RecordEbikeTravelRangeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordEbikeBatteryLevelField(
-            size=self.__get_field_size(definition_message, RecordEbikeBatteryLevelField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordEbikeAssistModeField(
-            size=self.__get_field_size(definition_message, RecordEbikeAssistModeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordEbikeAssistLevelPercentField(
-            size=self.__get_field_size(definition_message, RecordEbikeAssistLevelPercentField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordAirTimeRemainingField(
-            size=self.__get_field_size(definition_message, RecordAirTimeRemainingField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordPressureSacField(
-            size=self.__get_field_size(definition_message, RecordPressureSacField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordVolumeSacField(
-            size=self.__get_field_size(definition_message, RecordVolumeSacField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordRmvField(
-            size=self.__get_field_size(definition_message, RecordRmvField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordAscentRateField(
-            size=self.__get_field_size(definition_message, RecordAscentRateField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordPo2Field(
-            size=self.__get_field_size(definition_message, RecordPo2Field.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RecordCoreTemperatureField(
-            size=self.__get_field_size(definition_message, RecordCoreTemperatureField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        TimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampField.ID),
+            growable=False), 
+        RecordPositionLatField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordPositionLatField.ID),
+            growable=False), 
+        RecordPositionLongField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordPositionLongField.ID),
+            growable=False), 
+        RecordAltitudeField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordAltitudeField.ID),
+            growable=False), 
+        RecordHeartRateField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordHeartRateField.ID),
+            growable=False), 
+        RecordCadenceField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordCadenceField.ID),
+            growable=False), 
+        RecordDistanceField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordDistanceField.ID),
+            growable=False), 
+        RecordSpeedField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordSpeedField.ID),
+            growable=False), 
+        RecordPowerField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordPowerField.ID),
+            growable=False), 
+        RecordCompressedSpeedDistanceField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordCompressedSpeedDistanceField.ID),
+            growable=False), 
+        RecordGradeField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordGradeField.ID),
+            growable=False), 
+        RecordResistanceField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordResistanceField.ID),
+            growable=False), 
+        RecordTimeFromCourseField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordTimeFromCourseField.ID),
+            growable=False), 
+        RecordCycleLengthField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordCycleLengthField.ID),
+            growable=False), 
+        RecordTemperatureField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordTemperatureField.ID),
+            growable=False), 
+        RecordSpeed1sField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordSpeed1sField.ID),
+            growable=False), 
+        RecordCyclesField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordCyclesField.ID),
+            growable=False), 
+        RecordTotalCyclesField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordTotalCyclesField.ID),
+            growable=False), 
+        RecordCompressedAccumulatedPowerField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordCompressedAccumulatedPowerField.ID),
+            growable=False), 
+        RecordAccumulatedPowerField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordAccumulatedPowerField.ID),
+            growable=False), 
+        RecordLeftRightBalanceField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordLeftRightBalanceField.ID),
+            growable=False), 
+        RecordGpsAccuracyField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordGpsAccuracyField.ID),
+            growable=False), 
+        RecordVerticalSpeedField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordVerticalSpeedField.ID),
+            growable=False), 
+        RecordCaloriesField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordCaloriesField.ID),
+            growable=False), 
+        RecordVerticalOscillationField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordVerticalOscillationField.ID),
+            growable=False), 
+        RecordStanceTimePercentField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordStanceTimePercentField.ID),
+            growable=False), 
+        RecordStanceTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordStanceTimeField.ID),
+            growable=False), 
+        RecordActivityTypeField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordActivityTypeField.ID),
+            growable=False), 
+        RecordLeftTorqueEffectivenessField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordLeftTorqueEffectivenessField.ID),
+            growable=False), 
+        RecordRightTorqueEffectivenessField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordRightTorqueEffectivenessField.ID),
+            growable=False), 
+        RecordLeftPedalSmoothnessField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordLeftPedalSmoothnessField.ID),
+            growable=False), 
+        RecordRightPedalSmoothnessField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordRightPedalSmoothnessField.ID),
+            growable=False), 
+        RecordCombinedPedalSmoothnessField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordCombinedPedalSmoothnessField.ID),
+            growable=False), 
+        RecordTime128Field(
+            size=cls._field_size_from_definition(
+                definition_message, RecordTime128Field.ID),
+            growable=False), 
+        RecordStrokeTypeField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordStrokeTypeField.ID),
+            growable=False), 
+        RecordZoneField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordZoneField.ID),
+            growable=False), 
+        RecordBallSpeedField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordBallSpeedField.ID),
+            growable=False), 
+        RecordCadence256Field(
+            size=cls._field_size_from_definition(
+                definition_message, RecordCadence256Field.ID),
+            growable=False), 
+        RecordFractionalCadenceField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordFractionalCadenceField.ID),
+            growable=False), 
+        RecordTotalHemoglobinConcField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordTotalHemoglobinConcField.ID),
+            growable=False), 
+        RecordTotalHemoglobinConcMinField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordTotalHemoglobinConcMinField.ID),
+            growable=False), 
+        RecordTotalHemoglobinConcMaxField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordTotalHemoglobinConcMaxField.ID),
+            growable=False), 
+        RecordSaturatedHemoglobinPercentField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordSaturatedHemoglobinPercentField.ID),
+            growable=False), 
+        RecordSaturatedHemoglobinPercentMinField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordSaturatedHemoglobinPercentMinField.ID),
+            growable=False), 
+        RecordSaturatedHemoglobinPercentMaxField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordSaturatedHemoglobinPercentMaxField.ID),
+            growable=False), 
+        RecordDeviceIndexField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordDeviceIndexField.ID),
+            growable=False), 
+        RecordLeftPcoField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordLeftPcoField.ID),
+            growable=False), 
+        RecordRightPcoField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordRightPcoField.ID),
+            growable=False), 
+        RecordLeftPowerPhaseField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordLeftPowerPhaseField.ID),
+            growable=False), 
+        RecordLeftPowerPhasePeakField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordLeftPowerPhasePeakField.ID),
+            growable=False), 
+        RecordRightPowerPhaseField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordRightPowerPhaseField.ID),
+            growable=False), 
+        RecordRightPowerPhasePeakField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordRightPowerPhasePeakField.ID),
+            growable=False), 
+        RecordEnhancedSpeedField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordEnhancedSpeedField.ID),
+            growable=False), 
+        RecordEnhancedAltitudeField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordEnhancedAltitudeField.ID),
+            growable=False), 
+        RecordBatterySocField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordBatterySocField.ID),
+            growable=False), 
+        RecordMotorPowerField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordMotorPowerField.ID),
+            growable=False), 
+        RecordVerticalRatioField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordVerticalRatioField.ID),
+            growable=False), 
+        RecordStanceTimeBalanceField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordStanceTimeBalanceField.ID),
+            growable=False), 
+        RecordStepLengthField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordStepLengthField.ID),
+            growable=False), 
+        RecordCycleLength16Field(
+            size=cls._field_size_from_definition(
+                definition_message, RecordCycleLength16Field.ID),
+            growable=False), 
+        RecordAbsolutePressureField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordAbsolutePressureField.ID),
+            growable=False), 
+        RecordDepthField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordDepthField.ID),
+            growable=False), 
+        RecordNextStopDepthField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordNextStopDepthField.ID),
+            growable=False), 
+        RecordNextStopTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordNextStopTimeField.ID),
+            growable=False), 
+        RecordTimeToSurfaceField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordTimeToSurfaceField.ID),
+            growable=False), 
+        RecordNdlTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordNdlTimeField.ID),
+            growable=False), 
+        RecordCnsLoadField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordCnsLoadField.ID),
+            growable=False), 
+        RecordN2LoadField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordN2LoadField.ID),
+            growable=False), 
+        RecordRespirationRateField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordRespirationRateField.ID),
+            growable=False), 
+        RecordEnhancedRespirationRateField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordEnhancedRespirationRateField.ID),
+            growable=False), 
+        RecordGritField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordGritField.ID),
+            growable=False), 
+        RecordFlowField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordFlowField.ID),
+            growable=False), 
+        RecordCurrentStressField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordCurrentStressField.ID),
+            growable=False), 
+        RecordEbikeTravelRangeField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordEbikeTravelRangeField.ID),
+            growable=False), 
+        RecordEbikeBatteryLevelField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordEbikeBatteryLevelField.ID),
+            growable=False), 
+        RecordEbikeAssistModeField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordEbikeAssistModeField.ID),
+            growable=False), 
+        RecordEbikeAssistLevelPercentField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordEbikeAssistLevelPercentField.ID),
+            growable=False), 
+        RecordAirTimeRemainingField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordAirTimeRemainingField.ID),
+            growable=False), 
+        RecordPressureSacField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordPressureSacField.ID),
+            growable=False), 
+        RecordVolumeSacField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordVolumeSacField.ID),
+            growable=False), 
+        RecordRmvField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordRmvField.ID),
+            growable=False), 
+        RecordAscentRateField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordAscentRateField.ID),
+            growable=False), 
+        RecordPo2Field(
+            size=cls._field_size_from_definition(
+                definition_message, RecordPo2Field.ID),
+            growable=False), 
+        RecordCoreTemperatureField(
+            size=cls._field_size_from_definition(
+                definition_message, RecordCoreTemperatureField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/respiration_rate_message.py
+++ b/fit_tool/profile/messages/respiration_rate_message.py
@@ -17,42 +17,77 @@ from typing import Dict as dict
 
 
 class RespirationRateMessage(DataMessage):
+    """RespirationRateMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``RespirationRateMessage()`` — create path: growable fields, no wire definition.
+    * ``RespirationRateMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 297
     NAME = 'respiration_rate'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=RespirationRateMessage.NAME,
                          global_id=RespirationRateMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         TimestampField(
-            size=self.__get_field_size(definition_message, TimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         RespirationRateRespirationRateField(
-            size=self.__get_field_size(definition_message, RespirationRateRespirationRateField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        TimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampField.ID),
+            growable=False), 
+        RespirationRateRespirationRateField(
+            size=cls._field_size_from_definition(
+                definition_message, RespirationRateRespirationRateField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/schedule_message.py
+++ b/fit_tool/profile/messages/schedule_message.py
@@ -17,57 +17,112 @@ from typing import Dict as dict
 
 
 class ScheduleMessage(DataMessage):
+    """ScheduleMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``ScheduleMessage()`` — create path: growable fields, no wire definition.
+    * ``ScheduleMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 28
     NAME = 'schedule'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=ScheduleMessage.NAME,
                          global_id=ScheduleMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         ScheduleManufacturerField(
-            size=self.__get_field_size(definition_message, ScheduleManufacturerField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ScheduleProductField(
-            size=self.__get_field_size(definition_message, ScheduleProductField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ScheduleSerialNumberField(
-            size=self.__get_field_size(definition_message, ScheduleSerialNumberField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ScheduleTimeCreatedField(
-            size=self.__get_field_size(definition_message, ScheduleTimeCreatedField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ScheduleCompletedField(
-            size=self.__get_field_size(definition_message, ScheduleCompletedField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ScheduleTypeField(
-            size=self.__get_field_size(definition_message, ScheduleTypeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ScheduleScheduledTimeField(
-            size=self.__get_field_size(definition_message, ScheduleScheduledTimeField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        ScheduleManufacturerField(
+            size=cls._field_size_from_definition(
+                definition_message, ScheduleManufacturerField.ID),
+            growable=False), 
+        ScheduleProductField(
+            size=cls._field_size_from_definition(
+                definition_message, ScheduleProductField.ID),
+            growable=False), 
+        ScheduleSerialNumberField(
+            size=cls._field_size_from_definition(
+                definition_message, ScheduleSerialNumberField.ID),
+            growable=False), 
+        ScheduleTimeCreatedField(
+            size=cls._field_size_from_definition(
+                definition_message, ScheduleTimeCreatedField.ID),
+            growable=False), 
+        ScheduleCompletedField(
+            size=cls._field_size_from_definition(
+                definition_message, ScheduleCompletedField.ID),
+            growable=False), 
+        ScheduleTypeField(
+            size=cls._field_size_from_definition(
+                definition_message, ScheduleTypeField.ID),
+            growable=False), 
+        ScheduleScheduledTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, ScheduleScheduledTimeField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/sdm_profile_message.py
+++ b/fit_tool/profile/messages/sdm_profile_message.py
@@ -17,60 +17,119 @@ from typing import Dict as dict
 
 
 class SdmProfileMessage(DataMessage):
+    """SdmProfileMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``SdmProfileMessage()`` — create path: growable fields, no wire definition.
+    * ``SdmProfileMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 5
     NAME = 'sdm_profile'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=SdmProfileMessage.NAME,
                          global_id=SdmProfileMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         MessageIndexField(
-            size=self.__get_field_size(definition_message, MessageIndexField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SdmProfileEnabledField(
-            size=self.__get_field_size(definition_message, SdmProfileEnabledField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SdmProfileSdmAntIdField(
-            size=self.__get_field_size(definition_message, SdmProfileSdmAntIdField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SdmProfileSdmCalFactorField(
-            size=self.__get_field_size(definition_message, SdmProfileSdmCalFactorField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SdmProfileOdometerField(
-            size=self.__get_field_size(definition_message, SdmProfileOdometerField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SdmProfileSpeedSourceField(
-            size=self.__get_field_size(definition_message, SdmProfileSpeedSourceField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SdmProfileSdmAntIdTransTypeField(
-            size=self.__get_field_size(definition_message, SdmProfileSdmAntIdTransTypeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SdmProfileOdometerRolloverField(
-            size=self.__get_field_size(definition_message, SdmProfileOdometerRolloverField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        MessageIndexField(
+            size=cls._field_size_from_definition(
+                definition_message, MessageIndexField.ID),
+            growable=False), 
+        SdmProfileEnabledField(
+            size=cls._field_size_from_definition(
+                definition_message, SdmProfileEnabledField.ID),
+            growable=False), 
+        SdmProfileSdmAntIdField(
+            size=cls._field_size_from_definition(
+                definition_message, SdmProfileSdmAntIdField.ID),
+            growable=False), 
+        SdmProfileSdmCalFactorField(
+            size=cls._field_size_from_definition(
+                definition_message, SdmProfileSdmCalFactorField.ID),
+            growable=False), 
+        SdmProfileOdometerField(
+            size=cls._field_size_from_definition(
+                definition_message, SdmProfileOdometerField.ID),
+            growable=False), 
+        SdmProfileSpeedSourceField(
+            size=cls._field_size_from_definition(
+                definition_message, SdmProfileSpeedSourceField.ID),
+            growable=False), 
+        SdmProfileSdmAntIdTransTypeField(
+            size=cls._field_size_from_definition(
+                definition_message, SdmProfileSdmAntIdTransTypeField.ID),
+            growable=False), 
+        SdmProfileOdometerRolloverField(
+            size=cls._field_size_from_definition(
+                definition_message, SdmProfileOdometerRolloverField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/segment_file_message.py
+++ b/fit_tool/profile/messages/segment_file_message.py
@@ -17,63 +17,126 @@ from typing import Dict as dict
 
 
 class SegmentFileMessage(DataMessage):
+    """SegmentFileMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``SegmentFileMessage()`` — create path: growable fields, no wire definition.
+    * ``SegmentFileMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 151
     NAME = 'segment_file'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=SegmentFileMessage.NAME,
                          global_id=SegmentFileMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         MessageIndexField(
-            size=self.__get_field_size(definition_message, MessageIndexField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentFileFileUuidField(
-            size=self.__get_field_size(definition_message, SegmentFileFileUuidField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentFileEnabledField(
-            size=self.__get_field_size(definition_message, SegmentFileEnabledField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentFileUserProfilePrimaryKeyField(
-            size=self.__get_field_size(definition_message, SegmentFileUserProfilePrimaryKeyField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentFileLeaderTypeField(
-            size=self.__get_field_size(definition_message, SegmentFileLeaderTypeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentFileLeaderGroupPrimaryKeyField(
-            size=self.__get_field_size(definition_message, SegmentFileLeaderGroupPrimaryKeyField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentFileLeaderActivityIdField(
-            size=self.__get_field_size(definition_message, SegmentFileLeaderActivityIdField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentFileLeaderActivityIdStringField(
-            size=self.__get_field_size(definition_message, SegmentFileLeaderActivityIdStringField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentFileDefaultRaceLeaderField(
-            size=self.__get_field_size(definition_message, SegmentFileDefaultRaceLeaderField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        MessageIndexField(
+            size=cls._field_size_from_definition(
+                definition_message, MessageIndexField.ID),
+            growable=False), 
+        SegmentFileFileUuidField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentFileFileUuidField.ID),
+            growable=False), 
+        SegmentFileEnabledField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentFileEnabledField.ID),
+            growable=False), 
+        SegmentFileUserProfilePrimaryKeyField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentFileUserProfilePrimaryKeyField.ID),
+            growable=False), 
+        SegmentFileLeaderTypeField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentFileLeaderTypeField.ID),
+            growable=False), 
+        SegmentFileLeaderGroupPrimaryKeyField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentFileLeaderGroupPrimaryKeyField.ID),
+            growable=False), 
+        SegmentFileLeaderActivityIdField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentFileLeaderActivityIdField.ID),
+            growable=False), 
+        SegmentFileLeaderActivityIdStringField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentFileLeaderActivityIdStringField.ID),
+            growable=False), 
+        SegmentFileDefaultRaceLeaderField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentFileDefaultRaceLeaderField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/segment_id_message.py
+++ b/fit_tool/profile/messages/segment_id_message.py
@@ -17,63 +17,126 @@ from typing import Dict as dict
 
 
 class SegmentIdMessage(DataMessage):
+    """SegmentIdMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``SegmentIdMessage()`` — create path: growable fields, no wire definition.
+    * ``SegmentIdMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 148
     NAME = 'segment_id'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=SegmentIdMessage.NAME,
                          global_id=SegmentIdMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         SegmentIdNameField(
-            size=self.__get_field_size(definition_message, SegmentIdNameField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentIdUuidField(
-            size=self.__get_field_size(definition_message, SegmentIdUuidField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentIdSportField(
-            size=self.__get_field_size(definition_message, SegmentIdSportField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentIdEnabledField(
-            size=self.__get_field_size(definition_message, SegmentIdEnabledField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentIdUserProfilePrimaryKeyField(
-            size=self.__get_field_size(definition_message, SegmentIdUserProfilePrimaryKeyField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentIdDeviceIdField(
-            size=self.__get_field_size(definition_message, SegmentIdDeviceIdField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentIdDefaultRaceLeaderField(
-            size=self.__get_field_size(definition_message, SegmentIdDefaultRaceLeaderField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentIdDeleteStatusField(
-            size=self.__get_field_size(definition_message, SegmentIdDeleteStatusField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentIdSelectionTypeField(
-            size=self.__get_field_size(definition_message, SegmentIdSelectionTypeField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        SegmentIdNameField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentIdNameField.ID),
+            growable=False), 
+        SegmentIdUuidField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentIdUuidField.ID),
+            growable=False), 
+        SegmentIdSportField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentIdSportField.ID),
+            growable=False), 
+        SegmentIdEnabledField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentIdEnabledField.ID),
+            growable=False), 
+        SegmentIdUserProfilePrimaryKeyField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentIdUserProfilePrimaryKeyField.ID),
+            growable=False), 
+        SegmentIdDeviceIdField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentIdDeviceIdField.ID),
+            growable=False), 
+        SegmentIdDefaultRaceLeaderField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentIdDefaultRaceLeaderField.ID),
+            growable=False), 
+        SegmentIdDeleteStatusField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentIdDeleteStatusField.ID),
+            growable=False), 
+        SegmentIdSelectionTypeField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentIdSelectionTypeField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/segment_lap_message.py
+++ b/fit_tool/profile/messages/segment_lap_message.py
@@ -17,321 +17,728 @@ from typing import Dict as dict
 
 
 class SegmentLapMessage(DataMessage):
+    """SegmentLapMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``SegmentLapMessage()`` — create path: growable fields, no wire definition.
+    * ``SegmentLapMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 142
     NAME = 'segment_lap'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=SegmentLapMessage.NAME,
                          global_id=SegmentLapMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         MessageIndexField(
-            size=self.__get_field_size(definition_message, MessageIndexField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         TimestampField(
-            size=self.__get_field_size(definition_message, TimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapEventField(
-            size=self.__get_field_size(definition_message, SegmentLapEventField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapEventTypeField(
-            size=self.__get_field_size(definition_message, SegmentLapEventTypeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapStartTimeField(
-            size=self.__get_field_size(definition_message, SegmentLapStartTimeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapStartPositionLatField(
-            size=self.__get_field_size(definition_message, SegmentLapStartPositionLatField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapStartPositionLongField(
-            size=self.__get_field_size(definition_message, SegmentLapStartPositionLongField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapEndPositionLatField(
-            size=self.__get_field_size(definition_message, SegmentLapEndPositionLatField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapEndPositionLongField(
-            size=self.__get_field_size(definition_message, SegmentLapEndPositionLongField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapTotalElapsedTimeField(
-            size=self.__get_field_size(definition_message, SegmentLapTotalElapsedTimeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapTotalTimerTimeField(
-            size=self.__get_field_size(definition_message, SegmentLapTotalTimerTimeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapTotalDistanceField(
-            size=self.__get_field_size(definition_message, SegmentLapTotalDistanceField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapTotalCyclesField(
-            size=self.__get_field_size(definition_message, SegmentLapTotalCyclesField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapTotalCaloriesField(
-            size=self.__get_field_size(definition_message, SegmentLapTotalCaloriesField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapTotalFatCaloriesField(
-            size=self.__get_field_size(definition_message, SegmentLapTotalFatCaloriesField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapAvgSpeedField(
-            size=self.__get_field_size(definition_message, SegmentLapAvgSpeedField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapMaxSpeedField(
-            size=self.__get_field_size(definition_message, SegmentLapMaxSpeedField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapAvgHeartRateField(
-            size=self.__get_field_size(definition_message, SegmentLapAvgHeartRateField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapMaxHeartRateField(
-            size=self.__get_field_size(definition_message, SegmentLapMaxHeartRateField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapAvgCadenceField(
-            size=self.__get_field_size(definition_message, SegmentLapAvgCadenceField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapMaxCadenceField(
-            size=self.__get_field_size(definition_message, SegmentLapMaxCadenceField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapAvgPowerField(
-            size=self.__get_field_size(definition_message, SegmentLapAvgPowerField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapMaxPowerField(
-            size=self.__get_field_size(definition_message, SegmentLapMaxPowerField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapTotalAscentField(
-            size=self.__get_field_size(definition_message, SegmentLapTotalAscentField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapTotalDescentField(
-            size=self.__get_field_size(definition_message, SegmentLapTotalDescentField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapSportField(
-            size=self.__get_field_size(definition_message, SegmentLapSportField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapEventGroupField(
-            size=self.__get_field_size(definition_message, SegmentLapEventGroupField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapNecLatField(
-            size=self.__get_field_size(definition_message, SegmentLapNecLatField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapNecLongField(
-            size=self.__get_field_size(definition_message, SegmentLapNecLongField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapSwcLatField(
-            size=self.__get_field_size(definition_message, SegmentLapSwcLatField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapSwcLongField(
-            size=self.__get_field_size(definition_message, SegmentLapSwcLongField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapNameField(
-            size=self.__get_field_size(definition_message, SegmentLapNameField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapNormalizedPowerField(
-            size=self.__get_field_size(definition_message, SegmentLapNormalizedPowerField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapLeftRightBalanceField(
-            size=self.__get_field_size(definition_message, SegmentLapLeftRightBalanceField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapSubSportField(
-            size=self.__get_field_size(definition_message, SegmentLapSubSportField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapTotalWorkField(
-            size=self.__get_field_size(definition_message, SegmentLapTotalWorkField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapAvgAltitudeField(
-            size=self.__get_field_size(definition_message, SegmentLapAvgAltitudeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapMaxAltitudeField(
-            size=self.__get_field_size(definition_message, SegmentLapMaxAltitudeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapGpsAccuracyField(
-            size=self.__get_field_size(definition_message, SegmentLapGpsAccuracyField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapAvgGradeField(
-            size=self.__get_field_size(definition_message, SegmentLapAvgGradeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapAvgPosGradeField(
-            size=self.__get_field_size(definition_message, SegmentLapAvgPosGradeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapAvgNegGradeField(
-            size=self.__get_field_size(definition_message, SegmentLapAvgNegGradeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapMaxPosGradeField(
-            size=self.__get_field_size(definition_message, SegmentLapMaxPosGradeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapMaxNegGradeField(
-            size=self.__get_field_size(definition_message, SegmentLapMaxNegGradeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapAvgTemperatureField(
-            size=self.__get_field_size(definition_message, SegmentLapAvgTemperatureField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapMaxTemperatureField(
-            size=self.__get_field_size(definition_message, SegmentLapMaxTemperatureField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapTotalMovingTimeField(
-            size=self.__get_field_size(definition_message, SegmentLapTotalMovingTimeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapAvgPosVerticalSpeedField(
-            size=self.__get_field_size(definition_message, SegmentLapAvgPosVerticalSpeedField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapAvgNegVerticalSpeedField(
-            size=self.__get_field_size(definition_message, SegmentLapAvgNegVerticalSpeedField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapMaxPosVerticalSpeedField(
-            size=self.__get_field_size(definition_message, SegmentLapMaxPosVerticalSpeedField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapMaxNegVerticalSpeedField(
-            size=self.__get_field_size(definition_message, SegmentLapMaxNegVerticalSpeedField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapTimeInHrZoneField(
-            size=self.__get_field_size(definition_message, SegmentLapTimeInHrZoneField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapTimeInSpeedZoneField(
-            size=self.__get_field_size(definition_message, SegmentLapTimeInSpeedZoneField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapTimeInCadenceZoneField(
-            size=self.__get_field_size(definition_message, SegmentLapTimeInCadenceZoneField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapTimeInPowerZoneField(
-            size=self.__get_field_size(definition_message, SegmentLapTimeInPowerZoneField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapRepetitionNumField(
-            size=self.__get_field_size(definition_message, SegmentLapRepetitionNumField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapMinAltitudeField(
-            size=self.__get_field_size(definition_message, SegmentLapMinAltitudeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapMinHeartRateField(
-            size=self.__get_field_size(definition_message, SegmentLapMinHeartRateField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapActiveTimeField(
-            size=self.__get_field_size(definition_message, SegmentLapActiveTimeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapWorkoutStepIndexField(
-            size=self.__get_field_size(definition_message, SegmentLapWorkoutStepIndexField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapSportEventField(
-            size=self.__get_field_size(definition_message, SegmentLapSportEventField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapAvgLeftTorqueEffectivenessField(
-            size=self.__get_field_size(definition_message, SegmentLapAvgLeftTorqueEffectivenessField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapAvgRightTorqueEffectivenessField(
-            size=self.__get_field_size(definition_message, SegmentLapAvgRightTorqueEffectivenessField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapAvgLeftPedalSmoothnessField(
-            size=self.__get_field_size(definition_message, SegmentLapAvgLeftPedalSmoothnessField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapAvgRightPedalSmoothnessField(
-            size=self.__get_field_size(definition_message, SegmentLapAvgRightPedalSmoothnessField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapAvgCombinedPedalSmoothnessField(
-            size=self.__get_field_size(definition_message, SegmentLapAvgCombinedPedalSmoothnessField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapStatusField(
-            size=self.__get_field_size(definition_message, SegmentLapStatusField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapUuidField(
-            size=self.__get_field_size(definition_message, SegmentLapUuidField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapAvgFractionalCadenceField(
-            size=self.__get_field_size(definition_message, SegmentLapAvgFractionalCadenceField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapMaxFractionalCadenceField(
-            size=self.__get_field_size(definition_message, SegmentLapMaxFractionalCadenceField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapTotalFractionalCyclesField(
-            size=self.__get_field_size(definition_message, SegmentLapTotalFractionalCyclesField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapFrontGearShiftCountField(
-            size=self.__get_field_size(definition_message, SegmentLapFrontGearShiftCountField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapRearGearShiftCountField(
-            size=self.__get_field_size(definition_message, SegmentLapRearGearShiftCountField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapTimeStandingField(
-            size=self.__get_field_size(definition_message, SegmentLapTimeStandingField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapStandCountField(
-            size=self.__get_field_size(definition_message, SegmentLapStandCountField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapAvgLeftPcoField(
-            size=self.__get_field_size(definition_message, SegmentLapAvgLeftPcoField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapAvgRightPcoField(
-            size=self.__get_field_size(definition_message, SegmentLapAvgRightPcoField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapAvgLeftPowerPhaseField(
-            size=self.__get_field_size(definition_message, SegmentLapAvgLeftPowerPhaseField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapAvgLeftPowerPhasePeakField(
-            size=self.__get_field_size(definition_message, SegmentLapAvgLeftPowerPhasePeakField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapAvgRightPowerPhaseField(
-            size=self.__get_field_size(definition_message, SegmentLapAvgRightPowerPhaseField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapAvgRightPowerPhasePeakField(
-            size=self.__get_field_size(definition_message, SegmentLapAvgRightPowerPhasePeakField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapAvgPowerPositionField(
-            size=self.__get_field_size(definition_message, SegmentLapAvgPowerPositionField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapMaxPowerPositionField(
-            size=self.__get_field_size(definition_message, SegmentLapMaxPowerPositionField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapAvgCadencePositionField(
-            size=self.__get_field_size(definition_message, SegmentLapAvgCadencePositionField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapMaxCadencePositionField(
-            size=self.__get_field_size(definition_message, SegmentLapMaxCadencePositionField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapManufacturerField(
-            size=self.__get_field_size(definition_message, SegmentLapManufacturerField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapTotalGritField(
-            size=self.__get_field_size(definition_message, SegmentLapTotalGritField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapTotalFlowField(
-            size=self.__get_field_size(definition_message, SegmentLapTotalFlowField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapAvgGritField(
-            size=self.__get_field_size(definition_message, SegmentLapAvgGritField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapAvgFlowField(
-            size=self.__get_field_size(definition_message, SegmentLapAvgFlowField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapTotalFractionalAscentField(
-            size=self.__get_field_size(definition_message, SegmentLapTotalFractionalAscentField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapTotalFractionalDescentField(
-            size=self.__get_field_size(definition_message, SegmentLapTotalFractionalDescentField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapEnhancedAvgAltitudeField(
-            size=self.__get_field_size(definition_message, SegmentLapEnhancedAvgAltitudeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapEnhancedMaxAltitudeField(
-            size=self.__get_field_size(definition_message, SegmentLapEnhancedMaxAltitudeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLapEnhancedMinAltitudeField(
-            size=self.__get_field_size(definition_message, SegmentLapEnhancedMinAltitudeField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        MessageIndexField(
+            size=cls._field_size_from_definition(
+                definition_message, MessageIndexField.ID),
+            growable=False), 
+        TimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampField.ID),
+            growable=False), 
+        SegmentLapEventField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapEventField.ID),
+            growable=False), 
+        SegmentLapEventTypeField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapEventTypeField.ID),
+            growable=False), 
+        SegmentLapStartTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapStartTimeField.ID),
+            growable=False), 
+        SegmentLapStartPositionLatField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapStartPositionLatField.ID),
+            growable=False), 
+        SegmentLapStartPositionLongField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapStartPositionLongField.ID),
+            growable=False), 
+        SegmentLapEndPositionLatField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapEndPositionLatField.ID),
+            growable=False), 
+        SegmentLapEndPositionLongField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapEndPositionLongField.ID),
+            growable=False), 
+        SegmentLapTotalElapsedTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapTotalElapsedTimeField.ID),
+            growable=False), 
+        SegmentLapTotalTimerTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapTotalTimerTimeField.ID),
+            growable=False), 
+        SegmentLapTotalDistanceField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapTotalDistanceField.ID),
+            growable=False), 
+        SegmentLapTotalCyclesField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapTotalCyclesField.ID),
+            growable=False), 
+        SegmentLapTotalCaloriesField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapTotalCaloriesField.ID),
+            growable=False), 
+        SegmentLapTotalFatCaloriesField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapTotalFatCaloriesField.ID),
+            growable=False), 
+        SegmentLapAvgSpeedField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapAvgSpeedField.ID),
+            growable=False), 
+        SegmentLapMaxSpeedField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapMaxSpeedField.ID),
+            growable=False), 
+        SegmentLapAvgHeartRateField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapAvgHeartRateField.ID),
+            growable=False), 
+        SegmentLapMaxHeartRateField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapMaxHeartRateField.ID),
+            growable=False), 
+        SegmentLapAvgCadenceField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapAvgCadenceField.ID),
+            growable=False), 
+        SegmentLapMaxCadenceField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapMaxCadenceField.ID),
+            growable=False), 
+        SegmentLapAvgPowerField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapAvgPowerField.ID),
+            growable=False), 
+        SegmentLapMaxPowerField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapMaxPowerField.ID),
+            growable=False), 
+        SegmentLapTotalAscentField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapTotalAscentField.ID),
+            growable=False), 
+        SegmentLapTotalDescentField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapTotalDescentField.ID),
+            growable=False), 
+        SegmentLapSportField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapSportField.ID),
+            growable=False), 
+        SegmentLapEventGroupField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapEventGroupField.ID),
+            growable=False), 
+        SegmentLapNecLatField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapNecLatField.ID),
+            growable=False), 
+        SegmentLapNecLongField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapNecLongField.ID),
+            growable=False), 
+        SegmentLapSwcLatField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapSwcLatField.ID),
+            growable=False), 
+        SegmentLapSwcLongField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapSwcLongField.ID),
+            growable=False), 
+        SegmentLapNameField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapNameField.ID),
+            growable=False), 
+        SegmentLapNormalizedPowerField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapNormalizedPowerField.ID),
+            growable=False), 
+        SegmentLapLeftRightBalanceField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapLeftRightBalanceField.ID),
+            growable=False), 
+        SegmentLapSubSportField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapSubSportField.ID),
+            growable=False), 
+        SegmentLapTotalWorkField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapTotalWorkField.ID),
+            growable=False), 
+        SegmentLapAvgAltitudeField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapAvgAltitudeField.ID),
+            growable=False), 
+        SegmentLapMaxAltitudeField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapMaxAltitudeField.ID),
+            growable=False), 
+        SegmentLapGpsAccuracyField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapGpsAccuracyField.ID),
+            growable=False), 
+        SegmentLapAvgGradeField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapAvgGradeField.ID),
+            growable=False), 
+        SegmentLapAvgPosGradeField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapAvgPosGradeField.ID),
+            growable=False), 
+        SegmentLapAvgNegGradeField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapAvgNegGradeField.ID),
+            growable=False), 
+        SegmentLapMaxPosGradeField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapMaxPosGradeField.ID),
+            growable=False), 
+        SegmentLapMaxNegGradeField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapMaxNegGradeField.ID),
+            growable=False), 
+        SegmentLapAvgTemperatureField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapAvgTemperatureField.ID),
+            growable=False), 
+        SegmentLapMaxTemperatureField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapMaxTemperatureField.ID),
+            growable=False), 
+        SegmentLapTotalMovingTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapTotalMovingTimeField.ID),
+            growable=False), 
+        SegmentLapAvgPosVerticalSpeedField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapAvgPosVerticalSpeedField.ID),
+            growable=False), 
+        SegmentLapAvgNegVerticalSpeedField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapAvgNegVerticalSpeedField.ID),
+            growable=False), 
+        SegmentLapMaxPosVerticalSpeedField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapMaxPosVerticalSpeedField.ID),
+            growable=False), 
+        SegmentLapMaxNegVerticalSpeedField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapMaxNegVerticalSpeedField.ID),
+            growable=False), 
+        SegmentLapTimeInHrZoneField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapTimeInHrZoneField.ID),
+            growable=False), 
+        SegmentLapTimeInSpeedZoneField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapTimeInSpeedZoneField.ID),
+            growable=False), 
+        SegmentLapTimeInCadenceZoneField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapTimeInCadenceZoneField.ID),
+            growable=False), 
+        SegmentLapTimeInPowerZoneField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapTimeInPowerZoneField.ID),
+            growable=False), 
+        SegmentLapRepetitionNumField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapRepetitionNumField.ID),
+            growable=False), 
+        SegmentLapMinAltitudeField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapMinAltitudeField.ID),
+            growable=False), 
+        SegmentLapMinHeartRateField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapMinHeartRateField.ID),
+            growable=False), 
+        SegmentLapActiveTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapActiveTimeField.ID),
+            growable=False), 
+        SegmentLapWorkoutStepIndexField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapWorkoutStepIndexField.ID),
+            growable=False), 
+        SegmentLapSportEventField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapSportEventField.ID),
+            growable=False), 
+        SegmentLapAvgLeftTorqueEffectivenessField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapAvgLeftTorqueEffectivenessField.ID),
+            growable=False), 
+        SegmentLapAvgRightTorqueEffectivenessField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapAvgRightTorqueEffectivenessField.ID),
+            growable=False), 
+        SegmentLapAvgLeftPedalSmoothnessField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapAvgLeftPedalSmoothnessField.ID),
+            growable=False), 
+        SegmentLapAvgRightPedalSmoothnessField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapAvgRightPedalSmoothnessField.ID),
+            growable=False), 
+        SegmentLapAvgCombinedPedalSmoothnessField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapAvgCombinedPedalSmoothnessField.ID),
+            growable=False), 
+        SegmentLapStatusField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapStatusField.ID),
+            growable=False), 
+        SegmentLapUuidField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapUuidField.ID),
+            growable=False), 
+        SegmentLapAvgFractionalCadenceField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapAvgFractionalCadenceField.ID),
+            growable=False), 
+        SegmentLapMaxFractionalCadenceField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapMaxFractionalCadenceField.ID),
+            growable=False), 
+        SegmentLapTotalFractionalCyclesField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapTotalFractionalCyclesField.ID),
+            growable=False), 
+        SegmentLapFrontGearShiftCountField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapFrontGearShiftCountField.ID),
+            growable=False), 
+        SegmentLapRearGearShiftCountField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapRearGearShiftCountField.ID),
+            growable=False), 
+        SegmentLapTimeStandingField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapTimeStandingField.ID),
+            growable=False), 
+        SegmentLapStandCountField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapStandCountField.ID),
+            growable=False), 
+        SegmentLapAvgLeftPcoField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapAvgLeftPcoField.ID),
+            growable=False), 
+        SegmentLapAvgRightPcoField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapAvgRightPcoField.ID),
+            growable=False), 
+        SegmentLapAvgLeftPowerPhaseField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapAvgLeftPowerPhaseField.ID),
+            growable=False), 
+        SegmentLapAvgLeftPowerPhasePeakField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapAvgLeftPowerPhasePeakField.ID),
+            growable=False), 
+        SegmentLapAvgRightPowerPhaseField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapAvgRightPowerPhaseField.ID),
+            growable=False), 
+        SegmentLapAvgRightPowerPhasePeakField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapAvgRightPowerPhasePeakField.ID),
+            growable=False), 
+        SegmentLapAvgPowerPositionField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapAvgPowerPositionField.ID),
+            growable=False), 
+        SegmentLapMaxPowerPositionField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapMaxPowerPositionField.ID),
+            growable=False), 
+        SegmentLapAvgCadencePositionField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapAvgCadencePositionField.ID),
+            growable=False), 
+        SegmentLapMaxCadencePositionField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapMaxCadencePositionField.ID),
+            growable=False), 
+        SegmentLapManufacturerField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapManufacturerField.ID),
+            growable=False), 
+        SegmentLapTotalGritField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapTotalGritField.ID),
+            growable=False), 
+        SegmentLapTotalFlowField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapTotalFlowField.ID),
+            growable=False), 
+        SegmentLapAvgGritField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapAvgGritField.ID),
+            growable=False), 
+        SegmentLapAvgFlowField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapAvgFlowField.ID),
+            growable=False), 
+        SegmentLapTotalFractionalAscentField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapTotalFractionalAscentField.ID),
+            growable=False), 
+        SegmentLapTotalFractionalDescentField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapTotalFractionalDescentField.ID),
+            growable=False), 
+        SegmentLapEnhancedAvgAltitudeField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapEnhancedAvgAltitudeField.ID),
+            growable=False), 
+        SegmentLapEnhancedMaxAltitudeField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapEnhancedMaxAltitudeField.ID),
+            growable=False), 
+        SegmentLapEnhancedMinAltitudeField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLapEnhancedMinAltitudeField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/segment_leaderboard_entry_message.py
+++ b/fit_tool/profile/messages/segment_leaderboard_entry_message.py
@@ -17,57 +17,112 @@ from typing import Dict as dict
 
 
 class SegmentLeaderboardEntryMessage(DataMessage):
+    """SegmentLeaderboardEntryMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``SegmentLeaderboardEntryMessage()`` — create path: growable fields, no wire definition.
+    * ``SegmentLeaderboardEntryMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 149
     NAME = 'segment_leaderboard_entry'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=SegmentLeaderboardEntryMessage.NAME,
                          global_id=SegmentLeaderboardEntryMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         MessageIndexField(
-            size=self.__get_field_size(definition_message, MessageIndexField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLeaderboardEntryNameField(
-            size=self.__get_field_size(definition_message, SegmentLeaderboardEntryNameField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLeaderboardEntryTypeField(
-            size=self.__get_field_size(definition_message, SegmentLeaderboardEntryTypeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLeaderboardEntryGroupPrimaryKeyField(
-            size=self.__get_field_size(definition_message, SegmentLeaderboardEntryGroupPrimaryKeyField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLeaderboardEntryActivityIdField(
-            size=self.__get_field_size(definition_message, SegmentLeaderboardEntryActivityIdField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLeaderboardEntrySegmentTimeField(
-            size=self.__get_field_size(definition_message, SegmentLeaderboardEntrySegmentTimeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentLeaderboardEntryActivityIdStringField(
-            size=self.__get_field_size(definition_message, SegmentLeaderboardEntryActivityIdStringField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        MessageIndexField(
+            size=cls._field_size_from_definition(
+                definition_message, MessageIndexField.ID),
+            growable=False), 
+        SegmentLeaderboardEntryNameField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLeaderboardEntryNameField.ID),
+            growable=False), 
+        SegmentLeaderboardEntryTypeField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLeaderboardEntryTypeField.ID),
+            growable=False), 
+        SegmentLeaderboardEntryGroupPrimaryKeyField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLeaderboardEntryGroupPrimaryKeyField.ID),
+            growable=False), 
+        SegmentLeaderboardEntryActivityIdField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLeaderboardEntryActivityIdField.ID),
+            growable=False), 
+        SegmentLeaderboardEntrySegmentTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLeaderboardEntrySegmentTimeField.ID),
+            growable=False), 
+        SegmentLeaderboardEntryActivityIdStringField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentLeaderboardEntryActivityIdStringField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/segment_point_message.py
+++ b/fit_tool/profile/messages/segment_point_message.py
@@ -17,57 +17,112 @@ from typing import Dict as dict
 
 
 class SegmentPointMessage(DataMessage):
+    """SegmentPointMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``SegmentPointMessage()`` — create path: growable fields, no wire definition.
+    * ``SegmentPointMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 150
     NAME = 'segment_point'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=SegmentPointMessage.NAME,
                          global_id=SegmentPointMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         MessageIndexField(
-            size=self.__get_field_size(definition_message, MessageIndexField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentPointPositionLatField(
-            size=self.__get_field_size(definition_message, SegmentPointPositionLatField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentPointPositionLongField(
-            size=self.__get_field_size(definition_message, SegmentPointPositionLongField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentPointDistanceField(
-            size=self.__get_field_size(definition_message, SegmentPointDistanceField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentPointAltitudeField(
-            size=self.__get_field_size(definition_message, SegmentPointAltitudeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentPointLeaderTimeField(
-            size=self.__get_field_size(definition_message, SegmentPointLeaderTimeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SegmentPointEnhancedAltitudeField(
-            size=self.__get_field_size(definition_message, SegmentPointEnhancedAltitudeField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        MessageIndexField(
+            size=cls._field_size_from_definition(
+                definition_message, MessageIndexField.ID),
+            growable=False), 
+        SegmentPointPositionLatField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentPointPositionLatField.ID),
+            growable=False), 
+        SegmentPointPositionLongField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentPointPositionLongField.ID),
+            growable=False), 
+        SegmentPointDistanceField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentPointDistanceField.ID),
+            growable=False), 
+        SegmentPointAltitudeField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentPointAltitudeField.ID),
+            growable=False), 
+        SegmentPointLeaderTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentPointLeaderTimeField.ID),
+            growable=False), 
+        SegmentPointEnhancedAltitudeField(
+            size=cls._field_size_from_definition(
+                definition_message, SegmentPointEnhancedAltitudeField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/session_message.py
+++ b/fit_tool/profile/messages/session_message.py
@@ -17,510 +17,1169 @@ from typing import Dict as dict
 
 
 class SessionMessage(DataMessage):
+    """SessionMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``SessionMessage()`` — create path: growable fields, no wire definition.
+    * ``SessionMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 18
     NAME = 'session'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=SessionMessage.NAME,
                          global_id=SessionMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         MessageIndexField(
-            size=self.__get_field_size(definition_message, MessageIndexField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         TimestampField(
-            size=self.__get_field_size(definition_message, TimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionEventField(
-            size=self.__get_field_size(definition_message, SessionEventField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionEventTypeField(
-            size=self.__get_field_size(definition_message, SessionEventTypeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionStartTimeField(
-            size=self.__get_field_size(definition_message, SessionStartTimeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionStartPositionLatField(
-            size=self.__get_field_size(definition_message, SessionStartPositionLatField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionStartPositionLongField(
-            size=self.__get_field_size(definition_message, SessionStartPositionLongField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionSportField(
-            size=self.__get_field_size(definition_message, SessionSportField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionSubSportField(
-            size=self.__get_field_size(definition_message, SessionSubSportField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionTotalElapsedTimeField(
-            size=self.__get_field_size(definition_message, SessionTotalElapsedTimeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionTotalTimerTimeField(
-            size=self.__get_field_size(definition_message, SessionTotalTimerTimeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionTotalDistanceField(
-            size=self.__get_field_size(definition_message, SessionTotalDistanceField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionTotalCyclesField(
-            size=self.__get_field_size(definition_message, SessionTotalCyclesField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionTotalCaloriesField(
-            size=self.__get_field_size(definition_message, SessionTotalCaloriesField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionTotalFatCaloriesField(
-            size=self.__get_field_size(definition_message, SessionTotalFatCaloriesField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionAvgSpeedField(
-            size=self.__get_field_size(definition_message, SessionAvgSpeedField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionMaxSpeedField(
-            size=self.__get_field_size(definition_message, SessionMaxSpeedField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionAvgHeartRateField(
-            size=self.__get_field_size(definition_message, SessionAvgHeartRateField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionMaxHeartRateField(
-            size=self.__get_field_size(definition_message, SessionMaxHeartRateField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionAvgCadenceField(
-            size=self.__get_field_size(definition_message, SessionAvgCadenceField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionMaxCadenceField(
-            size=self.__get_field_size(definition_message, SessionMaxCadenceField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionAvgPowerField(
-            size=self.__get_field_size(definition_message, SessionAvgPowerField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionMaxPowerField(
-            size=self.__get_field_size(definition_message, SessionMaxPowerField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionTotalAscentField(
-            size=self.__get_field_size(definition_message, SessionTotalAscentField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionTotalDescentField(
-            size=self.__get_field_size(definition_message, SessionTotalDescentField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionTotalTrainingEffectField(
-            size=self.__get_field_size(definition_message, SessionTotalTrainingEffectField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionFirstLapIndexField(
-            size=self.__get_field_size(definition_message, SessionFirstLapIndexField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionNumLapsField(
-            size=self.__get_field_size(definition_message, SessionNumLapsField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionEventGroupField(
-            size=self.__get_field_size(definition_message, SessionEventGroupField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionTriggerField(
-            size=self.__get_field_size(definition_message, SessionTriggerField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionNecLatField(
-            size=self.__get_field_size(definition_message, SessionNecLatField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionNecLongField(
-            size=self.__get_field_size(definition_message, SessionNecLongField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionSwcLatField(
-            size=self.__get_field_size(definition_message, SessionSwcLatField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionSwcLongField(
-            size=self.__get_field_size(definition_message, SessionSwcLongField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionNumLengthsField(
-            size=self.__get_field_size(definition_message, SessionNumLengthsField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionNormalizedPowerField(
-            size=self.__get_field_size(definition_message, SessionNormalizedPowerField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionTrainingStressScoreField(
-            size=self.__get_field_size(definition_message, SessionTrainingStressScoreField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionIntensityFactorField(
-            size=self.__get_field_size(definition_message, SessionIntensityFactorField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionLeftRightBalanceField(
-            size=self.__get_field_size(definition_message, SessionLeftRightBalanceField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionEndPositionLatField(
-            size=self.__get_field_size(definition_message, SessionEndPositionLatField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionEndPositionLongField(
-            size=self.__get_field_size(definition_message, SessionEndPositionLongField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionAvgStrokeCountField(
-            size=self.__get_field_size(definition_message, SessionAvgStrokeCountField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionAvgStrokeDistanceField(
-            size=self.__get_field_size(definition_message, SessionAvgStrokeDistanceField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionSwimStrokeField(
-            size=self.__get_field_size(definition_message, SessionSwimStrokeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionPoolLengthField(
-            size=self.__get_field_size(definition_message, SessionPoolLengthField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionThresholdPowerField(
-            size=self.__get_field_size(definition_message, SessionThresholdPowerField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionPoolLengthUnitField(
-            size=self.__get_field_size(definition_message, SessionPoolLengthUnitField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionNumActiveLengthsField(
-            size=self.__get_field_size(definition_message, SessionNumActiveLengthsField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionTotalWorkField(
-            size=self.__get_field_size(definition_message, SessionTotalWorkField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionAvgAltitudeField(
-            size=self.__get_field_size(definition_message, SessionAvgAltitudeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionMaxAltitudeField(
-            size=self.__get_field_size(definition_message, SessionMaxAltitudeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionGpsAccuracyField(
-            size=self.__get_field_size(definition_message, SessionGpsAccuracyField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionAvgGradeField(
-            size=self.__get_field_size(definition_message, SessionAvgGradeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionAvgPosGradeField(
-            size=self.__get_field_size(definition_message, SessionAvgPosGradeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionAvgNegGradeField(
-            size=self.__get_field_size(definition_message, SessionAvgNegGradeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionMaxPosGradeField(
-            size=self.__get_field_size(definition_message, SessionMaxPosGradeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionMaxNegGradeField(
-            size=self.__get_field_size(definition_message, SessionMaxNegGradeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionAvgTemperatureField(
-            size=self.__get_field_size(definition_message, SessionAvgTemperatureField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionMaxTemperatureField(
-            size=self.__get_field_size(definition_message, SessionMaxTemperatureField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionTotalMovingTimeField(
-            size=self.__get_field_size(definition_message, SessionTotalMovingTimeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionAvgPosVerticalSpeedField(
-            size=self.__get_field_size(definition_message, SessionAvgPosVerticalSpeedField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionAvgNegVerticalSpeedField(
-            size=self.__get_field_size(definition_message, SessionAvgNegVerticalSpeedField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionMaxPosVerticalSpeedField(
-            size=self.__get_field_size(definition_message, SessionMaxPosVerticalSpeedField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionMaxNegVerticalSpeedField(
-            size=self.__get_field_size(definition_message, SessionMaxNegVerticalSpeedField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionMinHeartRateField(
-            size=self.__get_field_size(definition_message, SessionMinHeartRateField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionTimeInHrZoneField(
-            size=self.__get_field_size(definition_message, SessionTimeInHrZoneField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionTimeInSpeedZoneField(
-            size=self.__get_field_size(definition_message, SessionTimeInSpeedZoneField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionTimeInCadenceZoneField(
-            size=self.__get_field_size(definition_message, SessionTimeInCadenceZoneField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionTimeInPowerZoneField(
-            size=self.__get_field_size(definition_message, SessionTimeInPowerZoneField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionAvgLapTimeField(
-            size=self.__get_field_size(definition_message, SessionAvgLapTimeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionBestLapIndexField(
-            size=self.__get_field_size(definition_message, SessionBestLapIndexField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionMinAltitudeField(
-            size=self.__get_field_size(definition_message, SessionMinAltitudeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionActiveTimeField(
-            size=self.__get_field_size(definition_message, SessionActiveTimeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionPlayerScoreField(
-            size=self.__get_field_size(definition_message, SessionPlayerScoreField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionOpponentScoreField(
-            size=self.__get_field_size(definition_message, SessionOpponentScoreField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionOpponentNameField(
-            size=self.__get_field_size(definition_message, SessionOpponentNameField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionStrokeCountField(
-            size=self.__get_field_size(definition_message, SessionStrokeCountField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionZoneCountField(
-            size=self.__get_field_size(definition_message, SessionZoneCountField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionMaxBallSpeedField(
-            size=self.__get_field_size(definition_message, SessionMaxBallSpeedField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionAvgBallSpeedField(
-            size=self.__get_field_size(definition_message, SessionAvgBallSpeedField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionAvgVerticalOscillationField(
-            size=self.__get_field_size(definition_message, SessionAvgVerticalOscillationField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionAvgStanceTimePercentField(
-            size=self.__get_field_size(definition_message, SessionAvgStanceTimePercentField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionAvgStanceTimeField(
-            size=self.__get_field_size(definition_message, SessionAvgStanceTimeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionAvgFractionalCadenceField(
-            size=self.__get_field_size(definition_message, SessionAvgFractionalCadenceField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionMaxFractionalCadenceField(
-            size=self.__get_field_size(definition_message, SessionMaxFractionalCadenceField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionTotalFractionalCyclesField(
-            size=self.__get_field_size(definition_message, SessionTotalFractionalCyclesField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionAvgTotalHemoglobinConcField(
-            size=self.__get_field_size(definition_message, SessionAvgTotalHemoglobinConcField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionMinTotalHemoglobinConcField(
-            size=self.__get_field_size(definition_message, SessionMinTotalHemoglobinConcField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionMaxTotalHemoglobinConcField(
-            size=self.__get_field_size(definition_message, SessionMaxTotalHemoglobinConcField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionAvgSaturatedHemoglobinPercentField(
-            size=self.__get_field_size(definition_message, SessionAvgSaturatedHemoglobinPercentField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionMinSaturatedHemoglobinPercentField(
-            size=self.__get_field_size(definition_message, SessionMinSaturatedHemoglobinPercentField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionMaxSaturatedHemoglobinPercentField(
-            size=self.__get_field_size(definition_message, SessionMaxSaturatedHemoglobinPercentField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionAvgLeftTorqueEffectivenessField(
-            size=self.__get_field_size(definition_message, SessionAvgLeftTorqueEffectivenessField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionAvgRightTorqueEffectivenessField(
-            size=self.__get_field_size(definition_message, SessionAvgRightTorqueEffectivenessField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionAvgLeftPedalSmoothnessField(
-            size=self.__get_field_size(definition_message, SessionAvgLeftPedalSmoothnessField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionAvgRightPedalSmoothnessField(
-            size=self.__get_field_size(definition_message, SessionAvgRightPedalSmoothnessField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionAvgCombinedPedalSmoothnessField(
-            size=self.__get_field_size(definition_message, SessionAvgCombinedPedalSmoothnessField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionSportProfileNameField(
-            size=self.__get_field_size(definition_message, SessionSportProfileNameField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionSportIndexField(
-            size=self.__get_field_size(definition_message, SessionSportIndexField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionTimeStandingField(
-            size=self.__get_field_size(definition_message, SessionTimeStandingField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionStandCountField(
-            size=self.__get_field_size(definition_message, SessionStandCountField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionAvgLeftPcoField(
-            size=self.__get_field_size(definition_message, SessionAvgLeftPcoField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionAvgRightPcoField(
-            size=self.__get_field_size(definition_message, SessionAvgRightPcoField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionAvgLeftPowerPhaseField(
-            size=self.__get_field_size(definition_message, SessionAvgLeftPowerPhaseField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionAvgLeftPowerPhasePeakField(
-            size=self.__get_field_size(definition_message, SessionAvgLeftPowerPhasePeakField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionAvgRightPowerPhaseField(
-            size=self.__get_field_size(definition_message, SessionAvgRightPowerPhaseField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionAvgRightPowerPhasePeakField(
-            size=self.__get_field_size(definition_message, SessionAvgRightPowerPhasePeakField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionAvgPowerPositionField(
-            size=self.__get_field_size(definition_message, SessionAvgPowerPositionField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionMaxPowerPositionField(
-            size=self.__get_field_size(definition_message, SessionMaxPowerPositionField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionAvgCadencePositionField(
-            size=self.__get_field_size(definition_message, SessionAvgCadencePositionField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionMaxCadencePositionField(
-            size=self.__get_field_size(definition_message, SessionMaxCadencePositionField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionEnhancedAvgSpeedField(
-            size=self.__get_field_size(definition_message, SessionEnhancedAvgSpeedField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionEnhancedMaxSpeedField(
-            size=self.__get_field_size(definition_message, SessionEnhancedMaxSpeedField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionEnhancedAvgAltitudeField(
-            size=self.__get_field_size(definition_message, SessionEnhancedAvgAltitudeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionEnhancedMinAltitudeField(
-            size=self.__get_field_size(definition_message, SessionEnhancedMinAltitudeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionEnhancedMaxAltitudeField(
-            size=self.__get_field_size(definition_message, SessionEnhancedMaxAltitudeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionAvgLevMotorPowerField(
-            size=self.__get_field_size(definition_message, SessionAvgLevMotorPowerField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionMaxLevMotorPowerField(
-            size=self.__get_field_size(definition_message, SessionMaxLevMotorPowerField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionLevBatteryConsumptionField(
-            size=self.__get_field_size(definition_message, SessionLevBatteryConsumptionField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionAvgVerticalRatioField(
-            size=self.__get_field_size(definition_message, SessionAvgVerticalRatioField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionAvgStanceTimeBalanceField(
-            size=self.__get_field_size(definition_message, SessionAvgStanceTimeBalanceField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionAvgStepLengthField(
-            size=self.__get_field_size(definition_message, SessionAvgStepLengthField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionTotalAnaerobicTrainingEffectField(
-            size=self.__get_field_size(definition_message, SessionTotalAnaerobicTrainingEffectField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionAvgVamField(
-            size=self.__get_field_size(definition_message, SessionAvgVamField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionAvgDepthField(
-            size=self.__get_field_size(definition_message, SessionAvgDepthField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionMaxDepthField(
-            size=self.__get_field_size(definition_message, SessionMaxDepthField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionSurfaceIntervalField(
-            size=self.__get_field_size(definition_message, SessionSurfaceIntervalField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionStartCnsField(
-            size=self.__get_field_size(definition_message, SessionStartCnsField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionEndCnsField(
-            size=self.__get_field_size(definition_message, SessionEndCnsField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionStartN2Field(
-            size=self.__get_field_size(definition_message, SessionStartN2Field.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionEndN2Field(
-            size=self.__get_field_size(definition_message, SessionEndN2Field.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionAvgRespirationRateField(
-            size=self.__get_field_size(definition_message, SessionAvgRespirationRateField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionMaxRespirationRateField(
-            size=self.__get_field_size(definition_message, SessionMaxRespirationRateField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionMinRespirationRateField(
-            size=self.__get_field_size(definition_message, SessionMinRespirationRateField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionMinTemperatureField(
-            size=self.__get_field_size(definition_message, SessionMinTemperatureField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionO2ToxicityField(
-            size=self.__get_field_size(definition_message, SessionO2ToxicityField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionDiveNumberField(
-            size=self.__get_field_size(definition_message, SessionDiveNumberField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionTrainingLoadPeakField(
-            size=self.__get_field_size(definition_message, SessionTrainingLoadPeakField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionEnhancedAvgRespirationRateField(
-            size=self.__get_field_size(definition_message, SessionEnhancedAvgRespirationRateField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionEnhancedMaxRespirationRateField(
-            size=self.__get_field_size(definition_message, SessionEnhancedMaxRespirationRateField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionEnhancedMinRespirationRateField(
-            size=self.__get_field_size(definition_message, SessionEnhancedMinRespirationRateField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionTotalGritField(
-            size=self.__get_field_size(definition_message, SessionTotalGritField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionTotalFlowField(
-            size=self.__get_field_size(definition_message, SessionTotalFlowField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionJumpCountField(
-            size=self.__get_field_size(definition_message, SessionJumpCountField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionAvgGritField(
-            size=self.__get_field_size(definition_message, SessionAvgGritField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionAvgFlowField(
-            size=self.__get_field_size(definition_message, SessionAvgFlowField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionWorkoutFeelField(
-            size=self.__get_field_size(definition_message, SessionWorkoutFeelField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionWorkoutRpeField(
-            size=self.__get_field_size(definition_message, SessionWorkoutRpeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionAvgSpo2Field(
-            size=self.__get_field_size(definition_message, SessionAvgSpo2Field.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionAvgStressField(
-            size=self.__get_field_size(definition_message, SessionAvgStressField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionMetabolicCaloriesField(
-            size=self.__get_field_size(definition_message, SessionMetabolicCaloriesField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionSdrrHrvField(
-            size=self.__get_field_size(definition_message, SessionSdrrHrvField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionRmssdHrvField(
-            size=self.__get_field_size(definition_message, SessionRmssdHrvField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionTotalFractionalAscentField(
-            size=self.__get_field_size(definition_message, SessionTotalFractionalAscentField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionTotalFractionalDescentField(
-            size=self.__get_field_size(definition_message, SessionTotalFractionalDescentField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionAvgCoreTemperatureField(
-            size=self.__get_field_size(definition_message, SessionAvgCoreTemperatureField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionMinCoreTemperatureField(
-            size=self.__get_field_size(definition_message, SessionMinCoreTemperatureField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SessionMaxCoreTemperatureField(
-            size=self.__get_field_size(definition_message, SessionMaxCoreTemperatureField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        MessageIndexField(
+            size=cls._field_size_from_definition(
+                definition_message, MessageIndexField.ID),
+            growable=False), 
+        TimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampField.ID),
+            growable=False), 
+        SessionEventField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionEventField.ID),
+            growable=False), 
+        SessionEventTypeField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionEventTypeField.ID),
+            growable=False), 
+        SessionStartTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionStartTimeField.ID),
+            growable=False), 
+        SessionStartPositionLatField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionStartPositionLatField.ID),
+            growable=False), 
+        SessionStartPositionLongField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionStartPositionLongField.ID),
+            growable=False), 
+        SessionSportField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionSportField.ID),
+            growable=False), 
+        SessionSubSportField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionSubSportField.ID),
+            growable=False), 
+        SessionTotalElapsedTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionTotalElapsedTimeField.ID),
+            growable=False), 
+        SessionTotalTimerTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionTotalTimerTimeField.ID),
+            growable=False), 
+        SessionTotalDistanceField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionTotalDistanceField.ID),
+            growable=False), 
+        SessionTotalCyclesField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionTotalCyclesField.ID),
+            growable=False), 
+        SessionTotalCaloriesField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionTotalCaloriesField.ID),
+            growable=False), 
+        SessionTotalFatCaloriesField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionTotalFatCaloriesField.ID),
+            growable=False), 
+        SessionAvgSpeedField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionAvgSpeedField.ID),
+            growable=False), 
+        SessionMaxSpeedField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionMaxSpeedField.ID),
+            growable=False), 
+        SessionAvgHeartRateField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionAvgHeartRateField.ID),
+            growable=False), 
+        SessionMaxHeartRateField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionMaxHeartRateField.ID),
+            growable=False), 
+        SessionAvgCadenceField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionAvgCadenceField.ID),
+            growable=False), 
+        SessionMaxCadenceField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionMaxCadenceField.ID),
+            growable=False), 
+        SessionAvgPowerField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionAvgPowerField.ID),
+            growable=False), 
+        SessionMaxPowerField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionMaxPowerField.ID),
+            growable=False), 
+        SessionTotalAscentField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionTotalAscentField.ID),
+            growable=False), 
+        SessionTotalDescentField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionTotalDescentField.ID),
+            growable=False), 
+        SessionTotalTrainingEffectField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionTotalTrainingEffectField.ID),
+            growable=False), 
+        SessionFirstLapIndexField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionFirstLapIndexField.ID),
+            growable=False), 
+        SessionNumLapsField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionNumLapsField.ID),
+            growable=False), 
+        SessionEventGroupField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionEventGroupField.ID),
+            growable=False), 
+        SessionTriggerField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionTriggerField.ID),
+            growable=False), 
+        SessionNecLatField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionNecLatField.ID),
+            growable=False), 
+        SessionNecLongField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionNecLongField.ID),
+            growable=False), 
+        SessionSwcLatField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionSwcLatField.ID),
+            growable=False), 
+        SessionSwcLongField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionSwcLongField.ID),
+            growable=False), 
+        SessionNumLengthsField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionNumLengthsField.ID),
+            growable=False), 
+        SessionNormalizedPowerField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionNormalizedPowerField.ID),
+            growable=False), 
+        SessionTrainingStressScoreField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionTrainingStressScoreField.ID),
+            growable=False), 
+        SessionIntensityFactorField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionIntensityFactorField.ID),
+            growable=False), 
+        SessionLeftRightBalanceField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionLeftRightBalanceField.ID),
+            growable=False), 
+        SessionEndPositionLatField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionEndPositionLatField.ID),
+            growable=False), 
+        SessionEndPositionLongField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionEndPositionLongField.ID),
+            growable=False), 
+        SessionAvgStrokeCountField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionAvgStrokeCountField.ID),
+            growable=False), 
+        SessionAvgStrokeDistanceField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionAvgStrokeDistanceField.ID),
+            growable=False), 
+        SessionSwimStrokeField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionSwimStrokeField.ID),
+            growable=False), 
+        SessionPoolLengthField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionPoolLengthField.ID),
+            growable=False), 
+        SessionThresholdPowerField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionThresholdPowerField.ID),
+            growable=False), 
+        SessionPoolLengthUnitField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionPoolLengthUnitField.ID),
+            growable=False), 
+        SessionNumActiveLengthsField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionNumActiveLengthsField.ID),
+            growable=False), 
+        SessionTotalWorkField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionTotalWorkField.ID),
+            growable=False), 
+        SessionAvgAltitudeField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionAvgAltitudeField.ID),
+            growable=False), 
+        SessionMaxAltitudeField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionMaxAltitudeField.ID),
+            growable=False), 
+        SessionGpsAccuracyField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionGpsAccuracyField.ID),
+            growable=False), 
+        SessionAvgGradeField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionAvgGradeField.ID),
+            growable=False), 
+        SessionAvgPosGradeField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionAvgPosGradeField.ID),
+            growable=False), 
+        SessionAvgNegGradeField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionAvgNegGradeField.ID),
+            growable=False), 
+        SessionMaxPosGradeField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionMaxPosGradeField.ID),
+            growable=False), 
+        SessionMaxNegGradeField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionMaxNegGradeField.ID),
+            growable=False), 
+        SessionAvgTemperatureField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionAvgTemperatureField.ID),
+            growable=False), 
+        SessionMaxTemperatureField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionMaxTemperatureField.ID),
+            growable=False), 
+        SessionTotalMovingTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionTotalMovingTimeField.ID),
+            growable=False), 
+        SessionAvgPosVerticalSpeedField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionAvgPosVerticalSpeedField.ID),
+            growable=False), 
+        SessionAvgNegVerticalSpeedField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionAvgNegVerticalSpeedField.ID),
+            growable=False), 
+        SessionMaxPosVerticalSpeedField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionMaxPosVerticalSpeedField.ID),
+            growable=False), 
+        SessionMaxNegVerticalSpeedField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionMaxNegVerticalSpeedField.ID),
+            growable=False), 
+        SessionMinHeartRateField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionMinHeartRateField.ID),
+            growable=False), 
+        SessionTimeInHrZoneField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionTimeInHrZoneField.ID),
+            growable=False), 
+        SessionTimeInSpeedZoneField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionTimeInSpeedZoneField.ID),
+            growable=False), 
+        SessionTimeInCadenceZoneField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionTimeInCadenceZoneField.ID),
+            growable=False), 
+        SessionTimeInPowerZoneField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionTimeInPowerZoneField.ID),
+            growable=False), 
+        SessionAvgLapTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionAvgLapTimeField.ID),
+            growable=False), 
+        SessionBestLapIndexField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionBestLapIndexField.ID),
+            growable=False), 
+        SessionMinAltitudeField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionMinAltitudeField.ID),
+            growable=False), 
+        SessionActiveTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionActiveTimeField.ID),
+            growable=False), 
+        SessionPlayerScoreField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionPlayerScoreField.ID),
+            growable=False), 
+        SessionOpponentScoreField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionOpponentScoreField.ID),
+            growable=False), 
+        SessionOpponentNameField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionOpponentNameField.ID),
+            growable=False), 
+        SessionStrokeCountField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionStrokeCountField.ID),
+            growable=False), 
+        SessionZoneCountField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionZoneCountField.ID),
+            growable=False), 
+        SessionMaxBallSpeedField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionMaxBallSpeedField.ID),
+            growable=False), 
+        SessionAvgBallSpeedField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionAvgBallSpeedField.ID),
+            growable=False), 
+        SessionAvgVerticalOscillationField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionAvgVerticalOscillationField.ID),
+            growable=False), 
+        SessionAvgStanceTimePercentField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionAvgStanceTimePercentField.ID),
+            growable=False), 
+        SessionAvgStanceTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionAvgStanceTimeField.ID),
+            growable=False), 
+        SessionAvgFractionalCadenceField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionAvgFractionalCadenceField.ID),
+            growable=False), 
+        SessionMaxFractionalCadenceField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionMaxFractionalCadenceField.ID),
+            growable=False), 
+        SessionTotalFractionalCyclesField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionTotalFractionalCyclesField.ID),
+            growable=False), 
+        SessionAvgTotalHemoglobinConcField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionAvgTotalHemoglobinConcField.ID),
+            growable=False), 
+        SessionMinTotalHemoglobinConcField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionMinTotalHemoglobinConcField.ID),
+            growable=False), 
+        SessionMaxTotalHemoglobinConcField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionMaxTotalHemoglobinConcField.ID),
+            growable=False), 
+        SessionAvgSaturatedHemoglobinPercentField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionAvgSaturatedHemoglobinPercentField.ID),
+            growable=False), 
+        SessionMinSaturatedHemoglobinPercentField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionMinSaturatedHemoglobinPercentField.ID),
+            growable=False), 
+        SessionMaxSaturatedHemoglobinPercentField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionMaxSaturatedHemoglobinPercentField.ID),
+            growable=False), 
+        SessionAvgLeftTorqueEffectivenessField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionAvgLeftTorqueEffectivenessField.ID),
+            growable=False), 
+        SessionAvgRightTorqueEffectivenessField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionAvgRightTorqueEffectivenessField.ID),
+            growable=False), 
+        SessionAvgLeftPedalSmoothnessField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionAvgLeftPedalSmoothnessField.ID),
+            growable=False), 
+        SessionAvgRightPedalSmoothnessField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionAvgRightPedalSmoothnessField.ID),
+            growable=False), 
+        SessionAvgCombinedPedalSmoothnessField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionAvgCombinedPedalSmoothnessField.ID),
+            growable=False), 
+        SessionSportProfileNameField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionSportProfileNameField.ID),
+            growable=False), 
+        SessionSportIndexField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionSportIndexField.ID),
+            growable=False), 
+        SessionTimeStandingField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionTimeStandingField.ID),
+            growable=False), 
+        SessionStandCountField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionStandCountField.ID),
+            growable=False), 
+        SessionAvgLeftPcoField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionAvgLeftPcoField.ID),
+            growable=False), 
+        SessionAvgRightPcoField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionAvgRightPcoField.ID),
+            growable=False), 
+        SessionAvgLeftPowerPhaseField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionAvgLeftPowerPhaseField.ID),
+            growable=False), 
+        SessionAvgLeftPowerPhasePeakField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionAvgLeftPowerPhasePeakField.ID),
+            growable=False), 
+        SessionAvgRightPowerPhaseField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionAvgRightPowerPhaseField.ID),
+            growable=False), 
+        SessionAvgRightPowerPhasePeakField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionAvgRightPowerPhasePeakField.ID),
+            growable=False), 
+        SessionAvgPowerPositionField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionAvgPowerPositionField.ID),
+            growable=False), 
+        SessionMaxPowerPositionField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionMaxPowerPositionField.ID),
+            growable=False), 
+        SessionAvgCadencePositionField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionAvgCadencePositionField.ID),
+            growable=False), 
+        SessionMaxCadencePositionField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionMaxCadencePositionField.ID),
+            growable=False), 
+        SessionEnhancedAvgSpeedField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionEnhancedAvgSpeedField.ID),
+            growable=False), 
+        SessionEnhancedMaxSpeedField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionEnhancedMaxSpeedField.ID),
+            growable=False), 
+        SessionEnhancedAvgAltitudeField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionEnhancedAvgAltitudeField.ID),
+            growable=False), 
+        SessionEnhancedMinAltitudeField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionEnhancedMinAltitudeField.ID),
+            growable=False), 
+        SessionEnhancedMaxAltitudeField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionEnhancedMaxAltitudeField.ID),
+            growable=False), 
+        SessionAvgLevMotorPowerField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionAvgLevMotorPowerField.ID),
+            growable=False), 
+        SessionMaxLevMotorPowerField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionMaxLevMotorPowerField.ID),
+            growable=False), 
+        SessionLevBatteryConsumptionField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionLevBatteryConsumptionField.ID),
+            growable=False), 
+        SessionAvgVerticalRatioField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionAvgVerticalRatioField.ID),
+            growable=False), 
+        SessionAvgStanceTimeBalanceField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionAvgStanceTimeBalanceField.ID),
+            growable=False), 
+        SessionAvgStepLengthField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionAvgStepLengthField.ID),
+            growable=False), 
+        SessionTotalAnaerobicTrainingEffectField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionTotalAnaerobicTrainingEffectField.ID),
+            growable=False), 
+        SessionAvgVamField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionAvgVamField.ID),
+            growable=False), 
+        SessionAvgDepthField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionAvgDepthField.ID),
+            growable=False), 
+        SessionMaxDepthField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionMaxDepthField.ID),
+            growable=False), 
+        SessionSurfaceIntervalField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionSurfaceIntervalField.ID),
+            growable=False), 
+        SessionStartCnsField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionStartCnsField.ID),
+            growable=False), 
+        SessionEndCnsField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionEndCnsField.ID),
+            growable=False), 
+        SessionStartN2Field(
+            size=cls._field_size_from_definition(
+                definition_message, SessionStartN2Field.ID),
+            growable=False), 
+        SessionEndN2Field(
+            size=cls._field_size_from_definition(
+                definition_message, SessionEndN2Field.ID),
+            growable=False), 
+        SessionAvgRespirationRateField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionAvgRespirationRateField.ID),
+            growable=False), 
+        SessionMaxRespirationRateField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionMaxRespirationRateField.ID),
+            growable=False), 
+        SessionMinRespirationRateField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionMinRespirationRateField.ID),
+            growable=False), 
+        SessionMinTemperatureField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionMinTemperatureField.ID),
+            growable=False), 
+        SessionO2ToxicityField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionO2ToxicityField.ID),
+            growable=False), 
+        SessionDiveNumberField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionDiveNumberField.ID),
+            growable=False), 
+        SessionTrainingLoadPeakField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionTrainingLoadPeakField.ID),
+            growable=False), 
+        SessionEnhancedAvgRespirationRateField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionEnhancedAvgRespirationRateField.ID),
+            growable=False), 
+        SessionEnhancedMaxRespirationRateField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionEnhancedMaxRespirationRateField.ID),
+            growable=False), 
+        SessionEnhancedMinRespirationRateField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionEnhancedMinRespirationRateField.ID),
+            growable=False), 
+        SessionTotalGritField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionTotalGritField.ID),
+            growable=False), 
+        SessionTotalFlowField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionTotalFlowField.ID),
+            growable=False), 
+        SessionJumpCountField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionJumpCountField.ID),
+            growable=False), 
+        SessionAvgGritField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionAvgGritField.ID),
+            growable=False), 
+        SessionAvgFlowField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionAvgFlowField.ID),
+            growable=False), 
+        SessionWorkoutFeelField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionWorkoutFeelField.ID),
+            growable=False), 
+        SessionWorkoutRpeField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionWorkoutRpeField.ID),
+            growable=False), 
+        SessionAvgSpo2Field(
+            size=cls._field_size_from_definition(
+                definition_message, SessionAvgSpo2Field.ID),
+            growable=False), 
+        SessionAvgStressField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionAvgStressField.ID),
+            growable=False), 
+        SessionMetabolicCaloriesField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionMetabolicCaloriesField.ID),
+            growable=False), 
+        SessionSdrrHrvField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionSdrrHrvField.ID),
+            growable=False), 
+        SessionRmssdHrvField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionRmssdHrvField.ID),
+            growable=False), 
+        SessionTotalFractionalAscentField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionTotalFractionalAscentField.ID),
+            growable=False), 
+        SessionTotalFractionalDescentField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionTotalFractionalDescentField.ID),
+            growable=False), 
+        SessionAvgCoreTemperatureField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionAvgCoreTemperatureField.ID),
+            growable=False), 
+        SessionMinCoreTemperatureField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionMinCoreTemperatureField.ID),
+            growable=False), 
+        SessionMaxCoreTemperatureField(
+            size=cls._field_size_from_definition(
+                definition_message, SessionMaxCoreTemperatureField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/set_message.py
+++ b/fit_tool/profile/messages/set_message.py
@@ -17,69 +17,140 @@ from typing import Dict as dict
 
 
 class SetMessage(DataMessage):
+    """SetMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``SetMessage()`` — create path: growable fields, no wire definition.
+    * ``SetMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 225
     NAME = 'set'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=SetMessage.NAME,
                          global_id=SetMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         SetTimestampField(
-            size=self.__get_field_size(definition_message, SetTimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SetDurationField(
-            size=self.__get_field_size(definition_message, SetDurationField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SetRepetitionsField(
-            size=self.__get_field_size(definition_message, SetRepetitionsField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SetWeightField(
-            size=self.__get_field_size(definition_message, SetWeightField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SetSetTypeField(
-            size=self.__get_field_size(definition_message, SetSetTypeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SetStartTimeField(
-            size=self.__get_field_size(definition_message, SetStartTimeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SetCategoryField(
-            size=self.__get_field_size(definition_message, SetCategoryField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SetCategorySubtypeField(
-            size=self.__get_field_size(definition_message, SetCategorySubtypeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SetWeightDisplayUnitField(
-            size=self.__get_field_size(definition_message, SetWeightDisplayUnitField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SetMessageIndexField(
-            size=self.__get_field_size(definition_message, SetMessageIndexField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SetWorkoutStepIndexField(
-            size=self.__get_field_size(definition_message, SetWorkoutStepIndexField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        SetTimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, SetTimestampField.ID),
+            growable=False), 
+        SetDurationField(
+            size=cls._field_size_from_definition(
+                definition_message, SetDurationField.ID),
+            growable=False), 
+        SetRepetitionsField(
+            size=cls._field_size_from_definition(
+                definition_message, SetRepetitionsField.ID),
+            growable=False), 
+        SetWeightField(
+            size=cls._field_size_from_definition(
+                definition_message, SetWeightField.ID),
+            growable=False), 
+        SetSetTypeField(
+            size=cls._field_size_from_definition(
+                definition_message, SetSetTypeField.ID),
+            growable=False), 
+        SetStartTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, SetStartTimeField.ID),
+            growable=False), 
+        SetCategoryField(
+            size=cls._field_size_from_definition(
+                definition_message, SetCategoryField.ID),
+            growable=False), 
+        SetCategorySubtypeField(
+            size=cls._field_size_from_definition(
+                definition_message, SetCategorySubtypeField.ID),
+            growable=False), 
+        SetWeightDisplayUnitField(
+            size=cls._field_size_from_definition(
+                definition_message, SetWeightDisplayUnitField.ID),
+            growable=False), 
+        SetMessageIndexField(
+            size=cls._field_size_from_definition(
+                definition_message, SetMessageIndexField.ID),
+            growable=False), 
+        SetWorkoutStepIndexField(
+            size=cls._field_size_from_definition(
+                definition_message, SetWorkoutStepIndexField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/skin_temp_overnight_message.py
+++ b/fit_tool/profile/messages/skin_temp_overnight_message.py
@@ -17,51 +17,98 @@ from typing import Dict as dict
 
 
 class SkinTempOvernightMessage(DataMessage):
+    """SkinTempOvernightMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``SkinTempOvernightMessage()`` — create path: growable fields, no wire definition.
+    * ``SkinTempOvernightMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 398
     NAME = 'skin_temp_overnight'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=SkinTempOvernightMessage.NAME,
                          global_id=SkinTempOvernightMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         TimestampField(
-            size=self.__get_field_size(definition_message, TimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SkinTempOvernightLocalTimestampField(
-            size=self.__get_field_size(definition_message, SkinTempOvernightLocalTimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SkinTempOvernightAverageDeviationField(
-            size=self.__get_field_size(definition_message, SkinTempOvernightAverageDeviationField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SkinTempOvernightAverage7DayDeviationField(
-            size=self.__get_field_size(definition_message, SkinTempOvernightAverage7DayDeviationField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SkinTempOvernightNightlyValueField(
-            size=self.__get_field_size(definition_message, SkinTempOvernightNightlyValueField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        TimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampField.ID),
+            growable=False), 
+        SkinTempOvernightLocalTimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, SkinTempOvernightLocalTimestampField.ID),
+            growable=False), 
+        SkinTempOvernightAverageDeviationField(
+            size=cls._field_size_from_definition(
+                definition_message, SkinTempOvernightAverageDeviationField.ID),
+            growable=False), 
+        SkinTempOvernightAverage7DayDeviationField(
+            size=cls._field_size_from_definition(
+                definition_message, SkinTempOvernightAverage7DayDeviationField.ID),
+            growable=False), 
+        SkinTempOvernightNightlyValueField(
+            size=cls._field_size_from_definition(
+                definition_message, SkinTempOvernightNightlyValueField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/slave_device_message.py
+++ b/fit_tool/profile/messages/slave_device_message.py
@@ -17,42 +17,77 @@ from typing import Dict as dict
 
 
 class SlaveDeviceMessage(DataMessage):
+    """SlaveDeviceMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``SlaveDeviceMessage()`` — create path: growable fields, no wire definition.
+    * ``SlaveDeviceMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 106
     NAME = 'slave_device'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=SlaveDeviceMessage.NAME,
                          global_id=SlaveDeviceMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         SlaveDeviceManufacturerField(
-            size=self.__get_field_size(definition_message, SlaveDeviceManufacturerField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SlaveDeviceProductField(
-            size=self.__get_field_size(definition_message, SlaveDeviceProductField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        SlaveDeviceManufacturerField(
+            size=cls._field_size_from_definition(
+                definition_message, SlaveDeviceManufacturerField.ID),
+            growable=False), 
+        SlaveDeviceProductField(
+            size=cls._field_size_from_definition(
+                definition_message, SlaveDeviceProductField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/sleep_assessment_message.py
+++ b/fit_tool/profile/messages/sleep_assessment_message.py
@@ -17,78 +17,161 @@ from typing import Dict as dict
 
 
 class SleepAssessmentMessage(DataMessage):
+    """SleepAssessmentMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``SleepAssessmentMessage()`` — create path: growable fields, no wire definition.
+    * ``SleepAssessmentMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 346
     NAME = 'sleep_assessment'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=SleepAssessmentMessage.NAME,
                          global_id=SleepAssessmentMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         SleepAssessmentCombinedAwakeScoreField(
-            size=self.__get_field_size(definition_message, SleepAssessmentCombinedAwakeScoreField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SleepAssessmentAwakeTimeScoreField(
-            size=self.__get_field_size(definition_message, SleepAssessmentAwakeTimeScoreField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SleepAssessmentAwakeningsCountScoreField(
-            size=self.__get_field_size(definition_message, SleepAssessmentAwakeningsCountScoreField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SleepAssessmentDeepSleepScoreField(
-            size=self.__get_field_size(definition_message, SleepAssessmentDeepSleepScoreField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SleepAssessmentSleepDurationScoreField(
-            size=self.__get_field_size(definition_message, SleepAssessmentSleepDurationScoreField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SleepAssessmentLightSleepScoreField(
-            size=self.__get_field_size(definition_message, SleepAssessmentLightSleepScoreField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SleepAssessmentOverallSleepScoreField(
-            size=self.__get_field_size(definition_message, SleepAssessmentOverallSleepScoreField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SleepAssessmentSleepQualityScoreField(
-            size=self.__get_field_size(definition_message, SleepAssessmentSleepQualityScoreField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SleepAssessmentSleepRecoveryScoreField(
-            size=self.__get_field_size(definition_message, SleepAssessmentSleepRecoveryScoreField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SleepAssessmentRemSleepScoreField(
-            size=self.__get_field_size(definition_message, SleepAssessmentRemSleepScoreField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SleepAssessmentSleepRestlessnessScoreField(
-            size=self.__get_field_size(definition_message, SleepAssessmentSleepRestlessnessScoreField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SleepAssessmentAwakeningsCountField(
-            size=self.__get_field_size(definition_message, SleepAssessmentAwakeningsCountField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SleepAssessmentInterruptionsScoreField(
-            size=self.__get_field_size(definition_message, SleepAssessmentInterruptionsScoreField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SleepAssessmentAverageStressDuringSleepField(
-            size=self.__get_field_size(definition_message, SleepAssessmentAverageStressDuringSleepField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        SleepAssessmentCombinedAwakeScoreField(
+            size=cls._field_size_from_definition(
+                definition_message, SleepAssessmentCombinedAwakeScoreField.ID),
+            growable=False), 
+        SleepAssessmentAwakeTimeScoreField(
+            size=cls._field_size_from_definition(
+                definition_message, SleepAssessmentAwakeTimeScoreField.ID),
+            growable=False), 
+        SleepAssessmentAwakeningsCountScoreField(
+            size=cls._field_size_from_definition(
+                definition_message, SleepAssessmentAwakeningsCountScoreField.ID),
+            growable=False), 
+        SleepAssessmentDeepSleepScoreField(
+            size=cls._field_size_from_definition(
+                definition_message, SleepAssessmentDeepSleepScoreField.ID),
+            growable=False), 
+        SleepAssessmentSleepDurationScoreField(
+            size=cls._field_size_from_definition(
+                definition_message, SleepAssessmentSleepDurationScoreField.ID),
+            growable=False), 
+        SleepAssessmentLightSleepScoreField(
+            size=cls._field_size_from_definition(
+                definition_message, SleepAssessmentLightSleepScoreField.ID),
+            growable=False), 
+        SleepAssessmentOverallSleepScoreField(
+            size=cls._field_size_from_definition(
+                definition_message, SleepAssessmentOverallSleepScoreField.ID),
+            growable=False), 
+        SleepAssessmentSleepQualityScoreField(
+            size=cls._field_size_from_definition(
+                definition_message, SleepAssessmentSleepQualityScoreField.ID),
+            growable=False), 
+        SleepAssessmentSleepRecoveryScoreField(
+            size=cls._field_size_from_definition(
+                definition_message, SleepAssessmentSleepRecoveryScoreField.ID),
+            growable=False), 
+        SleepAssessmentRemSleepScoreField(
+            size=cls._field_size_from_definition(
+                definition_message, SleepAssessmentRemSleepScoreField.ID),
+            growable=False), 
+        SleepAssessmentSleepRestlessnessScoreField(
+            size=cls._field_size_from_definition(
+                definition_message, SleepAssessmentSleepRestlessnessScoreField.ID),
+            growable=False), 
+        SleepAssessmentAwakeningsCountField(
+            size=cls._field_size_from_definition(
+                definition_message, SleepAssessmentAwakeningsCountField.ID),
+            growable=False), 
+        SleepAssessmentInterruptionsScoreField(
+            size=cls._field_size_from_definition(
+                definition_message, SleepAssessmentInterruptionsScoreField.ID),
+            growable=False), 
+        SleepAssessmentAverageStressDuringSleepField(
+            size=cls._field_size_from_definition(
+                definition_message, SleepAssessmentAverageStressDuringSleepField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/sleep_disruption_overnight_severity_message.py
+++ b/fit_tool/profile/messages/sleep_disruption_overnight_severity_message.py
@@ -17,42 +17,77 @@ from typing import Dict as dict
 
 
 class SleepDisruptionOvernightSeverityMessage(DataMessage):
+    """SleepDisruptionOvernightSeverityMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``SleepDisruptionOvernightSeverityMessage()`` — create path: growable fields, no wire definition.
+    * ``SleepDisruptionOvernightSeverityMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 471
     NAME = 'sleep_disruption_overnight_severity'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=SleepDisruptionOvernightSeverityMessage.NAME,
                          global_id=SleepDisruptionOvernightSeverityMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         TimestampField(
-            size=self.__get_field_size(definition_message, TimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SleepDisruptionOvernightSeveritySeverityField(
-            size=self.__get_field_size(definition_message, SleepDisruptionOvernightSeveritySeverityField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        TimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampField.ID),
+            growable=False), 
+        SleepDisruptionOvernightSeveritySeverityField(
+            size=cls._field_size_from_definition(
+                definition_message, SleepDisruptionOvernightSeveritySeverityField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/sleep_disruption_severity_period_message.py
+++ b/fit_tool/profile/messages/sleep_disruption_severity_period_message.py
@@ -17,45 +17,84 @@ from typing import Dict as dict
 
 
 class SleepDisruptionSeverityPeriodMessage(DataMessage):
+    """SleepDisruptionSeverityPeriodMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``SleepDisruptionSeverityPeriodMessage()`` — create path: growable fields, no wire definition.
+    * ``SleepDisruptionSeverityPeriodMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 470
     NAME = 'sleep_disruption_severity_period'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=SleepDisruptionSeverityPeriodMessage.NAME,
                          global_id=SleepDisruptionSeverityPeriodMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         MessageIndexField(
-            size=self.__get_field_size(definition_message, MessageIndexField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         TimestampField(
-            size=self.__get_field_size(definition_message, TimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SleepDisruptionSeverityPeriodSeverityField(
-            size=self.__get_field_size(definition_message, SleepDisruptionSeverityPeriodSeverityField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        MessageIndexField(
+            size=cls._field_size_from_definition(
+                definition_message, MessageIndexField.ID),
+            growable=False), 
+        TimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampField.ID),
+            growable=False), 
+        SleepDisruptionSeverityPeriodSeverityField(
+            size=cls._field_size_from_definition(
+                definition_message, SleepDisruptionSeverityPeriodSeverityField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/sleep_level_message.py
+++ b/fit_tool/profile/messages/sleep_level_message.py
@@ -17,42 +17,77 @@ from typing import Dict as dict
 
 
 class SleepLevelMessage(DataMessage):
+    """SleepLevelMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``SleepLevelMessage()`` — create path: growable fields, no wire definition.
+    * ``SleepLevelMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 275
     NAME = 'sleep_level'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=SleepLevelMessage.NAME,
                          global_id=SleepLevelMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         TimestampField(
-            size=self.__get_field_size(definition_message, TimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SleepLevelSleepLevelField(
-            size=self.__get_field_size(definition_message, SleepLevelSleepLevelField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        TimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampField.ID),
+            growable=False), 
+        SleepLevelSleepLevelField(
+            size=cls._field_size_from_definition(
+                definition_message, SleepLevelSleepLevelField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/software_message.py
+++ b/fit_tool/profile/messages/software_message.py
@@ -17,45 +17,84 @@ from typing import Dict as dict
 
 
 class SoftwareMessage(DataMessage):
+    """SoftwareMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``SoftwareMessage()`` — create path: growable fields, no wire definition.
+    * ``SoftwareMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 35
     NAME = 'software'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=SoftwareMessage.NAME,
                          global_id=SoftwareMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         MessageIndexField(
-            size=self.__get_field_size(definition_message, MessageIndexField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SoftwareVersionField(
-            size=self.__get_field_size(definition_message, SoftwareVersionField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SoftwarePartNumberField(
-            size=self.__get_field_size(definition_message, SoftwarePartNumberField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        MessageIndexField(
+            size=cls._field_size_from_definition(
+                definition_message, MessageIndexField.ID),
+            growable=False), 
+        SoftwareVersionField(
+            size=cls._field_size_from_definition(
+                definition_message, SoftwareVersionField.ID),
+            growable=False), 
+        SoftwarePartNumberField(
+            size=cls._field_size_from_definition(
+                definition_message, SoftwarePartNumberField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/speed_zone_message.py
+++ b/fit_tool/profile/messages/speed_zone_message.py
@@ -17,45 +17,84 @@ from typing import Dict as dict
 
 
 class SpeedZoneMessage(DataMessage):
+    """SpeedZoneMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``SpeedZoneMessage()`` — create path: growable fields, no wire definition.
+    * ``SpeedZoneMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 53
     NAME = 'speed_zone'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=SpeedZoneMessage.NAME,
                          global_id=SpeedZoneMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         MessageIndexField(
-            size=self.__get_field_size(definition_message, MessageIndexField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SpeedZoneHighValueField(
-            size=self.__get_field_size(definition_message, SpeedZoneHighValueField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SpeedZoneNameField(
-            size=self.__get_field_size(definition_message, SpeedZoneNameField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        MessageIndexField(
+            size=cls._field_size_from_definition(
+                definition_message, MessageIndexField.ID),
+            growable=False), 
+        SpeedZoneHighValueField(
+            size=cls._field_size_from_definition(
+                definition_message, SpeedZoneHighValueField.ID),
+            growable=False), 
+        SpeedZoneNameField(
+            size=cls._field_size_from_definition(
+                definition_message, SpeedZoneNameField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/split_message.py
+++ b/fit_tool/profile/messages/split_message.py
@@ -17,96 +17,203 @@ from typing import Dict as dict
 
 
 class SplitMessage(DataMessage):
+    """SplitMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``SplitMessage()`` — create path: growable fields, no wire definition.
+    * ``SplitMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 312
     NAME = 'split'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=SplitMessage.NAME,
                          global_id=SplitMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         MessageIndexField(
-            size=self.__get_field_size(definition_message, MessageIndexField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SplitSplitTypeField(
-            size=self.__get_field_size(definition_message, SplitSplitTypeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SplitTotalElapsedTimeField(
-            size=self.__get_field_size(definition_message, SplitTotalElapsedTimeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SplitTotalTimerTimeField(
-            size=self.__get_field_size(definition_message, SplitTotalTimerTimeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SplitTotalDistanceField(
-            size=self.__get_field_size(definition_message, SplitTotalDistanceField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SplitAvgSpeedField(
-            size=self.__get_field_size(definition_message, SplitAvgSpeedField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SplitStartTimeField(
-            size=self.__get_field_size(definition_message, SplitStartTimeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SplitTotalAscentField(
-            size=self.__get_field_size(definition_message, SplitTotalAscentField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SplitTotalDescentField(
-            size=self.__get_field_size(definition_message, SplitTotalDescentField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SplitStartPositionLatField(
-            size=self.__get_field_size(definition_message, SplitStartPositionLatField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SplitStartPositionLongField(
-            size=self.__get_field_size(definition_message, SplitStartPositionLongField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SplitEndPositionLatField(
-            size=self.__get_field_size(definition_message, SplitEndPositionLatField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SplitEndPositionLongField(
-            size=self.__get_field_size(definition_message, SplitEndPositionLongField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SplitMaxSpeedField(
-            size=self.__get_field_size(definition_message, SplitMaxSpeedField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SplitAvgVertSpeedField(
-            size=self.__get_field_size(definition_message, SplitAvgVertSpeedField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SplitEndTimeField(
-            size=self.__get_field_size(definition_message, SplitEndTimeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SplitTotalCaloriesField(
-            size=self.__get_field_size(definition_message, SplitTotalCaloriesField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SplitStartElevationField(
-            size=self.__get_field_size(definition_message, SplitStartElevationField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SplitActiveTimeField(
-            size=self.__get_field_size(definition_message, SplitActiveTimeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SplitTotalMovingTimeField(
-            size=self.__get_field_size(definition_message, SplitTotalMovingTimeField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        MessageIndexField(
+            size=cls._field_size_from_definition(
+                definition_message, MessageIndexField.ID),
+            growable=False), 
+        SplitSplitTypeField(
+            size=cls._field_size_from_definition(
+                definition_message, SplitSplitTypeField.ID),
+            growable=False), 
+        SplitTotalElapsedTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, SplitTotalElapsedTimeField.ID),
+            growable=False), 
+        SplitTotalTimerTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, SplitTotalTimerTimeField.ID),
+            growable=False), 
+        SplitTotalDistanceField(
+            size=cls._field_size_from_definition(
+                definition_message, SplitTotalDistanceField.ID),
+            growable=False), 
+        SplitAvgSpeedField(
+            size=cls._field_size_from_definition(
+                definition_message, SplitAvgSpeedField.ID),
+            growable=False), 
+        SplitStartTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, SplitStartTimeField.ID),
+            growable=False), 
+        SplitTotalAscentField(
+            size=cls._field_size_from_definition(
+                definition_message, SplitTotalAscentField.ID),
+            growable=False), 
+        SplitTotalDescentField(
+            size=cls._field_size_from_definition(
+                definition_message, SplitTotalDescentField.ID),
+            growable=False), 
+        SplitStartPositionLatField(
+            size=cls._field_size_from_definition(
+                definition_message, SplitStartPositionLatField.ID),
+            growable=False), 
+        SplitStartPositionLongField(
+            size=cls._field_size_from_definition(
+                definition_message, SplitStartPositionLongField.ID),
+            growable=False), 
+        SplitEndPositionLatField(
+            size=cls._field_size_from_definition(
+                definition_message, SplitEndPositionLatField.ID),
+            growable=False), 
+        SplitEndPositionLongField(
+            size=cls._field_size_from_definition(
+                definition_message, SplitEndPositionLongField.ID),
+            growable=False), 
+        SplitMaxSpeedField(
+            size=cls._field_size_from_definition(
+                definition_message, SplitMaxSpeedField.ID),
+            growable=False), 
+        SplitAvgVertSpeedField(
+            size=cls._field_size_from_definition(
+                definition_message, SplitAvgVertSpeedField.ID),
+            growable=False), 
+        SplitEndTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, SplitEndTimeField.ID),
+            growable=False), 
+        SplitTotalCaloriesField(
+            size=cls._field_size_from_definition(
+                definition_message, SplitTotalCaloriesField.ID),
+            growable=False), 
+        SplitStartElevationField(
+            size=cls._field_size_from_definition(
+                definition_message, SplitStartElevationField.ID),
+            growable=False), 
+        SplitActiveTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, SplitActiveTimeField.ID),
+            growable=False), 
+        SplitTotalMovingTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, SplitTotalMovingTimeField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/split_summary_message.py
+++ b/fit_tool/profile/messages/split_summary_message.py
@@ -17,81 +17,168 @@ from typing import Dict as dict
 
 
 class SplitSummaryMessage(DataMessage):
+    """SplitSummaryMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``SplitSummaryMessage()`` — create path: growable fields, no wire definition.
+    * ``SplitSummaryMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 313
     NAME = 'split_summary'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=SplitSummaryMessage.NAME,
                          global_id=SplitSummaryMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         MessageIndexField(
-            size=self.__get_field_size(definition_message, MessageIndexField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SplitSummarySplitTypeField(
-            size=self.__get_field_size(definition_message, SplitSummarySplitTypeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SplitSummaryNumSplitsField(
-            size=self.__get_field_size(definition_message, SplitSummaryNumSplitsField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SplitSummaryTotalTimerTimeField(
-            size=self.__get_field_size(definition_message, SplitSummaryTotalTimerTimeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SplitSummaryTotalDistanceField(
-            size=self.__get_field_size(definition_message, SplitSummaryTotalDistanceField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SplitSummaryAvgSpeedField(
-            size=self.__get_field_size(definition_message, SplitSummaryAvgSpeedField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SplitSummaryMaxSpeedField(
-            size=self.__get_field_size(definition_message, SplitSummaryMaxSpeedField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SplitSummaryTotalAscentField(
-            size=self.__get_field_size(definition_message, SplitSummaryTotalAscentField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SplitSummaryTotalDescentField(
-            size=self.__get_field_size(definition_message, SplitSummaryTotalDescentField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SplitSummaryAvgHeartRateField(
-            size=self.__get_field_size(definition_message, SplitSummaryAvgHeartRateField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SplitSummaryMaxHeartRateField(
-            size=self.__get_field_size(definition_message, SplitSummaryMaxHeartRateField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SplitSummaryAvgVertSpeedField(
-            size=self.__get_field_size(definition_message, SplitSummaryAvgVertSpeedField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SplitSummaryTotalCaloriesField(
-            size=self.__get_field_size(definition_message, SplitSummaryTotalCaloriesField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SplitSummaryActiveTimeField(
-            size=self.__get_field_size(definition_message, SplitSummaryActiveTimeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SplitSummaryTotalMovingTimeField(
-            size=self.__get_field_size(definition_message, SplitSummaryTotalMovingTimeField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        MessageIndexField(
+            size=cls._field_size_from_definition(
+                definition_message, MessageIndexField.ID),
+            growable=False), 
+        SplitSummarySplitTypeField(
+            size=cls._field_size_from_definition(
+                definition_message, SplitSummarySplitTypeField.ID),
+            growable=False), 
+        SplitSummaryNumSplitsField(
+            size=cls._field_size_from_definition(
+                definition_message, SplitSummaryNumSplitsField.ID),
+            growable=False), 
+        SplitSummaryTotalTimerTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, SplitSummaryTotalTimerTimeField.ID),
+            growable=False), 
+        SplitSummaryTotalDistanceField(
+            size=cls._field_size_from_definition(
+                definition_message, SplitSummaryTotalDistanceField.ID),
+            growable=False), 
+        SplitSummaryAvgSpeedField(
+            size=cls._field_size_from_definition(
+                definition_message, SplitSummaryAvgSpeedField.ID),
+            growable=False), 
+        SplitSummaryMaxSpeedField(
+            size=cls._field_size_from_definition(
+                definition_message, SplitSummaryMaxSpeedField.ID),
+            growable=False), 
+        SplitSummaryTotalAscentField(
+            size=cls._field_size_from_definition(
+                definition_message, SplitSummaryTotalAscentField.ID),
+            growable=False), 
+        SplitSummaryTotalDescentField(
+            size=cls._field_size_from_definition(
+                definition_message, SplitSummaryTotalDescentField.ID),
+            growable=False), 
+        SplitSummaryAvgHeartRateField(
+            size=cls._field_size_from_definition(
+                definition_message, SplitSummaryAvgHeartRateField.ID),
+            growable=False), 
+        SplitSummaryMaxHeartRateField(
+            size=cls._field_size_from_definition(
+                definition_message, SplitSummaryMaxHeartRateField.ID),
+            growable=False), 
+        SplitSummaryAvgVertSpeedField(
+            size=cls._field_size_from_definition(
+                definition_message, SplitSummaryAvgVertSpeedField.ID),
+            growable=False), 
+        SplitSummaryTotalCaloriesField(
+            size=cls._field_size_from_definition(
+                definition_message, SplitSummaryTotalCaloriesField.ID),
+            growable=False), 
+        SplitSummaryActiveTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, SplitSummaryActiveTimeField.ID),
+            growable=False), 
+        SplitSummaryTotalMovingTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, SplitSummaryTotalMovingTimeField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/spo2_data_message.py
+++ b/fit_tool/profile/messages/spo2_data_message.py
@@ -17,48 +17,91 @@ from typing import Dict as dict
 
 
 class Spo2DataMessage(DataMessage):
+    """Spo2DataMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``Spo2DataMessage()`` — create path: growable fields, no wire definition.
+    * ``Spo2DataMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 269
     NAME = 'spo2_data'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=Spo2DataMessage.NAME,
                          global_id=Spo2DataMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         TimestampField(
-            size=self.__get_field_size(definition_message, TimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         Spo2DataReadingSpo2Field(
-            size=self.__get_field_size(definition_message, Spo2DataReadingSpo2Field.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         Spo2DataReadingConfidenceField(
-            size=self.__get_field_size(definition_message, Spo2DataReadingConfidenceField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         Spo2DataModeField(
-            size=self.__get_field_size(definition_message, Spo2DataModeField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        TimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampField.ID),
+            growable=False), 
+        Spo2DataReadingSpo2Field(
+            size=cls._field_size_from_definition(
+                definition_message, Spo2DataReadingSpo2Field.ID),
+            growable=False), 
+        Spo2DataReadingConfidenceField(
+            size=cls._field_size_from_definition(
+                definition_message, Spo2DataReadingConfidenceField.ID),
+            growable=False), 
+        Spo2DataModeField(
+            size=cls._field_size_from_definition(
+                definition_message, Spo2DataModeField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/sport_message.py
+++ b/fit_tool/profile/messages/sport_message.py
@@ -17,45 +17,84 @@ from typing import Dict as dict
 
 
 class SportMessage(DataMessage):
+    """SportMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``SportMessage()`` — create path: growable fields, no wire definition.
+    * ``SportMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 12
     NAME = 'sport'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=SportMessage.NAME,
                          global_id=SportMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         SportSportField(
-            size=self.__get_field_size(definition_message, SportSportField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SportSubSportField(
-            size=self.__get_field_size(definition_message, SportSubSportField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         SportNameField(
-            size=self.__get_field_size(definition_message, SportNameField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        SportSportField(
+            size=cls._field_size_from_definition(
+                definition_message, SportSportField.ID),
+            growable=False), 
+        SportSubSportField(
+            size=cls._field_size_from_definition(
+                definition_message, SportSubSportField.ID),
+            growable=False), 
+        SportNameField(
+            size=cls._field_size_from_definition(
+                definition_message, SportNameField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/stress_level_message.py
+++ b/fit_tool/profile/messages/stress_level_message.py
@@ -17,42 +17,77 @@ from typing import Dict as dict
 
 
 class StressLevelMessage(DataMessage):
+    """StressLevelMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``StressLevelMessage()`` — create path: growable fields, no wire definition.
+    * ``StressLevelMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 227
     NAME = 'stress_level'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=StressLevelMessage.NAME,
                          global_id=StressLevelMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         StressLevelStressLevelValueField(
-            size=self.__get_field_size(definition_message, StressLevelStressLevelValueField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         StressLevelStressLevelTimeField(
-            size=self.__get_field_size(definition_message, StressLevelStressLevelTimeField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        StressLevelStressLevelValueField(
+            size=cls._field_size_from_definition(
+                definition_message, StressLevelStressLevelValueField.ID),
+            growable=False), 
+        StressLevelStressLevelTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, StressLevelStressLevelTimeField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/tank_summary_message.py
+++ b/fit_tool/profile/messages/tank_summary_message.py
@@ -17,51 +17,98 @@ from typing import Dict as dict
 
 
 class TankSummaryMessage(DataMessage):
+    """TankSummaryMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``TankSummaryMessage()`` — create path: growable fields, no wire definition.
+    * ``TankSummaryMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 323
     NAME = 'tank_summary'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=TankSummaryMessage.NAME,
                          global_id=TankSummaryMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         TimestampField(
-            size=self.__get_field_size(definition_message, TimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         TankSummarySensorField(
-            size=self.__get_field_size(definition_message, TankSummarySensorField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         TankSummaryStartPressureField(
-            size=self.__get_field_size(definition_message, TankSummaryStartPressureField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         TankSummaryEndPressureField(
-            size=self.__get_field_size(definition_message, TankSummaryEndPressureField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         TankSummaryVolumeUsedField(
-            size=self.__get_field_size(definition_message, TankSummaryVolumeUsedField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        TimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampField.ID),
+            growable=False), 
+        TankSummarySensorField(
+            size=cls._field_size_from_definition(
+                definition_message, TankSummarySensorField.ID),
+            growable=False), 
+        TankSummaryStartPressureField(
+            size=cls._field_size_from_definition(
+                definition_message, TankSummaryStartPressureField.ID),
+            growable=False), 
+        TankSummaryEndPressureField(
+            size=cls._field_size_from_definition(
+                definition_message, TankSummaryEndPressureField.ID),
+            growable=False), 
+        TankSummaryVolumeUsedField(
+            size=cls._field_size_from_definition(
+                definition_message, TankSummaryVolumeUsedField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/tank_update_message.py
+++ b/fit_tool/profile/messages/tank_update_message.py
@@ -17,45 +17,84 @@ from typing import Dict as dict
 
 
 class TankUpdateMessage(DataMessage):
+    """TankUpdateMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``TankUpdateMessage()`` — create path: growable fields, no wire definition.
+    * ``TankUpdateMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 319
     NAME = 'tank_update'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=TankUpdateMessage.NAME,
                          global_id=TankUpdateMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         TimestampField(
-            size=self.__get_field_size(definition_message, TimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         TankUpdateSensorField(
-            size=self.__get_field_size(definition_message, TankUpdateSensorField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         TankUpdatePressureField(
-            size=self.__get_field_size(definition_message, TankUpdatePressureField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        TimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampField.ID),
+            growable=False), 
+        TankUpdateSensorField(
+            size=cls._field_size_from_definition(
+                definition_message, TankUpdateSensorField.ID),
+            growable=False), 
+        TankUpdatePressureField(
+            size=cls._field_size_from_definition(
+                definition_message, TankUpdatePressureField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/three_d_sensor_calibration_message.py
+++ b/fit_tool/profile/messages/three_d_sensor_calibration_message.py
@@ -17,57 +17,112 @@ from typing import Dict as dict
 
 
 class ThreeDSensorCalibrationMessage(DataMessage):
+    """ThreeDSensorCalibrationMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``ThreeDSensorCalibrationMessage()`` — create path: growable fields, no wire definition.
+    * ``ThreeDSensorCalibrationMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 167
     NAME = 'three_d_sensor_calibration'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=ThreeDSensorCalibrationMessage.NAME,
                          global_id=ThreeDSensorCalibrationMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         TimestampField(
-            size=self.__get_field_size(definition_message, TimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ThreeDSensorCalibrationSensorTypeField(
-            size=self.__get_field_size(definition_message, ThreeDSensorCalibrationSensorTypeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ThreeDSensorCalibrationCalibrationFactorField(
-            size=self.__get_field_size(definition_message, ThreeDSensorCalibrationCalibrationFactorField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ThreeDSensorCalibrationCalibrationDivisorField(
-            size=self.__get_field_size(definition_message, ThreeDSensorCalibrationCalibrationDivisorField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ThreeDSensorCalibrationLevelShiftField(
-            size=self.__get_field_size(definition_message, ThreeDSensorCalibrationLevelShiftField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ThreeDSensorCalibrationOffsetCalField(
-            size=self.__get_field_size(definition_message, ThreeDSensorCalibrationOffsetCalField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ThreeDSensorCalibrationOrientationMatrixField(
-            size=self.__get_field_size(definition_message, ThreeDSensorCalibrationOrientationMatrixField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        TimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampField.ID),
+            growable=False), 
+        ThreeDSensorCalibrationSensorTypeField(
+            size=cls._field_size_from_definition(
+                definition_message, ThreeDSensorCalibrationSensorTypeField.ID),
+            growable=False), 
+        ThreeDSensorCalibrationCalibrationFactorField(
+            size=cls._field_size_from_definition(
+                definition_message, ThreeDSensorCalibrationCalibrationFactorField.ID),
+            growable=False), 
+        ThreeDSensorCalibrationCalibrationDivisorField(
+            size=cls._field_size_from_definition(
+                definition_message, ThreeDSensorCalibrationCalibrationDivisorField.ID),
+            growable=False), 
+        ThreeDSensorCalibrationLevelShiftField(
+            size=cls._field_size_from_definition(
+                definition_message, ThreeDSensorCalibrationLevelShiftField.ID),
+            growable=False), 
+        ThreeDSensorCalibrationOffsetCalField(
+            size=cls._field_size_from_definition(
+                definition_message, ThreeDSensorCalibrationOffsetCalField.ID),
+            growable=False), 
+        ThreeDSensorCalibrationOrientationMatrixField(
+            size=cls._field_size_from_definition(
+                definition_message, ThreeDSensorCalibrationOrientationMatrixField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/time_in_zone_message.py
+++ b/fit_tool/profile/messages/time_in_zone_message.py
@@ -17,87 +17,182 @@ from typing import Dict as dict
 
 
 class TimeInZoneMessage(DataMessage):
+    """TimeInZoneMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``TimeInZoneMessage()`` — create path: growable fields, no wire definition.
+    * ``TimeInZoneMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 216
     NAME = 'time_in_zone'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=TimeInZoneMessage.NAME,
                          global_id=TimeInZoneMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         TimestampField(
-            size=self.__get_field_size(definition_message, TimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         TimeInZoneReferenceMesgField(
-            size=self.__get_field_size(definition_message, TimeInZoneReferenceMesgField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         TimeInZoneReferenceIndexField(
-            size=self.__get_field_size(definition_message, TimeInZoneReferenceIndexField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         TimeInZoneTimeInHrZoneField(
-            size=self.__get_field_size(definition_message, TimeInZoneTimeInHrZoneField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         TimeInZoneTimeInSpeedZoneField(
-            size=self.__get_field_size(definition_message, TimeInZoneTimeInSpeedZoneField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         TimeInZoneTimeInCadenceZoneField(
-            size=self.__get_field_size(definition_message, TimeInZoneTimeInCadenceZoneField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         TimeInZoneTimeInPowerZoneField(
-            size=self.__get_field_size(definition_message, TimeInZoneTimeInPowerZoneField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         TimeInZoneHrZoneHighBoundaryField(
-            size=self.__get_field_size(definition_message, TimeInZoneHrZoneHighBoundaryField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         TimeInZoneSpeedZoneHighBoundaryField(
-            size=self.__get_field_size(definition_message, TimeInZoneSpeedZoneHighBoundaryField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         TimeInZoneCadenceZoneHighBondaryField(
-            size=self.__get_field_size(definition_message, TimeInZoneCadenceZoneHighBondaryField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         TimeInZonePowerZoneHighBoundaryField(
-            size=self.__get_field_size(definition_message, TimeInZonePowerZoneHighBoundaryField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         TimeInZoneHrCalcTypeField(
-            size=self.__get_field_size(definition_message, TimeInZoneHrCalcTypeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         TimeInZoneMaxHeartRateField(
-            size=self.__get_field_size(definition_message, TimeInZoneMaxHeartRateField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         TimeInZoneRestingHeartRateField(
-            size=self.__get_field_size(definition_message, TimeInZoneRestingHeartRateField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         TimeInZoneThresholdHeartRateField(
-            size=self.__get_field_size(definition_message, TimeInZoneThresholdHeartRateField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         TimeInZonePwrCalcTypeField(
-            size=self.__get_field_size(definition_message, TimeInZonePwrCalcTypeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         TimeInZoneFunctionalThresholdPowerField(
-            size=self.__get_field_size(definition_message, TimeInZoneFunctionalThresholdPowerField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        TimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampField.ID),
+            growable=False), 
+        TimeInZoneReferenceMesgField(
+            size=cls._field_size_from_definition(
+                definition_message, TimeInZoneReferenceMesgField.ID),
+            growable=False), 
+        TimeInZoneReferenceIndexField(
+            size=cls._field_size_from_definition(
+                definition_message, TimeInZoneReferenceIndexField.ID),
+            growable=False), 
+        TimeInZoneTimeInHrZoneField(
+            size=cls._field_size_from_definition(
+                definition_message, TimeInZoneTimeInHrZoneField.ID),
+            growable=False), 
+        TimeInZoneTimeInSpeedZoneField(
+            size=cls._field_size_from_definition(
+                definition_message, TimeInZoneTimeInSpeedZoneField.ID),
+            growable=False), 
+        TimeInZoneTimeInCadenceZoneField(
+            size=cls._field_size_from_definition(
+                definition_message, TimeInZoneTimeInCadenceZoneField.ID),
+            growable=False), 
+        TimeInZoneTimeInPowerZoneField(
+            size=cls._field_size_from_definition(
+                definition_message, TimeInZoneTimeInPowerZoneField.ID),
+            growable=False), 
+        TimeInZoneHrZoneHighBoundaryField(
+            size=cls._field_size_from_definition(
+                definition_message, TimeInZoneHrZoneHighBoundaryField.ID),
+            growable=False), 
+        TimeInZoneSpeedZoneHighBoundaryField(
+            size=cls._field_size_from_definition(
+                definition_message, TimeInZoneSpeedZoneHighBoundaryField.ID),
+            growable=False), 
+        TimeInZoneCadenceZoneHighBondaryField(
+            size=cls._field_size_from_definition(
+                definition_message, TimeInZoneCadenceZoneHighBondaryField.ID),
+            growable=False), 
+        TimeInZonePowerZoneHighBoundaryField(
+            size=cls._field_size_from_definition(
+                definition_message, TimeInZonePowerZoneHighBoundaryField.ID),
+            growable=False), 
+        TimeInZoneHrCalcTypeField(
+            size=cls._field_size_from_definition(
+                definition_message, TimeInZoneHrCalcTypeField.ID),
+            growable=False), 
+        TimeInZoneMaxHeartRateField(
+            size=cls._field_size_from_definition(
+                definition_message, TimeInZoneMaxHeartRateField.ID),
+            growable=False), 
+        TimeInZoneRestingHeartRateField(
+            size=cls._field_size_from_definition(
+                definition_message, TimeInZoneRestingHeartRateField.ID),
+            growable=False), 
+        TimeInZoneThresholdHeartRateField(
+            size=cls._field_size_from_definition(
+                definition_message, TimeInZoneThresholdHeartRateField.ID),
+            growable=False), 
+        TimeInZonePwrCalcTypeField(
+            size=cls._field_size_from_definition(
+                definition_message, TimeInZonePwrCalcTypeField.ID),
+            growable=False), 
+        TimeInZoneFunctionalThresholdPowerField(
+            size=cls._field_size_from_definition(
+                definition_message, TimeInZoneFunctionalThresholdPowerField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/timestamp_correlation_message.py
+++ b/fit_tool/profile/messages/timestamp_correlation_message.py
@@ -17,57 +17,112 @@ from typing import Dict as dict
 
 
 class TimestampCorrelationMessage(DataMessage):
+    """TimestampCorrelationMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``TimestampCorrelationMessage()`` — create path: growable fields, no wire definition.
+    * ``TimestampCorrelationMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 162
     NAME = 'timestamp_correlation'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=TimestampCorrelationMessage.NAME,
                          global_id=TimestampCorrelationMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         TimestampField(
-            size=self.__get_field_size(definition_message, TimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         TimestampCorrelationFractionalTimestampField(
-            size=self.__get_field_size(definition_message, TimestampCorrelationFractionalTimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         TimestampCorrelationSystemTimestampField(
-            size=self.__get_field_size(definition_message, TimestampCorrelationSystemTimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         TimestampCorrelationFractionalSystemTimestampField(
-            size=self.__get_field_size(definition_message, TimestampCorrelationFractionalSystemTimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         TimestampCorrelationLocalTimestampField(
-            size=self.__get_field_size(definition_message, TimestampCorrelationLocalTimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         TimestampCorrelationTimestampMsField(
-            size=self.__get_field_size(definition_message, TimestampCorrelationTimestampMsField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         TimestampCorrelationSystemTimestampMsField(
-            size=self.__get_field_size(definition_message, TimestampCorrelationSystemTimestampMsField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        TimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampField.ID),
+            growable=False), 
+        TimestampCorrelationFractionalTimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampCorrelationFractionalTimestampField.ID),
+            growable=False), 
+        TimestampCorrelationSystemTimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampCorrelationSystemTimestampField.ID),
+            growable=False), 
+        TimestampCorrelationFractionalSystemTimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampCorrelationFractionalSystemTimestampField.ID),
+            growable=False), 
+        TimestampCorrelationLocalTimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampCorrelationLocalTimestampField.ID),
+            growable=False), 
+        TimestampCorrelationTimestampMsField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampCorrelationTimestampMsField.ID),
+            growable=False), 
+        TimestampCorrelationSystemTimestampMsField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampCorrelationSystemTimestampMsField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/totals_message.py
+++ b/fit_tool/profile/messages/totals_message.py
@@ -17,66 +17,133 @@ from typing import Dict as dict
 
 
 class TotalsMessage(DataMessage):
+    """TotalsMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``TotalsMessage()`` — create path: growable fields, no wire definition.
+    * ``TotalsMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 33
     NAME = 'totals'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=TotalsMessage.NAME,
                          global_id=TotalsMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         MessageIndexField(
-            size=self.__get_field_size(definition_message, MessageIndexField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         TimestampField(
-            size=self.__get_field_size(definition_message, TimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         TotalsTimerTimeField(
-            size=self.__get_field_size(definition_message, TotalsTimerTimeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         TotalsDistanceField(
-            size=self.__get_field_size(definition_message, TotalsDistanceField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         TotalsCaloriesField(
-            size=self.__get_field_size(definition_message, TotalsCaloriesField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         TotalsSportField(
-            size=self.__get_field_size(definition_message, TotalsSportField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         TotalsElapsedTimeField(
-            size=self.__get_field_size(definition_message, TotalsElapsedTimeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         TotalsSessionsField(
-            size=self.__get_field_size(definition_message, TotalsSessionsField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         TotalsActiveTimeField(
-            size=self.__get_field_size(definition_message, TotalsActiveTimeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         TotalsSportIndexField(
-            size=self.__get_field_size(definition_message, TotalsSportIndexField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        MessageIndexField(
+            size=cls._field_size_from_definition(
+                definition_message, MessageIndexField.ID),
+            growable=False), 
+        TimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampField.ID),
+            growable=False), 
+        TotalsTimerTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, TotalsTimerTimeField.ID),
+            growable=False), 
+        TotalsDistanceField(
+            size=cls._field_size_from_definition(
+                definition_message, TotalsDistanceField.ID),
+            growable=False), 
+        TotalsCaloriesField(
+            size=cls._field_size_from_definition(
+                definition_message, TotalsCaloriesField.ID),
+            growable=False), 
+        TotalsSportField(
+            size=cls._field_size_from_definition(
+                definition_message, TotalsSportField.ID),
+            growable=False), 
+        TotalsElapsedTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, TotalsElapsedTimeField.ID),
+            growable=False), 
+        TotalsSessionsField(
+            size=cls._field_size_from_definition(
+                definition_message, TotalsSessionsField.ID),
+            growable=False), 
+        TotalsActiveTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, TotalsActiveTimeField.ID),
+            growable=False), 
+        TotalsSportIndexField(
+            size=cls._field_size_from_definition(
+                definition_message, TotalsSportIndexField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/training_file_message.py
+++ b/fit_tool/profile/messages/training_file_message.py
@@ -17,54 +17,105 @@ from typing import Dict as dict
 
 
 class TrainingFileMessage(DataMessage):
+    """TrainingFileMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``TrainingFileMessage()`` — create path: growable fields, no wire definition.
+    * ``TrainingFileMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 72
     NAME = 'training_file'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=TrainingFileMessage.NAME,
                          global_id=TrainingFileMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         TimestampField(
-            size=self.__get_field_size(definition_message, TimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         TrainingFileTypeField(
-            size=self.__get_field_size(definition_message, TrainingFileTypeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         TrainingFileManufacturerField(
-            size=self.__get_field_size(definition_message, TrainingFileManufacturerField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         TrainingFileProductField(
-            size=self.__get_field_size(definition_message, TrainingFileProductField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         TrainingFileSerialNumberField(
-            size=self.__get_field_size(definition_message, TrainingFileSerialNumberField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         TrainingFileTimeCreatedField(
-            size=self.__get_field_size(definition_message, TrainingFileTimeCreatedField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        TimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampField.ID),
+            growable=False), 
+        TrainingFileTypeField(
+            size=cls._field_size_from_definition(
+                definition_message, TrainingFileTypeField.ID),
+            growable=False), 
+        TrainingFileManufacturerField(
+            size=cls._field_size_from_definition(
+                definition_message, TrainingFileManufacturerField.ID),
+            growable=False), 
+        TrainingFileProductField(
+            size=cls._field_size_from_definition(
+                definition_message, TrainingFileProductField.ID),
+            growable=False), 
+        TrainingFileSerialNumberField(
+            size=cls._field_size_from_definition(
+                definition_message, TrainingFileSerialNumberField.ID),
+            growable=False), 
+        TrainingFileTimeCreatedField(
+            size=cls._field_size_from_definition(
+                definition_message, TrainingFileTimeCreatedField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/training_settings_message.py
+++ b/fit_tool/profile/messages/training_settings_message.py
@@ -17,48 +17,91 @@ from typing import Dict as dict
 
 
 class TrainingSettingsMessage(DataMessage):
+    """TrainingSettingsMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``TrainingSettingsMessage()`` — create path: growable fields, no wire definition.
+    * ``TrainingSettingsMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 13
     NAME = 'training_settings'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=TrainingSettingsMessage.NAME,
                          global_id=TrainingSettingsMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         TrainingSettingsTargetDistanceField(
-            size=self.__get_field_size(definition_message, TrainingSettingsTargetDistanceField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         TrainingSettingsTargetSpeedField(
-            size=self.__get_field_size(definition_message, TrainingSettingsTargetSpeedField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         TrainingSettingsTargetTimeField(
-            size=self.__get_field_size(definition_message, TrainingSettingsTargetTimeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         TrainingSettingsPreciseTargetSpeedField(
-            size=self.__get_field_size(definition_message, TrainingSettingsPreciseTargetSpeedField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        TrainingSettingsTargetDistanceField(
+            size=cls._field_size_from_definition(
+                definition_message, TrainingSettingsTargetDistanceField.ID),
+            growable=False), 
+        TrainingSettingsTargetSpeedField(
+            size=cls._field_size_from_definition(
+                definition_message, TrainingSettingsTargetSpeedField.ID),
+            growable=False), 
+        TrainingSettingsTargetTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, TrainingSettingsTargetTimeField.ID),
+            growable=False), 
+        TrainingSettingsPreciseTargetSpeedField(
+            size=cls._field_size_from_definition(
+                definition_message, TrainingSettingsPreciseTargetSpeedField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/user_profile_message.py
+++ b/fit_tool/profile/messages/user_profile_message.py
@@ -17,123 +17,266 @@ from typing import Dict as dict
 
 
 class UserProfileMessage(DataMessage):
+    """UserProfileMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``UserProfileMessage()`` — create path: growable fields, no wire definition.
+    * ``UserProfileMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 3
     NAME = 'user_profile'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=UserProfileMessage.NAME,
                          global_id=UserProfileMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         MessageIndexField(
-            size=self.__get_field_size(definition_message, MessageIndexField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         UserProfileFriendlyNameField(
-            size=self.__get_field_size(definition_message, UserProfileFriendlyNameField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         UserProfileGenderField(
-            size=self.__get_field_size(definition_message, UserProfileGenderField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         UserProfileAgeField(
-            size=self.__get_field_size(definition_message, UserProfileAgeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         UserProfileHeightField(
-            size=self.__get_field_size(definition_message, UserProfileHeightField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         UserProfileWeightField(
-            size=self.__get_field_size(definition_message, UserProfileWeightField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         UserProfileLanguageField(
-            size=self.__get_field_size(definition_message, UserProfileLanguageField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         UserProfileElevSettingField(
-            size=self.__get_field_size(definition_message, UserProfileElevSettingField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         UserProfileWeightSettingField(
-            size=self.__get_field_size(definition_message, UserProfileWeightSettingField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         UserProfileRestingHeartRateField(
-            size=self.__get_field_size(definition_message, UserProfileRestingHeartRateField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         UserProfileDefaultMaxRunningHeartRateField(
-            size=self.__get_field_size(definition_message, UserProfileDefaultMaxRunningHeartRateField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         UserProfileDefaultMaxBikingHeartRateField(
-            size=self.__get_field_size(definition_message, UserProfileDefaultMaxBikingHeartRateField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         UserProfileDefaultMaxHeartRateField(
-            size=self.__get_field_size(definition_message, UserProfileDefaultMaxHeartRateField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         UserProfileHrSettingField(
-            size=self.__get_field_size(definition_message, UserProfileHrSettingField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         UserProfileSpeedSettingField(
-            size=self.__get_field_size(definition_message, UserProfileSpeedSettingField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         UserProfileDistSettingField(
-            size=self.__get_field_size(definition_message, UserProfileDistSettingField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         UserProfilePowerSettingField(
-            size=self.__get_field_size(definition_message, UserProfilePowerSettingField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         UserProfileActivityClassField(
-            size=self.__get_field_size(definition_message, UserProfileActivityClassField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         UserProfilePositionSettingField(
-            size=self.__get_field_size(definition_message, UserProfilePositionSettingField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         UserProfileTemperatureSettingField(
-            size=self.__get_field_size(definition_message, UserProfileTemperatureSettingField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         UserProfileLocalIdField(
-            size=self.__get_field_size(definition_message, UserProfileLocalIdField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         UserProfileGlobalIdField(
-            size=self.__get_field_size(definition_message, UserProfileGlobalIdField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         UserProfileWakeTimeField(
-            size=self.__get_field_size(definition_message, UserProfileWakeTimeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         UserProfileSleepTimeField(
-            size=self.__get_field_size(definition_message, UserProfileSleepTimeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         UserProfileHeightSettingField(
-            size=self.__get_field_size(definition_message, UserProfileHeightSettingField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         UserProfileUserRunningStepLengthField(
-            size=self.__get_field_size(definition_message, UserProfileUserRunningStepLengthField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         UserProfileUserWalkingStepLengthField(
-            size=self.__get_field_size(definition_message, UserProfileUserWalkingStepLengthField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         UserProfileDepthSettingField(
-            size=self.__get_field_size(definition_message, UserProfileDepthSettingField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         UserProfileDiveCountField(
-            size=self.__get_field_size(definition_message, UserProfileDiveCountField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        MessageIndexField(
+            size=cls._field_size_from_definition(
+                definition_message, MessageIndexField.ID),
+            growable=False), 
+        UserProfileFriendlyNameField(
+            size=cls._field_size_from_definition(
+                definition_message, UserProfileFriendlyNameField.ID),
+            growable=False), 
+        UserProfileGenderField(
+            size=cls._field_size_from_definition(
+                definition_message, UserProfileGenderField.ID),
+            growable=False), 
+        UserProfileAgeField(
+            size=cls._field_size_from_definition(
+                definition_message, UserProfileAgeField.ID),
+            growable=False), 
+        UserProfileHeightField(
+            size=cls._field_size_from_definition(
+                definition_message, UserProfileHeightField.ID),
+            growable=False), 
+        UserProfileWeightField(
+            size=cls._field_size_from_definition(
+                definition_message, UserProfileWeightField.ID),
+            growable=False), 
+        UserProfileLanguageField(
+            size=cls._field_size_from_definition(
+                definition_message, UserProfileLanguageField.ID),
+            growable=False), 
+        UserProfileElevSettingField(
+            size=cls._field_size_from_definition(
+                definition_message, UserProfileElevSettingField.ID),
+            growable=False), 
+        UserProfileWeightSettingField(
+            size=cls._field_size_from_definition(
+                definition_message, UserProfileWeightSettingField.ID),
+            growable=False), 
+        UserProfileRestingHeartRateField(
+            size=cls._field_size_from_definition(
+                definition_message, UserProfileRestingHeartRateField.ID),
+            growable=False), 
+        UserProfileDefaultMaxRunningHeartRateField(
+            size=cls._field_size_from_definition(
+                definition_message, UserProfileDefaultMaxRunningHeartRateField.ID),
+            growable=False), 
+        UserProfileDefaultMaxBikingHeartRateField(
+            size=cls._field_size_from_definition(
+                definition_message, UserProfileDefaultMaxBikingHeartRateField.ID),
+            growable=False), 
+        UserProfileDefaultMaxHeartRateField(
+            size=cls._field_size_from_definition(
+                definition_message, UserProfileDefaultMaxHeartRateField.ID),
+            growable=False), 
+        UserProfileHrSettingField(
+            size=cls._field_size_from_definition(
+                definition_message, UserProfileHrSettingField.ID),
+            growable=False), 
+        UserProfileSpeedSettingField(
+            size=cls._field_size_from_definition(
+                definition_message, UserProfileSpeedSettingField.ID),
+            growable=False), 
+        UserProfileDistSettingField(
+            size=cls._field_size_from_definition(
+                definition_message, UserProfileDistSettingField.ID),
+            growable=False), 
+        UserProfilePowerSettingField(
+            size=cls._field_size_from_definition(
+                definition_message, UserProfilePowerSettingField.ID),
+            growable=False), 
+        UserProfileActivityClassField(
+            size=cls._field_size_from_definition(
+                definition_message, UserProfileActivityClassField.ID),
+            growable=False), 
+        UserProfilePositionSettingField(
+            size=cls._field_size_from_definition(
+                definition_message, UserProfilePositionSettingField.ID),
+            growable=False), 
+        UserProfileTemperatureSettingField(
+            size=cls._field_size_from_definition(
+                definition_message, UserProfileTemperatureSettingField.ID),
+            growable=False), 
+        UserProfileLocalIdField(
+            size=cls._field_size_from_definition(
+                definition_message, UserProfileLocalIdField.ID),
+            growable=False), 
+        UserProfileGlobalIdField(
+            size=cls._field_size_from_definition(
+                definition_message, UserProfileGlobalIdField.ID),
+            growable=False), 
+        UserProfileWakeTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, UserProfileWakeTimeField.ID),
+            growable=False), 
+        UserProfileSleepTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, UserProfileSleepTimeField.ID),
+            growable=False), 
+        UserProfileHeightSettingField(
+            size=cls._field_size_from_definition(
+                definition_message, UserProfileHeightSettingField.ID),
+            growable=False), 
+        UserProfileUserRunningStepLengthField(
+            size=cls._field_size_from_definition(
+                definition_message, UserProfileUserRunningStepLengthField.ID),
+            growable=False), 
+        UserProfileUserWalkingStepLengthField(
+            size=cls._field_size_from_definition(
+                definition_message, UserProfileUserWalkingStepLengthField.ID),
+            growable=False), 
+        UserProfileDepthSettingField(
+            size=cls._field_size_from_definition(
+                definition_message, UserProfileDepthSettingField.ID),
+            growable=False), 
+        UserProfileDiveCountField(
+            size=cls._field_size_from_definition(
+                definition_message, UserProfileDiveCountField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/video_clip_message.py
+++ b/fit_tool/profile/messages/video_clip_message.py
@@ -17,57 +17,112 @@ from typing import Dict as dict
 
 
 class VideoClipMessage(DataMessage):
+    """VideoClipMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``VideoClipMessage()`` — create path: growable fields, no wire definition.
+    * ``VideoClipMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 187
     NAME = 'video_clip'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=VideoClipMessage.NAME,
                          global_id=VideoClipMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         VideoClipClipNumberField(
-            size=self.__get_field_size(definition_message, VideoClipClipNumberField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         VideoClipStartTimestampField(
-            size=self.__get_field_size(definition_message, VideoClipStartTimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         VideoClipStartTimestampMsField(
-            size=self.__get_field_size(definition_message, VideoClipStartTimestampMsField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         VideoClipEndTimestampField(
-            size=self.__get_field_size(definition_message, VideoClipEndTimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         VideoClipEndTimestampMsField(
-            size=self.__get_field_size(definition_message, VideoClipEndTimestampMsField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         VideoClipClipStartField(
-            size=self.__get_field_size(definition_message, VideoClipClipStartField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         VideoClipClipEndField(
-            size=self.__get_field_size(definition_message, VideoClipClipEndField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        VideoClipClipNumberField(
+            size=cls._field_size_from_definition(
+                definition_message, VideoClipClipNumberField.ID),
+            growable=False), 
+        VideoClipStartTimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, VideoClipStartTimestampField.ID),
+            growable=False), 
+        VideoClipStartTimestampMsField(
+            size=cls._field_size_from_definition(
+                definition_message, VideoClipStartTimestampMsField.ID),
+            growable=False), 
+        VideoClipEndTimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, VideoClipEndTimestampField.ID),
+            growable=False), 
+        VideoClipEndTimestampMsField(
+            size=cls._field_size_from_definition(
+                definition_message, VideoClipEndTimestampMsField.ID),
+            growable=False), 
+        VideoClipClipStartField(
+            size=cls._field_size_from_definition(
+                definition_message, VideoClipClipStartField.ID),
+            growable=False), 
+        VideoClipClipEndField(
+            size=cls._field_size_from_definition(
+                definition_message, VideoClipClipEndField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/video_description_message.py
+++ b/fit_tool/profile/messages/video_description_message.py
@@ -17,45 +17,84 @@ from typing import Dict as dict
 
 
 class VideoDescriptionMessage(DataMessage):
+    """VideoDescriptionMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``VideoDescriptionMessage()`` — create path: growable fields, no wire definition.
+    * ``VideoDescriptionMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 186
     NAME = 'video_description'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=VideoDescriptionMessage.NAME,
                          global_id=VideoDescriptionMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         MessageIndexField(
-            size=self.__get_field_size(definition_message, MessageIndexField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         VideoDescriptionMessageCountField(
-            size=self.__get_field_size(definition_message, VideoDescriptionMessageCountField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         VideoDescriptionTextField(
-            size=self.__get_field_size(definition_message, VideoDescriptionTextField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        MessageIndexField(
+            size=cls._field_size_from_definition(
+                definition_message, MessageIndexField.ID),
+            growable=False), 
+        VideoDescriptionMessageCountField(
+            size=cls._field_size_from_definition(
+                definition_message, VideoDescriptionMessageCountField.ID),
+            growable=False), 
+        VideoDescriptionTextField(
+            size=cls._field_size_from_definition(
+                definition_message, VideoDescriptionTextField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/video_frame_message.py
+++ b/fit_tool/profile/messages/video_frame_message.py
@@ -17,45 +17,84 @@ from typing import Dict as dict
 
 
 class VideoFrameMessage(DataMessage):
+    """VideoFrameMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``VideoFrameMessage()`` — create path: growable fields, no wire definition.
+    * ``VideoFrameMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 169
     NAME = 'video_frame'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=VideoFrameMessage.NAME,
                          global_id=VideoFrameMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         TimestampField(
-            size=self.__get_field_size(definition_message, TimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         VideoFrameTimestampMsField(
-            size=self.__get_field_size(definition_message, VideoFrameTimestampMsField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         VideoFrameFrameNumberField(
-            size=self.__get_field_size(definition_message, VideoFrameFrameNumberField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        TimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampField.ID),
+            growable=False), 
+        VideoFrameTimestampMsField(
+            size=cls._field_size_from_definition(
+                definition_message, VideoFrameTimestampMsField.ID),
+            growable=False), 
+        VideoFrameFrameNumberField(
+            size=cls._field_size_from_definition(
+                definition_message, VideoFrameFrameNumberField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/video_message.py
+++ b/fit_tool/profile/messages/video_message.py
@@ -17,45 +17,84 @@ from typing import Dict as dict
 
 
 class VideoMessage(DataMessage):
+    """VideoMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``VideoMessage()`` — create path: growable fields, no wire definition.
+    * ``VideoMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 184
     NAME = 'video'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=VideoMessage.NAME,
                          global_id=VideoMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         VideoUrlField(
-            size=self.__get_field_size(definition_message, VideoUrlField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         VideoHostingProviderField(
-            size=self.__get_field_size(definition_message, VideoHostingProviderField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         VideoDurationField(
-            size=self.__get_field_size(definition_message, VideoDurationField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        VideoUrlField(
+            size=cls._field_size_from_definition(
+                definition_message, VideoUrlField.ID),
+            growable=False), 
+        VideoHostingProviderField(
+            size=cls._field_size_from_definition(
+                definition_message, VideoHostingProviderField.ID),
+            growable=False), 
+        VideoDurationField(
+            size=cls._field_size_from_definition(
+                definition_message, VideoDurationField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/video_title_message.py
+++ b/fit_tool/profile/messages/video_title_message.py
@@ -17,45 +17,84 @@ from typing import Dict as dict
 
 
 class VideoTitleMessage(DataMessage):
+    """VideoTitleMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``VideoTitleMessage()`` — create path: growable fields, no wire definition.
+    * ``VideoTitleMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 185
     NAME = 'video_title'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=VideoTitleMessage.NAME,
                          global_id=VideoTitleMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         MessageIndexField(
-            size=self.__get_field_size(definition_message, MessageIndexField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         VideoTitleMessageCountField(
-            size=self.__get_field_size(definition_message, VideoTitleMessageCountField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         VideoTitleTextField(
-            size=self.__get_field_size(definition_message, VideoTitleTextField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        MessageIndexField(
+            size=cls._field_size_from_definition(
+                definition_message, MessageIndexField.ID),
+            growable=False), 
+        VideoTitleMessageCountField(
+            size=cls._field_size_from_definition(
+                definition_message, VideoTitleMessageCountField.ID),
+            growable=False), 
+        VideoTitleTextField(
+            size=cls._field_size_from_definition(
+                definition_message, VideoTitleTextField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/watchface_settings_message.py
+++ b/fit_tool/profile/messages/watchface_settings_message.py
@@ -17,45 +17,84 @@ from typing import Dict as dict
 
 
 class WatchfaceSettingsMessage(DataMessage):
+    """WatchfaceSettingsMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``WatchfaceSettingsMessage()`` — create path: growable fields, no wire definition.
+    * ``WatchfaceSettingsMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 159
     NAME = 'watchface_settings'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=WatchfaceSettingsMessage.NAME,
                          global_id=WatchfaceSettingsMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         MessageIndexField(
-            size=self.__get_field_size(definition_message, MessageIndexField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         WatchfaceSettingsModeField(
-            size=self.__get_field_size(definition_message, WatchfaceSettingsModeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         WatchfaceSettingsLayoutField(
-            size=self.__get_field_size(definition_message, WatchfaceSettingsLayoutField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        MessageIndexField(
+            size=cls._field_size_from_definition(
+                definition_message, MessageIndexField.ID),
+            growable=False), 
+        WatchfaceSettingsModeField(
+            size=cls._field_size_from_definition(
+                definition_message, WatchfaceSettingsModeField.ID),
+            growable=False), 
+        WatchfaceSettingsLayoutField(
+            size=cls._field_size_from_definition(
+                definition_message, WatchfaceSettingsLayoutField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/weather_alert_message.py
+++ b/fit_tool/profile/messages/weather_alert_message.py
@@ -17,54 +17,105 @@ from typing import Dict as dict
 
 
 class WeatherAlertMessage(DataMessage):
+    """WeatherAlertMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``WeatherAlertMessage()`` — create path: growable fields, no wire definition.
+    * ``WeatherAlertMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 129
     NAME = 'weather_alert'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=WeatherAlertMessage.NAME,
                          global_id=WeatherAlertMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         TimestampField(
-            size=self.__get_field_size(definition_message, TimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         WeatherAlertReportIdField(
-            size=self.__get_field_size(definition_message, WeatherAlertReportIdField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         WeatherAlertIssueTimeField(
-            size=self.__get_field_size(definition_message, WeatherAlertIssueTimeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         WeatherAlertExpireTimeField(
-            size=self.__get_field_size(definition_message, WeatherAlertExpireTimeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         WeatherAlertSeverityField(
-            size=self.__get_field_size(definition_message, WeatherAlertSeverityField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         WeatherAlertTypeField(
-            size=self.__get_field_size(definition_message, WeatherAlertTypeField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        TimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampField.ID),
+            growable=False), 
+        WeatherAlertReportIdField(
+            size=cls._field_size_from_definition(
+                definition_message, WeatherAlertReportIdField.ID),
+            growable=False), 
+        WeatherAlertIssueTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, WeatherAlertIssueTimeField.ID),
+            growable=False), 
+        WeatherAlertExpireTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, WeatherAlertExpireTimeField.ID),
+            growable=False), 
+        WeatherAlertSeverityField(
+            size=cls._field_size_from_definition(
+                definition_message, WeatherAlertSeverityField.ID),
+            growable=False), 
+        WeatherAlertTypeField(
+            size=cls._field_size_from_definition(
+                definition_message, WeatherAlertTypeField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/weather_conditions_message.py
+++ b/fit_tool/profile/messages/weather_conditions_message.py
@@ -17,84 +17,175 @@ from typing import Dict as dict
 
 
 class WeatherConditionsMessage(DataMessage):
+    """WeatherConditionsMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``WeatherConditionsMessage()`` — create path: growable fields, no wire definition.
+    * ``WeatherConditionsMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 128
     NAME = 'weather_conditions'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=WeatherConditionsMessage.NAME,
                          global_id=WeatherConditionsMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         TimestampField(
-            size=self.__get_field_size(definition_message, TimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         WeatherConditionsWeatherReportField(
-            size=self.__get_field_size(definition_message, WeatherConditionsWeatherReportField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         WeatherConditionsTemperatureField(
-            size=self.__get_field_size(definition_message, WeatherConditionsTemperatureField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         WeatherConditionsConditionField(
-            size=self.__get_field_size(definition_message, WeatherConditionsConditionField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         WeatherConditionsWindDirectionField(
-            size=self.__get_field_size(definition_message, WeatherConditionsWindDirectionField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         WeatherConditionsWindSpeedField(
-            size=self.__get_field_size(definition_message, WeatherConditionsWindSpeedField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         WeatherConditionsPrecipitationProbabilityField(
-            size=self.__get_field_size(definition_message, WeatherConditionsPrecipitationProbabilityField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         WeatherConditionsTemperatureFeelsLikeField(
-            size=self.__get_field_size(definition_message, WeatherConditionsTemperatureFeelsLikeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         WeatherConditionsRelativeHumidityField(
-            size=self.__get_field_size(definition_message, WeatherConditionsRelativeHumidityField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         WeatherConditionsLocationField(
-            size=self.__get_field_size(definition_message, WeatherConditionsLocationField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         WeatherConditionsObservedAtTimeField(
-            size=self.__get_field_size(definition_message, WeatherConditionsObservedAtTimeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         WeatherConditionsObservedLocationLatField(
-            size=self.__get_field_size(definition_message, WeatherConditionsObservedLocationLatField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         WeatherConditionsObservedLocationLongField(
-            size=self.__get_field_size(definition_message, WeatherConditionsObservedLocationLongField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         WeatherConditionsDayOfWeekField(
-            size=self.__get_field_size(definition_message, WeatherConditionsDayOfWeekField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         WeatherConditionsHighTemperatureField(
-            size=self.__get_field_size(definition_message, WeatherConditionsHighTemperatureField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         WeatherConditionsLowTemperatureField(
-            size=self.__get_field_size(definition_message, WeatherConditionsLowTemperatureField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        TimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampField.ID),
+            growable=False), 
+        WeatherConditionsWeatherReportField(
+            size=cls._field_size_from_definition(
+                definition_message, WeatherConditionsWeatherReportField.ID),
+            growable=False), 
+        WeatherConditionsTemperatureField(
+            size=cls._field_size_from_definition(
+                definition_message, WeatherConditionsTemperatureField.ID),
+            growable=False), 
+        WeatherConditionsConditionField(
+            size=cls._field_size_from_definition(
+                definition_message, WeatherConditionsConditionField.ID),
+            growable=False), 
+        WeatherConditionsWindDirectionField(
+            size=cls._field_size_from_definition(
+                definition_message, WeatherConditionsWindDirectionField.ID),
+            growable=False), 
+        WeatherConditionsWindSpeedField(
+            size=cls._field_size_from_definition(
+                definition_message, WeatherConditionsWindSpeedField.ID),
+            growable=False), 
+        WeatherConditionsPrecipitationProbabilityField(
+            size=cls._field_size_from_definition(
+                definition_message, WeatherConditionsPrecipitationProbabilityField.ID),
+            growable=False), 
+        WeatherConditionsTemperatureFeelsLikeField(
+            size=cls._field_size_from_definition(
+                definition_message, WeatherConditionsTemperatureFeelsLikeField.ID),
+            growable=False), 
+        WeatherConditionsRelativeHumidityField(
+            size=cls._field_size_from_definition(
+                definition_message, WeatherConditionsRelativeHumidityField.ID),
+            growable=False), 
+        WeatherConditionsLocationField(
+            size=cls._field_size_from_definition(
+                definition_message, WeatherConditionsLocationField.ID),
+            growable=False), 
+        WeatherConditionsObservedAtTimeField(
+            size=cls._field_size_from_definition(
+                definition_message, WeatherConditionsObservedAtTimeField.ID),
+            growable=False), 
+        WeatherConditionsObservedLocationLatField(
+            size=cls._field_size_from_definition(
+                definition_message, WeatherConditionsObservedLocationLatField.ID),
+            growable=False), 
+        WeatherConditionsObservedLocationLongField(
+            size=cls._field_size_from_definition(
+                definition_message, WeatherConditionsObservedLocationLongField.ID),
+            growable=False), 
+        WeatherConditionsDayOfWeekField(
+            size=cls._field_size_from_definition(
+                definition_message, WeatherConditionsDayOfWeekField.ID),
+            growable=False), 
+        WeatherConditionsHighTemperatureField(
+            size=cls._field_size_from_definition(
+                definition_message, WeatherConditionsHighTemperatureField.ID),
+            growable=False), 
+        WeatherConditionsLowTemperatureField(
+            size=cls._field_size_from_definition(
+                definition_message, WeatherConditionsLowTemperatureField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/weight_scale_message.py
+++ b/fit_tool/profile/messages/weight_scale_message.py
@@ -17,78 +17,161 @@ from typing import Dict as dict
 
 
 class WeightScaleMessage(DataMessage):
+    """WeightScaleMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``WeightScaleMessage()`` — create path: growable fields, no wire definition.
+    * ``WeightScaleMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 30
     NAME = 'weight_scale'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=WeightScaleMessage.NAME,
                          global_id=WeightScaleMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         TimestampField(
-            size=self.__get_field_size(definition_message, TimestampField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         WeightScaleWeightField(
-            size=self.__get_field_size(definition_message, WeightScaleWeightField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         WeightScalePercentFatField(
-            size=self.__get_field_size(definition_message, WeightScalePercentFatField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         WeightScalePercentHydrationField(
-            size=self.__get_field_size(definition_message, WeightScalePercentHydrationField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         WeightScaleVisceralFatMassField(
-            size=self.__get_field_size(definition_message, WeightScaleVisceralFatMassField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         WeightScaleBoneMassField(
-            size=self.__get_field_size(definition_message, WeightScaleBoneMassField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         WeightScaleMuscleMassField(
-            size=self.__get_field_size(definition_message, WeightScaleMuscleMassField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         WeightScaleBasalMetField(
-            size=self.__get_field_size(definition_message, WeightScaleBasalMetField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         WeightScalePhysiqueRatingField(
-            size=self.__get_field_size(definition_message, WeightScalePhysiqueRatingField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         WeightScaleActiveMetField(
-            size=self.__get_field_size(definition_message, WeightScaleActiveMetField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         WeightScaleMetabolicAgeField(
-            size=self.__get_field_size(definition_message, WeightScaleMetabolicAgeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         WeightScaleVisceralFatRatingField(
-            size=self.__get_field_size(definition_message, WeightScaleVisceralFatRatingField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         WeightScaleUserProfileIndexField(
-            size=self.__get_field_size(definition_message, WeightScaleUserProfileIndexField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         WeightScaleBmiField(
-            size=self.__get_field_size(definition_message, WeightScaleBmiField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        TimestampField(
+            size=cls._field_size_from_definition(
+                definition_message, TimestampField.ID),
+            growable=False), 
+        WeightScaleWeightField(
+            size=cls._field_size_from_definition(
+                definition_message, WeightScaleWeightField.ID),
+            growable=False), 
+        WeightScalePercentFatField(
+            size=cls._field_size_from_definition(
+                definition_message, WeightScalePercentFatField.ID),
+            growable=False), 
+        WeightScalePercentHydrationField(
+            size=cls._field_size_from_definition(
+                definition_message, WeightScalePercentHydrationField.ID),
+            growable=False), 
+        WeightScaleVisceralFatMassField(
+            size=cls._field_size_from_definition(
+                definition_message, WeightScaleVisceralFatMassField.ID),
+            growable=False), 
+        WeightScaleBoneMassField(
+            size=cls._field_size_from_definition(
+                definition_message, WeightScaleBoneMassField.ID),
+            growable=False), 
+        WeightScaleMuscleMassField(
+            size=cls._field_size_from_definition(
+                definition_message, WeightScaleMuscleMassField.ID),
+            growable=False), 
+        WeightScaleBasalMetField(
+            size=cls._field_size_from_definition(
+                definition_message, WeightScaleBasalMetField.ID),
+            growable=False), 
+        WeightScalePhysiqueRatingField(
+            size=cls._field_size_from_definition(
+                definition_message, WeightScalePhysiqueRatingField.ID),
+            growable=False), 
+        WeightScaleActiveMetField(
+            size=cls._field_size_from_definition(
+                definition_message, WeightScaleActiveMetField.ID),
+            growable=False), 
+        WeightScaleMetabolicAgeField(
+            size=cls._field_size_from_definition(
+                definition_message, WeightScaleMetabolicAgeField.ID),
+            growable=False), 
+        WeightScaleVisceralFatRatingField(
+            size=cls._field_size_from_definition(
+                definition_message, WeightScaleVisceralFatRatingField.ID),
+            growable=False), 
+        WeightScaleUserProfileIndexField(
+            size=cls._field_size_from_definition(
+                definition_message, WeightScaleUserProfileIndexField.ID),
+            growable=False), 
+        WeightScaleBmiField(
+            size=cls._field_size_from_definition(
+                definition_message, WeightScaleBmiField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/workout_message.py
+++ b/fit_tool/profile/messages/workout_message.py
@@ -17,63 +17,126 @@ from typing import Dict as dict
 
 
 class WorkoutMessage(DataMessage):
+    """WorkoutMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``WorkoutMessage()`` — create path: growable fields, no wire definition.
+    * ``WorkoutMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 26
     NAME = 'workout'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=WorkoutMessage.NAME,
                          global_id=WorkoutMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         MessageIndexField(
-            size=self.__get_field_size(definition_message, MessageIndexField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         WorkoutSportField(
-            size=self.__get_field_size(definition_message, WorkoutSportField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         WorkoutCapabilitiesField(
-            size=self.__get_field_size(definition_message, WorkoutCapabilitiesField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         WorkoutNumValidStepsField(
-            size=self.__get_field_size(definition_message, WorkoutNumValidStepsField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         WorkoutWorkoutNameField(
-            size=self.__get_field_size(definition_message, WorkoutWorkoutNameField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         WorkoutSubSportField(
-            size=self.__get_field_size(definition_message, WorkoutSubSportField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         WorkoutPoolLengthField(
-            size=self.__get_field_size(definition_message, WorkoutPoolLengthField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         WorkoutPoolLengthUnitField(
-            size=self.__get_field_size(definition_message, WorkoutPoolLengthUnitField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         WorkoutWorkoutDescriptionField(
-            size=self.__get_field_size(definition_message, WorkoutWorkoutDescriptionField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        MessageIndexField(
+            size=cls._field_size_from_definition(
+                definition_message, MessageIndexField.ID),
+            growable=False), 
+        WorkoutSportField(
+            size=cls._field_size_from_definition(
+                definition_message, WorkoutSportField.ID),
+            growable=False), 
+        WorkoutCapabilitiesField(
+            size=cls._field_size_from_definition(
+                definition_message, WorkoutCapabilitiesField.ID),
+            growable=False), 
+        WorkoutNumValidStepsField(
+            size=cls._field_size_from_definition(
+                definition_message, WorkoutNumValidStepsField.ID),
+            growable=False), 
+        WorkoutWorkoutNameField(
+            size=cls._field_size_from_definition(
+                definition_message, WorkoutWorkoutNameField.ID),
+            growable=False), 
+        WorkoutSubSportField(
+            size=cls._field_size_from_definition(
+                definition_message, WorkoutSubSportField.ID),
+            growable=False), 
+        WorkoutPoolLengthField(
+            size=cls._field_size_from_definition(
+                definition_message, WorkoutPoolLengthField.ID),
+            growable=False), 
+        WorkoutPoolLengthUnitField(
+            size=cls._field_size_from_definition(
+                definition_message, WorkoutPoolLengthUnitField.ID),
+            growable=False), 
+        WorkoutWorkoutDescriptionField(
+            size=cls._field_size_from_definition(
+                definition_message, WorkoutWorkoutDescriptionField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/workout_session_message.py
+++ b/fit_tool/profile/messages/workout_session_message.py
@@ -17,57 +17,112 @@ from typing import Dict as dict
 
 
 class WorkoutSessionMessage(DataMessage):
+    """WorkoutSessionMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``WorkoutSessionMessage()`` — create path: growable fields, no wire definition.
+    * ``WorkoutSessionMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 158
     NAME = 'workout_session'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=WorkoutSessionMessage.NAME,
                          global_id=WorkoutSessionMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         MessageIndexField(
-            size=self.__get_field_size(definition_message, MessageIndexField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         WorkoutSessionSportField(
-            size=self.__get_field_size(definition_message, WorkoutSessionSportField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         WorkoutSessionSubSportField(
-            size=self.__get_field_size(definition_message, WorkoutSessionSubSportField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         WorkoutSessionNumValidStepsField(
-            size=self.__get_field_size(definition_message, WorkoutSessionNumValidStepsField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         WorkoutSessionFirstStepIndexField(
-            size=self.__get_field_size(definition_message, WorkoutSessionFirstStepIndexField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         WorkoutSessionPoolLengthField(
-            size=self.__get_field_size(definition_message, WorkoutSessionPoolLengthField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         WorkoutSessionPoolLengthUnitField(
-            size=self.__get_field_size(definition_message, WorkoutSessionPoolLengthUnitField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        MessageIndexField(
+            size=cls._field_size_from_definition(
+                definition_message, MessageIndexField.ID),
+            growable=False), 
+        WorkoutSessionSportField(
+            size=cls._field_size_from_definition(
+                definition_message, WorkoutSessionSportField.ID),
+            growable=False), 
+        WorkoutSessionSubSportField(
+            size=cls._field_size_from_definition(
+                definition_message, WorkoutSessionSubSportField.ID),
+            growable=False), 
+        WorkoutSessionNumValidStepsField(
+            size=cls._field_size_from_definition(
+                definition_message, WorkoutSessionNumValidStepsField.ID),
+            growable=False), 
+        WorkoutSessionFirstStepIndexField(
+            size=cls._field_size_from_definition(
+                definition_message, WorkoutSessionFirstStepIndexField.ID),
+            growable=False), 
+        WorkoutSessionPoolLengthField(
+            size=cls._field_size_from_definition(
+                definition_message, WorkoutSessionPoolLengthField.ID),
+            growable=False), 
+        WorkoutSessionPoolLengthUnitField(
+            size=cls._field_size_from_definition(
+                definition_message, WorkoutSessionPoolLengthUnitField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/workout_step_message.py
+++ b/fit_tool/profile/messages/workout_step_message.py
@@ -17,93 +17,196 @@ from typing import Dict as dict
 
 
 class WorkoutStepMessage(DataMessage):
+    """WorkoutStepMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``WorkoutStepMessage()`` — create path: growable fields, no wire definition.
+    * ``WorkoutStepMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 27
     NAME = 'workout_step'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=WorkoutStepMessage.NAME,
                          global_id=WorkoutStepMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         MessageIndexField(
-            size=self.__get_field_size(definition_message, MessageIndexField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         WorkoutStepWorkoutStepNameField(
-            size=self.__get_field_size(definition_message, WorkoutStepWorkoutStepNameField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         WorkoutStepDurationTypeField(
-            size=self.__get_field_size(definition_message, WorkoutStepDurationTypeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         WorkoutStepDurationValueField(
-            size=self.__get_field_size(definition_message, WorkoutStepDurationValueField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         WorkoutStepTargetTypeField(
-            size=self.__get_field_size(definition_message, WorkoutStepTargetTypeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         WorkoutStepTargetValueField(
-            size=self.__get_field_size(definition_message, WorkoutStepTargetValueField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         WorkoutStepCustomTargetValueLowField(
-            size=self.__get_field_size(definition_message, WorkoutStepCustomTargetValueLowField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         WorkoutStepCustomTargetValueHighField(
-            size=self.__get_field_size(definition_message, WorkoutStepCustomTargetValueHighField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         WorkoutStepIntensityField(
-            size=self.__get_field_size(definition_message, WorkoutStepIntensityField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         WorkoutStepNotesField(
-            size=self.__get_field_size(definition_message, WorkoutStepNotesField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         WorkoutStepEquipmentField(
-            size=self.__get_field_size(definition_message, WorkoutStepEquipmentField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         WorkoutStepExerciseCategoryField(
-            size=self.__get_field_size(definition_message, WorkoutStepExerciseCategoryField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         WorkoutStepExerciseNameField(
-            size=self.__get_field_size(definition_message, WorkoutStepExerciseNameField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         WorkoutStepExerciseWeightField(
-            size=self.__get_field_size(definition_message, WorkoutStepExerciseWeightField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         WorkoutStepWeightDisplayUnitField(
-            size=self.__get_field_size(definition_message, WorkoutStepWeightDisplayUnitField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         WorkoutStepSecondaryTargetTypeField(
-            size=self.__get_field_size(definition_message, WorkoutStepSecondaryTargetTypeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         WorkoutStepSecondaryTargetValueField(
-            size=self.__get_field_size(definition_message, WorkoutStepSecondaryTargetValueField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         WorkoutStepSecondaryCustomTargetValueLowField(
-            size=self.__get_field_size(definition_message, WorkoutStepSecondaryCustomTargetValueLowField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         WorkoutStepSecondaryCustomTargetValueHighField(
-            size=self.__get_field_size(definition_message, WorkoutStepSecondaryCustomTargetValueHighField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        MessageIndexField(
+            size=cls._field_size_from_definition(
+                definition_message, MessageIndexField.ID),
+            growable=False), 
+        WorkoutStepWorkoutStepNameField(
+            size=cls._field_size_from_definition(
+                definition_message, WorkoutStepWorkoutStepNameField.ID),
+            growable=False), 
+        WorkoutStepDurationTypeField(
+            size=cls._field_size_from_definition(
+                definition_message, WorkoutStepDurationTypeField.ID),
+            growable=False), 
+        WorkoutStepDurationValueField(
+            size=cls._field_size_from_definition(
+                definition_message, WorkoutStepDurationValueField.ID),
+            growable=False), 
+        WorkoutStepTargetTypeField(
+            size=cls._field_size_from_definition(
+                definition_message, WorkoutStepTargetTypeField.ID),
+            growable=False), 
+        WorkoutStepTargetValueField(
+            size=cls._field_size_from_definition(
+                definition_message, WorkoutStepTargetValueField.ID),
+            growable=False), 
+        WorkoutStepCustomTargetValueLowField(
+            size=cls._field_size_from_definition(
+                definition_message, WorkoutStepCustomTargetValueLowField.ID),
+            growable=False), 
+        WorkoutStepCustomTargetValueHighField(
+            size=cls._field_size_from_definition(
+                definition_message, WorkoutStepCustomTargetValueHighField.ID),
+            growable=False), 
+        WorkoutStepIntensityField(
+            size=cls._field_size_from_definition(
+                definition_message, WorkoutStepIntensityField.ID),
+            growable=False), 
+        WorkoutStepNotesField(
+            size=cls._field_size_from_definition(
+                definition_message, WorkoutStepNotesField.ID),
+            growable=False), 
+        WorkoutStepEquipmentField(
+            size=cls._field_size_from_definition(
+                definition_message, WorkoutStepEquipmentField.ID),
+            growable=False), 
+        WorkoutStepExerciseCategoryField(
+            size=cls._field_size_from_definition(
+                definition_message, WorkoutStepExerciseCategoryField.ID),
+            growable=False), 
+        WorkoutStepExerciseNameField(
+            size=cls._field_size_from_definition(
+                definition_message, WorkoutStepExerciseNameField.ID),
+            growable=False), 
+        WorkoutStepExerciseWeightField(
+            size=cls._field_size_from_definition(
+                definition_message, WorkoutStepExerciseWeightField.ID),
+            growable=False), 
+        WorkoutStepWeightDisplayUnitField(
+            size=cls._field_size_from_definition(
+                definition_message, WorkoutStepWeightDisplayUnitField.ID),
+            growable=False), 
+        WorkoutStepSecondaryTargetTypeField(
+            size=cls._field_size_from_definition(
+                definition_message, WorkoutStepSecondaryTargetTypeField.ID),
+            growable=False), 
+        WorkoutStepSecondaryTargetValueField(
+            size=cls._field_size_from_definition(
+                definition_message, WorkoutStepSecondaryTargetValueField.ID),
+            growable=False), 
+        WorkoutStepSecondaryCustomTargetValueLowField(
+            size=cls._field_size_from_definition(
+                definition_message, WorkoutStepSecondaryCustomTargetValueLowField.ID),
+            growable=False), 
+        WorkoutStepSecondaryCustomTargetValueHighField(
+            size=cls._field_size_from_definition(
+                definition_message, WorkoutStepSecondaryCustomTargetValueHighField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/profile/messages/zones_target_message.py
+++ b/fit_tool/profile/messages/zones_target_message.py
@@ -17,51 +17,98 @@ from typing import Dict as dict
 
 
 class ZonesTargetMessage(DataMessage):
+    """ZonesTargetMessage — use blank construct for authoring, ``from_definition`` for decode.
+
+    * ``ZonesTargetMessage()`` — create path: growable fields, no wire definition.
+    * ``ZonesTargetMessage.from_definition(definition, developer_fields=...)`` —
+      project a local definition onto this type (decode / MessageFactory path).
+    """
+
     ID = 7
     NAME = 'zones_target'
 
     @staticmethod
-    def __get_field_size(definition_message: DefinitionMessage, field_id: int) -> int:
-        size = 0
-        if definition_message:
-            field_definition = definition_message.get_field_definition(field_id)
-            if field_definition:
-                size = field_definition.size
+    def _field_size_from_definition(definition_message: DefinitionMessage, field_id: int) -> int:
+        field_definition = definition_message.get_field_definition(field_id)
+        if field_definition:
+            return field_definition.size
+        return 0
 
-        return size
-
-    def __init__(self, definition_message=None, developer_fields=None, local_id: int = 0,
+    def __init__(self, developer_fields=None, local_id: int = 0,
                  endian: Endian = Endian.LITTLE):
+        """Create a blank message for authoring (growable fields, no definition)."""
         super().__init__(name=ZonesTargetMessage.NAME,
                          global_id=ZonesTargetMessage.ID,
-                         local_id=definition_message.local_id if definition_message else local_id,
-                         endian=definition_message.endian if definition_message else endian,
-                         definition_message=definition_message,
+                         local_id=local_id,
+                         endian=endian,
+                         definition_message=None,
                          developer_fields=developer_fields,
                          fields=[
         ZonesTargetMaxHeartRateField(
-            size=self.__get_field_size(definition_message, ZonesTargetMaxHeartRateField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ZonesTargetThresholdHeartRateField(
-            size=self.__get_field_size(definition_message, ZonesTargetThresholdHeartRateField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ZonesTargetFunctionalThresholdPowerField(
-            size=self.__get_field_size(definition_message, ZonesTargetFunctionalThresholdPowerField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ZonesTargetHrCalcTypeField(
-            size=self.__get_field_size(definition_message, ZonesTargetHrCalcTypeField.ID),
-            growable=definition_message is None), 
+            size=0,
+            growable=True), 
         ZonesTargetPwrCalcTypeField(
-            size=self.__get_field_size(definition_message, ZonesTargetPwrCalcTypeField.ID),
-            growable=definition_message is None)
+            size=0,
+            growable=True)
         ])
 
-        self.growable = self.definition_message is None
+        self.growable = True
+
+    @classmethod
+    def from_definition(cls, definition_message: DefinitionMessage,
+                        developer_fields: list[DeveloperField] = None):
+        """Project a wire definition onto this message type (decode path).
+
+        Field sizes come from the definition; fields are not growable. Prefer this
+        over passing a definition into ``__init__``.
+        """
+        message = cls.__new__(cls)
+        DataMessage.__init__(
+            message,
+            name=cls.NAME,
+            global_id=cls.ID,
+            local_id=definition_message.local_id,
+            endian=definition_message.endian,
+            definition_message=definition_message,
+            developer_fields=developer_fields,
+            fields=[
+        ZonesTargetMaxHeartRateField(
+            size=cls._field_size_from_definition(
+                definition_message, ZonesTargetMaxHeartRateField.ID),
+            growable=False), 
+        ZonesTargetThresholdHeartRateField(
+            size=cls._field_size_from_definition(
+                definition_message, ZonesTargetThresholdHeartRateField.ID),
+            growable=False), 
+        ZonesTargetFunctionalThresholdPowerField(
+            size=cls._field_size_from_definition(
+                definition_message, ZonesTargetFunctionalThresholdPowerField.ID),
+            growable=False), 
+        ZonesTargetHrCalcTypeField(
+            size=cls._field_size_from_definition(
+                definition_message, ZonesTargetHrCalcTypeField.ID),
+            growable=False), 
+        ZonesTargetPwrCalcTypeField(
+            size=cls._field_size_from_definition(
+                definition_message, ZonesTargetPwrCalcTypeField.ID),
+            growable=False)
+        ])
+        message.growable = False
+        return message
 
     @classmethod
     def from_bytes(cls, definition_message: DefinitionMessage, developer_fields: list[DeveloperField],
                    bytes_buffer: bytes, offset: int = 0):
-        message = cls(definition_message=definition_message, developer_fields=developer_fields)
+        message = cls.from_definition(definition_message, developer_fields=developer_fields)
         message.read_from_bytes(bytes_buffer, offset)
         return message
 

--- a/fit_tool/tests/test_data_message.py
+++ b/fit_tool/tests/test_data_message.py
@@ -26,13 +26,36 @@ class TestDataMessage(unittest.TestCase):
         bytes1 = dm1.to_bytes()
 
         definition_message = DefinitionMessage.from_data_message(dm1)
-        dm2 = WorkoutStepMessage(definition_message=definition_message)
+        dm2 = WorkoutStepMessage.from_definition(definition_message)
         dm2.read_from_bytes(bytes1)
         bytes2 = dm2.to_bytes()
 
         self.assertEqual('test', dm2.workout_step_name)
 
         self.assertEqual(bytes2, bytes1)
+
+    def test_create_vs_from_definition_paths(self):
+        """Blank create is growable; from_definition freezes field sizes."""
+        created = WorkoutStepMessage()
+        self.assertIsNone(created.definition_message)
+        self.assertTrue(created.growable)
+        name_field = created.get_field_by_name('wkt_step_name')
+        self.assertIsNotNone(name_field)
+        self.assertEqual(0, name_field.size)
+        self.assertTrue(name_field.growable)
+
+        created.workout_step_name = 'authored'
+        definition = DefinitionMessage.from_data_message(created)
+        projected = WorkoutStepMessage.from_definition(definition)
+        self.assertIs(definition, projected.definition_message)
+        self.assertFalse(projected.growable)
+        projected_name = projected.get_field_by_name('wkt_step_name')
+        self.assertIsNotNone(projected_name)
+        self.assertFalse(projected_name.growable)
+        self.assertEqual(
+            definition.get_field_definition(projected_name.field_id).size,
+            projected_name.size,
+        )
 
     def test_to_row(self):
         dm1 = WorkoutStepMessage()

--- a/fit_tool/tests/test_profile.py
+++ b/fit_tool/tests/test_profile.py
@@ -97,3 +97,16 @@ class TestMessageFactory(unittest.TestCase):
         message_class = message_factory._get_message_class(19)
         self.assertEqual('LapMessage', message_class.__name__)
         self.assertIn(module_name, sys.modules)
+
+    def test_from_definition_uses_class_factory(self):
+        from fit_tool.definition_message import DefinitionMessage
+        from fit_tool.profile.messages.message_factory import MessageFactory
+        from fit_tool.profile.messages.record_message import RecordMessage
+
+        blank = RecordMessage(local_id=3)
+        definition = DefinitionMessage.from_data_message(blank)
+        projected = MessageFactory.from_definition(definition, [])
+        self.assertIsInstance(projected, RecordMessage)
+        self.assertIs(definition, projected.definition_message)
+        self.assertFalse(projected.growable)
+        self.assertEqual(3, projected.local_id)

--- a/news/SHA-10.feature
+++ b/news/SHA-10.feature
@@ -1,0 +1,3 @@
+Split generated message construction into explicit create (`MessageClass()`)
+and decode (`MessageClass.from_definition(...)`) paths; MessageFactory uses the
+definition factory.


### PR DESCRIPTION
## Summary

Architecture Stage 4 / SHA-10: split generated message construction so authoring and decode projection are explicit (no dual-mode `__init__(definition_message=None, ...)`).

- **Create path:** `MessageClass()` / `MessageClass(local_id=..., endian=..., developer_fields=...)` — blank growable fields for writing
- **Project path:** `MessageClass.from_definition(definition, developer_fields=...)` — field sizes from the wire definition, not growable
- **MessageFactory.from_definition** and generated `from_bytes` call the definition factory
- **GenericMessage.from_definition** added (unknown global IDs remain definition-only)
- Templates under `fit_tool/gen/templates/` updated; profile messages regenerated
- Contributor docs in `AGENTS.md`; public note in `README.md`

## Test plan

- [x] `uv run pytest fit_tool/tests/test_data_message.py fit_tool/tests/test_profile.py fit_tool/tests/test_wire.py fit_tool/tests/test_decoder.py`
- [x] Full suite: 268 passed, 1 skipped
- [x] `write_workout_example.py` still runs
- [x] `ruff check` on handwritten changed modules

Depends on Stage 2–3 (wire + unified decoder + validation) already on main.