### PR TITLE
SHA-14: protocol gap fixtures and golden corpus (Stage 1 B)

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,20 @@ fit_bytes = builder.build_bytes()
 Non-strict builders remain unchanged. Prefer `validate_fit_file` / `FitFile.validate`
 when you need a report, level selection, or validation on the read path.
 
+### Protocol fixture corpus and gap inventory
+
+Committed samples live under [`fit_tool/tests/data/`](fit_tool/tests/data/). See
+[`fit_tool/tests/data/README.md`](fit_tool/tests/data/README.md) for:
+
+- layout of `sdk/`, `interop/`, and device smokes;
+- a **gap inventory** mapping Stage-2 topics (components, subfields, unknown fields,
+  multi-segment) to constructive helpers or fixtures;
+- how to obtain additional Garmin SDK samples when licensing allows.
+
+Prefer constructive builders in `fit_tool/tests/protocol_fixture_helpers.py` over
+new large binary dumps. Known incomplete semantics are pinned with explicit
+`xfail` in `fit_tool/tests/test_protocol_gap_fixtures.py` (no silent skips).
+
 ### Run Garmin SDK interoperability tests
 
 The normal test suite includes committed Garmin SDK golden bytes. A live bidirectional test additionally generates the

--- a/fit_tool/tests/data/README.md
+++ b/fit_tool/tests/data/README.md
@@ -1,0 +1,96 @@
+# Test fixture corpus
+
+Committed FIT/CSV/JSON samples and constructive test helpers used by the
+protocol and regression suite. Prefer **constructing bytes in tests** (see
+`fit_tool/tests/protocol_fixture_helpers.py`) unless a real-device or SDK
+binary is needed for interoperability.
+
+## Layout
+
+| Path | Role |
+| --- | --- |
+| `sdk/` | Official Garmin FIT SDK sample files (small golden activities, workouts, weight scale, settings, monitoring) |
+| `sdk/*.csv` | Companion CSV exports for some SDK samples |
+| `interop/activity.json` | Shared Activity semantics for Python ↔ `fit-javascript-sdk` interop |
+| `activity_*.fit`, `stagesLink_*.fit`, `palisade.fit`, `trainerroad_*.fit`, `old_stage_*.fit` | Third-party / device samples for decoder smoke |
+| `old_stage_left_hand_lee.gpx` | GPX companion for course/activity examples |
+
+## How to obtain Garmin SDK samples
+
+Garmin publishes sample FIT files and tools under their FIT SDK license.
+
+1. **SDK package (preferred for new samples)**  
+   - Site: <https://developer.garmin.com/fit/download/>  
+   - Also: <https://github.com/garmin/fit-sdk-tools> and language SDKs such as
+     <https://github.com/garmin/fit-javascript-sdk> (tag must match
+     `fit_tool.SDK_VERSION`, currently Profile **21.205.0**).
+2. **What you may commit**  
+   - Only small, redistributable SDK examples that Garmin ships as samples.  
+   - Do **not** commit proprietary device dumps, Connect exports with PII, or
+     multi‑megabyte activities. Prefer synthetic constructors in tests.
+3. **Licensing**  
+   - Follow Garmin’s FIT SDK / sample license in the package you download.  
+   - This repository already vendors a minimal subset under `sdk/` for CI; do
+     not bulk-replace it with a full SDK tree.
+4. **Profile spreadsheet**  
+   - Bundled at `fit_tool/gen/Profile_21.205.0.xlsx` for codegen only; not a
+     runtime fixture.
+
+## Live interop (optional)
+
+The default `pytest` run does **not** need Node or an external SDK checkout.
+Committed goldens under `sdk/` and `interop/` are enough.
+
+To run the live bidirectional Activity check against Garmin’s JavaScript SDK:
+
+```bash
+fit_profile_version=$(uv run python -c 'from fit_tool import SDK_VERSION; print(SDK_VERSION)')
+git clone --depth 1 --branch "$fit_profile_version" \
+  https://github.com/garmin/fit-javascript-sdk.git ../fit-javascript-sdk
+FIT_JS_SDK_PATH=../fit-javascript-sdk \
+  uv run pytest fit_tool/tests/test_garmin_sdk_interop.py -q
+```
+
+See also the README section **Run Garmin SDK interoperability tests**.
+
+## Gap inventory (protocol / Stage 2 topics)
+
+Maps known conformance gaps to fixtures or constructive tests. Stage-2 work
+(C/D/E) should promote `xfail` cases rather than invent new silent skips.
+
+| Gap / topic | Status today | Fixture or generator | Primary tests | Stage |
+| --- | --- | --- | --- | --- |
+| Compressed timestamp offset + rollover | Supported | Constructive + unit helpers | `test_protocol_high_severity.py` | done |
+| Chained multi-segment FIT | Supported | Constructive (`segment + segment`) | `test_protocol_high_severity.TestChainedAndTrailing` | done |
+| Trailing bytes after last segment | Supported (`allow_trailing_bytes`) | Constructive | same | done |
+| Component: `compressed_speed_distance` | Partial (registry) | Constructive wire + in-memory | `test_protocol_high_severity.TestComponents`, `test_protocol_gap_fixtures` | C |
+| Component: `compressed_accumulated_power` + accumulate | Partial (registry) | In-memory expansion | same | C |
+| Component: 16-bit accumulator **rollover** | Partial | Constructive expansion helper | `test_protocol_gap_fixtures` | C |
+| Nested components / full Profile component set | **Gap** | Constructive / `xfail` | `test_protocol_gap_fixtures` | C |
+| Unknown **global** messages | Partial (`GenericMessage`) | Device/SDK files with odd IDs; wire decode | `test_wire.py`, SDK smokes | E |
+| Unknown **field ids** on known messages | **Gap** (bytes skipped on project; wire preserve ok) | Constructive definition + data | `test_protocol_gap_fixtures` | E |
+| Subfields (e.g. `workout_step.duration_value`) | **Gap** (`SubField.is_valid` matches too broadly) | Constructive workout step | `test_protocol_gap_fixtures`, `test_field.py` | D |
+| Developer fields (common patterns) | Supported | `sdk/DeveloperData.fit`, `activity_developerdata.fit` | `test_sdk_files.py`, `test_developer_fields.py` | — |
+| Header CRC (14-byte / extended) | Supported | Constructive | `test_protocol_high_severity.TestHeaderCRC` | done |
+| File CRC | Supported | All CRC-checked loads | suite-wide | done |
+| Post-edit PRESERVATION | **Gap** | Untouched preserve tests only | `test_protocol_high_severity.TestPreservationEncode` | F |
+| FILE_TYPE Workout / Course rules | **Gap** (not Stage 1) | Builder examples / later | deferred | I/J |
+| Full PROFILE validation | **Gap** | deferred | deferred | H |
+
+Legend: **Gap** = behavior incomplete or incorrect relative to design doc;
+constructive tests may assert current behavior and mark the desired semantics
+with `@pytest.mark.xfail(strict=True, reason='… Stage N …')`.
+
+## Adding fixtures
+
+1. Prefer `protocol_fixture_helpers.build_fit_bytes(...)` or in-memory
+   `FitFileBuilder` over new `.fit` blobs.
+2. If a binary is required, keep it small and document origin in this README.
+3. Resolve paths with `Path(__file__).resolve().parent / 'data' / ...`.
+4. Never write into this directory from tests; use `fit_tool/tests/out/` or
+   pytest tmp paths.
+
+## Related design docs
+
+- [`docs/FIT_CONFORMANCE_DESIGN.md`](../../../docs/FIT_CONFORMANCE_DESIGN.md) — target architecture and Phase 0 golden corpus list (§9.1)
+- Repository `README.md` capability matrix — what ships today

--- a/fit_tool/tests/protocol_fixture_helpers.py
+++ b/fit_tool/tests/protocol_fixture_helpers.py
@@ -1,0 +1,138 @@
+"""Constructive FIT byte builders for protocol gap / golden tests.
+
+Prefer these helpers over committing large binary dumps. All builders produce
+CRC-valid 12-byte-header files unless noted.
+"""
+
+from __future__ import annotations
+
+import struct
+from collections.abc import Sequence
+
+from fit_tool.base_type import BaseType
+from fit_tool.definition_message import DefinitionMessage
+from fit_tool.endian import Endian
+from fit_tool.field_definition import FieldDefinition
+from fit_tool.fit_file_header import FitFileHeader
+from fit_tool.record import Record
+from fit_tool.utils.crc import crc16
+
+
+def wrap_records(records: bytes, *, with_header_crc: bool = False) -> bytes:
+    """Prefix *records* with a FIT header and append file CRC.
+
+    *with_header_crc* requests a classic 14-byte header (header CRC present).
+    """
+    if with_header_crc:
+        header = FitFileHeader(records_size=len(records), gen_crc=True)
+    else:
+        header = FitFileHeader(records_size=len(records))
+    body = header.to_bytes() + records
+    return body + struct.pack('<H', crc16(body))
+
+
+def definition_and_data(
+        *,
+        global_id: int,
+        field_definitions: Sequence[FieldDefinition],
+        payload: bytes,
+        local_id: int = 0,
+        endian: Endian = Endian.LITTLE,
+) -> bytes:
+    """Serialize one definition record + one data record (no header/CRC)."""
+    definition = DefinitionMessage(
+        local_id=local_id,
+        global_id=global_id,
+        endian=endian,
+        field_definitions=list(field_definitions),
+    )
+    definition_bytes = Record.from_message(definition).to_bytes()
+    data_header = bytes([local_id & 0x0F])
+    expected = sum(fd.size for fd in field_definitions)
+    if len(payload) != expected:
+        raise ValueError(f'payload length {len(payload)} != defined size {expected}')
+    return definition_bytes + data_header + payload
+
+
+def build_record_with_unknown_field(
+        *,
+        timestamp_raw: int = 1000,
+        heart_rate: int = 120,
+        unknown_field_id: int = 250,
+        unknown_value: int = 0xABCD,
+) -> bytes:
+    """Record (global 20) with known fields plus an unknown native field id.
+
+    Layout: timestamp (253), unknown UINT16, heart_rate (3).
+    """
+    payload = (
+        struct.pack('<I', timestamp_raw)
+        + struct.pack('<H', unknown_value)
+        + struct.pack('<B', heart_rate)
+    )
+    records = definition_and_data(
+        global_id=20,
+        field_definitions=[
+            FieldDefinition(field_id=253, size=4, base_type=BaseType.UINT32),
+            FieldDefinition(field_id=unknown_field_id, size=2, base_type=BaseType.UINT16),
+            FieldDefinition(field_id=3, size=1, base_type=BaseType.UINT8),
+        ],
+        payload=payload,
+    )
+    return wrap_records(records)
+
+
+def build_record_with_compressed_speed_distance(
+        *,
+        timestamp_raw: int = 1000,
+        speed_encoded_12bit: int = 1000,
+        distance_encoded_12bit: int = 32,
+) -> bytes:
+    """Record message with packed field 8 only (component expansion target)."""
+    packed = (speed_encoded_12bit & 0xFFF) | ((distance_encoded_12bit & 0xFFF) << 12)
+    payload = struct.pack('<I', timestamp_raw) + bytes(
+        [packed & 0xFF, (packed >> 8) & 0xFF, (packed >> 16) & 0xFF]
+    )
+    records = definition_and_data(
+        global_id=20,
+        field_definitions=[
+            FieldDefinition(field_id=253, size=4, base_type=BaseType.UINT32),
+            FieldDefinition(field_id=8, size=3, base_type=BaseType.BYTE),
+        ],
+        payload=payload,
+    )
+    return wrap_records(records)
+
+
+def build_workout_step_with_duration(
+        *,
+        duration_type: int,
+        duration_value_raw: int,
+        name: str = 'step',
+) -> bytes:
+    """Minimal workout_step (global 27) carrying duration_type + duration_value.
+
+    *duration_value_raw* is the on-wire UINT32 (before subfield scale).
+    """
+    name_bytes = name.encode('utf-8') + b'\x00'
+    # Fields: name (0 string), duration_type (1 enum), duration_value (2 uint32)
+    payload = name_bytes + struct.pack('<B', duration_type & 0xFF) + struct.pack(
+        '<I', duration_value_raw & 0xFFFFFFFF
+    )
+    records = definition_and_data(
+        global_id=27,
+        field_definitions=[
+            FieldDefinition(field_id=0, size=len(name_bytes), base_type=BaseType.STRING),
+            FieldDefinition(field_id=1, size=1, base_type=BaseType.ENUM),
+            FieldDefinition(field_id=2, size=4, base_type=BaseType.UINT32),
+        ],
+        payload=payload,
+    )
+    return wrap_records(records)
+
+
+def chain_segments(*segment_bodies: bytes) -> bytes:
+    """Concatenate complete FIT files (each already includes its file CRC)."""
+    if not segment_bodies:
+        raise ValueError('At least one segment body is required.')
+    return b''.join(segment_bodies)

--- a/fit_tool/tests/test_protocol_gap_fixtures.py
+++ b/fit_tool/tests/test_protocol_gap_fixtures.py
@@ -1,0 +1,232 @@
+"""Golden / constructive fixtures for Stage-2 protocol gaps (Phase 0 characterize).
+
+See ``fit_tool/tests/data/README.md`` for the gap inventory. These tests document
+current behavior and pin desired semantics with ``xfail`` until components (C),
+subfields (D), and unknown-field preservation (E) land. No unexplained skips.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import pytest
+
+from fit_tool.components import expand_message_components
+from fit_tool.exceptions import FitParseError
+from fit_tool.fit_file import FitFile
+from fit_tool.profile.messages.record_message import RecordMessage
+from fit_tool.profile.messages.workout_step_message import WorkoutStepMessage
+from fit_tool.profile.profile_type import WorkoutStepDuration
+from fit_tool.tests.protocol_fixture_helpers import (
+    build_record_with_compressed_speed_distance,
+    build_record_with_unknown_field,
+    build_workout_step_with_duration,
+    chain_segments,
+)
+from fit_tool.wire.decoder import decode_bytes
+from fit_tool.wire.model import RawDefinitionRecord
+
+
+class TestComponentExpansionEdges(unittest.TestCase):
+    """Additional packed-field cases beyond registry smoke in high-severity tests."""
+
+    def test_wire_decode_expands_compressed_speed_distance(self):
+        raw = build_record_with_compressed_speed_distance(
+            speed_encoded_12bit=1000,
+            distance_encoded_12bit=32,
+        )
+        fit = FitFile.from_bytes(raw)
+        message = next(r.message for r in fit.records if not r.header.is_definition)
+        self.assertIsInstance(message, RecordMessage)
+        speed = message.get_field(6)
+        distance = message.get_field(5)
+        assert speed is not None and distance is not None
+        self.assertAlmostEqual(speed.get_value(), 10.0)
+        self.assertAlmostEqual(distance.get_value(), 2.0)
+
+    def test_accumulate_16bit_rollover(self):
+        """Unsigned modular delta when the packed 16-bit value wraps."""
+        message = RecordMessage()
+        source = message.get_field(28)
+        assert source is not None
+        source.size = 2
+        acc: dict[tuple[int, int], int] = {}
+
+        source.encoded_values = [65535]
+        expand_message_components(message, acc)
+        self.assertEqual(acc[(20, 29)], 65535)
+
+        source.encoded_values = [1]  # wrap past 0xFFFF → modular delta 2
+        expand_message_components(message, acc)
+        power = message.get_field(29)
+        assert power is not None
+        self.assertEqual(acc[(20, 29)], 65537)
+        self.assertEqual(power.get_value(), 65537)
+
+    def test_nested_components_not_in_registry(self):
+        """Document that nested component graphs are not expanded yet (Stage 2 C)."""
+        from fit_tool.components import components_for_field
+        from fit_tool.field_component import FieldComponent
+
+        message = RecordMessage()
+        # No nested entries in _KNOWN_COMPONENTS; field without components returns ().
+        empty = message.get_field(0)  # position_lat — no components
+        assert empty is not None
+        self.assertEqual(components_for_field(20, empty), ())
+
+        # Explicit nested-style metadata is accepted on the Field but expansion is
+        # single-level only (no recursive expand of destinations as sources).
+        source = message.get_field(8)
+        assert source is not None
+        source.components = [
+            FieldComponent(field_id=6, accumulate=False, bits=12, scale=100.0, offset=0.0),
+            FieldComponent(field_id=5, accumulate=False, bits=12, scale=16.0, offset=0.0),
+        ]
+        self.assertEqual(len(components_for_field(20, source)), 2)
+
+
+class TestUnknownFieldOnKnownMessage(unittest.TestCase):
+    """Unknown field ids on a known global message (Stage 2 E)."""
+
+    UNKNOWN_ID = 250
+    UNKNOWN_VALUE = 0xABCD
+
+    def test_wire_definition_retains_unknown_field_id(self):
+        raw = build_record_with_unknown_field(
+            unknown_field_id=self.UNKNOWN_ID,
+            unknown_value=self.UNKNOWN_VALUE,
+        )
+        document = decode_bytes(raw)
+        definition = next(
+            r for r in document.first_segment.records if isinstance(r, RawDefinitionRecord)
+        )
+        field_ids = [fd.field_id for fd in definition.field_definitions]
+        self.assertEqual(field_ids, [253, self.UNKNOWN_ID, 3])
+
+    def test_projection_skips_unknown_field_but_keeps_known(self):
+        raw = build_record_with_unknown_field(
+            unknown_field_id=self.UNKNOWN_ID,
+            unknown_value=self.UNKNOWN_VALUE,
+            heart_rate=120,
+        )
+        fit = FitFile.from_bytes(raw)
+        message = next(r.message for r in fit.records if not r.header.is_definition)
+        self.assertIsInstance(message, RecordMessage)
+        # Current behavior: unknown native field is not projected onto the message.
+        self.assertIsNone(message.get_field(self.UNKNOWN_ID))
+        hr = message.get_field(3)
+        assert hr is not None
+        self.assertEqual(hr.get_value(), 120)
+        # Definition snapshot still lists the unknown id (structural truth).
+        assert message.definition_message is not None
+        def_ids = [fd.field_id for fd in message.definition_message.field_definitions]
+        self.assertIn(self.UNKNOWN_ID, def_ids)
+
+    def test_untouched_preserve_keeps_unknown_field_bytes(self):
+        raw = build_record_with_unknown_field(
+            unknown_field_id=self.UNKNOWN_ID,
+            unknown_value=self.UNKNOWN_VALUE,
+        )
+        fit = FitFile.from_bytes(raw)
+        self.assertEqual(fit.to_bytes(preserve=True), raw)
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason='Stage 2 E: project unknown field ids as retained values on known messages',
+    )
+    def test_projected_message_exposes_unknown_field_value(self):
+        raw = build_record_with_unknown_field(
+            unknown_field_id=self.UNKNOWN_ID,
+            unknown_value=self.UNKNOWN_VALUE,
+        )
+        fit = FitFile.from_bytes(raw)
+        message = next(r.message for r in fit.records if not r.header.is_definition)
+        unknown = message.get_field(self.UNKNOWN_ID)
+        assert unknown is not None
+        self.assertEqual(unknown.get_value(), self.UNKNOWN_VALUE)
+
+
+class TestSubfieldBearingMessage(unittest.TestCase):
+    """Subfield-relevant workout_step samples (Stage 2 D)."""
+
+    def test_workout_step_with_duration_decodes(self):
+        # duration_type DISTANCE = 1; raw duration_value 50000 (wire UINT32)
+        raw = build_workout_step_with_duration(
+            duration_type=WorkoutStepDuration.DISTANCE.value,
+            duration_value_raw=50000,
+            name='gap-step',
+        )
+        fit = FitFile.from_bytes(raw)
+        message = next(r.message for r in fit.records if not r.header.is_definition)
+        self.assertIsInstance(message, WorkoutStepMessage)
+        self.assertEqual(message.workout_step_name, 'gap-step')
+        self.assertEqual(message.duration_type, WorkoutStepDuration.DISTANCE.value)
+        # Smoke: value is readable (scale may be wrong until subfield fix — see xfail).
+        self.assertIsNotNone(message.duration_value)
+
+    def test_subfield_is_valid_matches_all_when_ref_field_present(self):
+        """Characterize SubField.is_valid bug: value checked against map keys, not ref list."""
+        message = WorkoutStepMessage()
+        message.duration_type = WorkoutStepDuration.DISTANCE
+        duration_value = message.get_field(2)
+        assert duration_value is not None
+        valid = [sf for sf in duration_value.sub_fields if sf.is_valid(message.fields)]
+        # With the bug, every subfield that keys on field 1 reports valid.
+        self.assertGreater(len(valid), 1)
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason='Stage 2 D: SubField.is_valid must match reference values, not map keys',
+    )
+    def test_duration_distance_subfield_is_selected(self):
+        message = WorkoutStepMessage()
+        message.duration_type = WorkoutStepDuration.DISTANCE
+        duration_value = message.get_field(2)
+        assert duration_value is not None
+        selected = duration_value.get_valid_sub_field(message.fields)
+        assert selected is not None
+        self.assertEqual(selected.name, 'duration_distance')
+        self.assertEqual(selected.scale, 100)
+        self.assertEqual(selected.units, 'm')
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason='Stage 2 D: decoded duration_value must use duration_distance scale (100)',
+    )
+    def test_duration_distance_scale_applied_on_decode(self):
+        # Wire raw 50000 with scale 100 → 500 m when duration_type is DISTANCE.
+        raw = build_workout_step_with_duration(
+            duration_type=WorkoutStepDuration.DISTANCE.value,
+            duration_value_raw=50000,
+        )
+        fit = FitFile.from_bytes(raw)
+        message = next(r.message for r in fit.records if not r.header.is_definition)
+        self.assertAlmostEqual(message.duration_value, 500.0)
+
+
+class TestMultiSegmentAndTrailingCorpus(unittest.TestCase):
+    """Cross-check multi-segment / trailing cases (already covered; keep corpus link)."""
+
+    def test_three_segment_chain(self):
+        one = build_workout_step_with_duration(
+            duration_type=WorkoutStepDuration.TIME.value,
+            duration_value_raw=1000,
+            name='a',
+        )
+        chained = chain_segments(one, one, one)
+        document = decode_bytes(chained)
+        self.assertEqual(len(document.segments), 3)
+        self.assertTrue(document.is_chained)
+        fit = FitFile.from_bytes(chained)
+        self.assertEqual(fit.to_bytes(preserve=True), chained)
+
+    def test_trailing_bytes_policy(self):
+        one = build_record_with_compressed_speed_distance()
+        with self.assertRaises(FitParseError):
+            FitFile.from_bytes(one + b'\xff\x00')
+        fit = FitFile.from_bytes(one + b'\xff\x00', allow_trailing_bytes=True)
+        self.assertGreaterEqual(len(fit.records), 1)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/news/SHA-14.doc
+++ b/news/SHA-14.doc
@@ -1,0 +1,4 @@
+Document the protocol fixture corpus and gap inventory under
+`fit_tool/tests/data/README.md`, with constructive Stage-2 golden tests for
+component edges, unknown fields on known messages, and subfield-bearing
+workout steps (explicit `xfail` where runtime is still incomplete).


### PR DESCRIPTION
## Summary

Stage 1 B for the protocol epic: expand the fixture/golden corpus so Stage 2 work (components, subfields, unknown fields) is testable and non-regressible without implementing those engines yet.

- **Gap inventory** in `fit_tool/tests/data/README.md` (gap → fixture/helper → tests → stage)
- **Constructive builders** in `fit_tool/tests/protocol_fixture_helpers.py` (prefer bytes in tests over large binaries)
- **New goldens** in `fit_tool/tests/test_protocol_gap_fixtures.py`:
  - component: wire decode of `compressed_speed_distance`, 16-bit accumulator rollover
  - unknown field ids on known messages: wire retain + project skip + preserve identity; `xfail` for projected value (E)
  - subfield-bearing workout_step smoke + `xfail` for correct selection/scale (D)
  - three-segment chain + trailing-byte policy cross-check
- README pointer to the corpus; Towncrier `news/SHA-14.doc`
- Documents how to obtain Garmin SDK samples (licensing-aware)

## Test plan

- [x] `uv run pytest fit_tool/tests/test_protocol_gap_fixtures.py -v`
- [x] `uv run pytest -q` (348 passed, 1 skipped interop, 3 xfailed)
- [x] `uv run ruff check` on new test modules

Maps to Multica SHA-14 / design-doc Phase 0 characterize.