### PR TITLE
SHA-18: post-edit PRESERVATION (dirty records + mixed encode)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ package already implements. Profile version in use: `21.205.0` (see
 
 | Status | Capabilities |
 | --- | --- |
-| **Supported** | Common Activity and Workout read/write via typed profile messages; `FitFileBuilder` encode path; **header CRC** (14-byte headers) and **file-level CRC** on load / stream exhaustion (`check_crc=True` default); developer fields for common declaration patterns; streaming iterators (`FitFile.iter_file` / `iter_stream`); CSV export (`to_csv` / `to_rows`); Course and similar message types when you construct them yourself; **chained multi-segment** FIT decode via `from_bytes` / `from_file` (all segments projected into `records`); **compressed timestamp** reconstruction into field 253; **subfield resolution** (ref-field match → type / scale / offset / units; multi-ref AND; first match wins); **component expansion** for all Profile **main-field** sources (generated registry) **and** components on the active subfield; nested expansion + accumulator rollover; **unknown field ids** on known messages as `UnknownField` (decoded values + `raw_bytes`); **preservation encode** (`to_bytes(preserve=True)`, default) when the file was buffer-decoded and not edited |
-| **Partial** | Unknown global messages via `GenericMessage` (readable; preservation rewrite keeps original bytes only while `wire_document` is intact); composable validation API (`validate_fit_file` / `FitFile.validate`) with WIRE + PROFILE + Activity FILE_TYPE levels — **PROFILE validation is CORE today** (developer-field subset + **ambiguous subfield** ERROR); architecture decision **O1** keeps bundled `Profile.xlsx` as the full metadata source of truth with future DOMAIN/FULL scopes (FULL opt-in, not default strict) — see [`docs/FIT_CONFORMANCE_DESIGN.md`](docs/FIT_CONFORMANCE_DESIGN.md) §3.1; Builder `strict=True` is a thin wrapper over the same checks |
-| **Not supported / incomplete** | Full PROFILE semantics (native field requirements, enums, units beyond subfield scale/units); file-type rules for non-Activity types (FILE_TYPE level fails closed); full PRESERVATION conformance level after in-memory edits (edited files re-encode from projected messages) |
+| **Supported** | Common Activity and Workout read/write via typed profile messages; `FitFileBuilder` encode path; **header CRC** (14-byte headers) and **file-level CRC** on load / stream exhaustion (`check_crc=True` default); developer fields for common declaration patterns; streaming iterators (`FitFile.iter_file` / `iter_stream`); CSV export (`to_csv` / `to_rows`); Course and similar message types when you construct them yourself; **chained multi-segment** FIT decode via `from_bytes` / `from_file` (all segments projected into `records`); **compressed timestamp** reconstruction into field 253; **subfield resolution** (ref-field match → type / scale / offset / units; multi-ref AND; first match wins); **component expansion** for all Profile main-field sources (generated registry) **and** components on the active subfield; nested expansion + accumulator rollover; **unknown field ids** on known messages as `UnknownField` (decoded values + `raw_bytes`); **preservation encode** (`to_bytes(preserve=True)`, default) for unedited files **and post-edit** (dirty records re-projected; untouched records keep `source_bytes`) |
+| **Partial** | Unknown global messages via `GenericMessage` (readable; unedited preserve keeps wire bytes; post-edit re-encodes dirty records only); composable validation API (`validate_fit_file` / `FitFile.validate`) with WIRE + PROFILE + Activity FILE_TYPE levels — **PROFILE validation is CORE today** (developer-field subset + **ambiguous subfield** ERROR); opt-in **PRESERVATION** level reports unknown-field `raw_bytes` loss after edits; architecture decision **O1** keeps bundled `Profile.xlsx` as the full metadata source of truth with future DOMAIN/FULL scopes (FULL opt-in, not default strict) — see [`docs/FIT_CONFORMANCE_DESIGN.md`](docs/FIT_CONFORMANCE_DESIGN.md) §3.1; Builder `strict=True` is a thin wrapper over the same checks (WIRE+PROFILE+FILE_TYPE only) |
+| **Not supported / incomplete** | Full PROFILE semantics (native field requirements, enums, units beyond subfield scale/units); file-type rules for non-Activity types (FILE_TYPE level fails closed); canonical encode policies (Stage 3 G); bit-identical rewrite of compressed-timestamp dirty records (re-encode may expand to normal headers) |
 
 If you need a construct listed as incomplete, prefer an official Garmin SDK or
 wait for the phased work in the design doc (including the **Remaining gaps**
@@ -221,6 +221,7 @@ Validation is a first-class API. Levels match the design doc
 | `ConformanceLevel.WIRE` | Local IDs, definition field layout/sizes, data records vs active definition | Implemented |
 | `ConformanceLevel.PROFILE` | Developer field declarations (`developer_data_id` / `field_description`) and base-type consistency; **ambiguous native subfields** (more than one Profile match) as ERROR | **CORE scope today** (+ ambiguous-subfield ERROR). Roadmap: DOMAIN then FULL rules from Profile.xlsx; FULL is opt-in, not default `strict` — design doc §3.1 (O1). Subfield *resolution* for decode/encode is separate and supported |
 | `ConformanceLevel.FILE_TYPE` | `file_id` first/unique + required fields; Activity required messages and fields | **Activity only**; other `file_id.type` values **fail closed** (intentional until more validators exist) |
+| `ConformanceLevel.PRESERVATION` | Post-edit rewrite loss (e.g. `UnknownField.raw_bytes` cleared by mutation) | **Opt-in** — not in default levels / Builder `strict=True` |
 
 Call validation on any `FitFile` or record list — after decode or before encode:
 
@@ -240,11 +241,36 @@ fit_file.validate(raise_on_error=True)
 
 # Wire-only (e.g. after decode, without file-type rules)
 validate_fit_file(fit_file, levels={ConformanceLevel.WIRE})
+
+# Opt-in post-edit rewrite-loss checks (unknown field raw_bytes, etc.)
+validate_fit_file(fit_file, levels={ConformanceLevel.PRESERVATION})
+```
+
+### Post-edit preservation
+
+After `FitFile.from_bytes` / `from_file`, field mutations mark the owning
+`Record` dirty. `to_bytes(preserve=True)` (default) re-encodes only dirty
+records and copies original wire bytes for the rest (including unknown fields
+on untouched records). Structural edits (`add_record` / `remove_record` /
+`mark_dirty()`) drop the wire snapshot and fully re-project:
+
+```python
+from fit_tool import FitFile
+from fit_tool.profile.messages.record_message import RecordMessage
+
+fit = FitFile.from_bytes(raw_bytes)
+for record in fit.records:
+    if not record.is_definition and isinstance(record.message, RecordMessage):
+        record.message.heart_rate = 140  # marks this record dirty
+        break
+
+# Untouched records keep source_bytes; edited record is re-projected.
+out = fit.to_bytes(preserve=True)
 ```
 
 `FitFileBuilder` always checks wire limits on `add` (local message numbers, definition
-sizes). `strict=True` is a thin wrapper over the same API with all levels and
-`raise_on_error=True`:
+sizes). `strict=True` is a thin wrapper over the same API with default levels
+(WIRE + PROFILE + FILE_TYPE) and `raise_on_error=True`:
 
 ```python
 from fit_tool import FitFileBuilder

--- a/docs/FIT_CONFORMANCE_DESIGN.md
+++ b/docs/FIT_CONFORMANCE_DESIGN.md
@@ -20,10 +20,10 @@ Baseline after wire-layer work (#44 / #45 and follow-ups on `main`):
 | **Component expansion** for all Profile **main-field** sources (generated registry, nested expansion, accumulators); also expands components declared on the **active subfield** | Supported (main fields + active-subfield components) | Remaining edge cases only |
 | **Subfield resolution** (ref-field match → type / scale / offset / units; first match wins; multi-ref AND) | Supported | Generated property accessors call `get_valid_sub_field` |
 | **Ambiguous subfields** (more than one match) | PROFILE ERROR (decode still uses first match) | Same policy |
-| **Preservation encode** (`to_bytes(preserve=True)`, default) for buffer-decoded, **unedited** files (`wire_document` intact) | Supported | Post-edit PRESERVATION and unknown-field rewrite (Phases 3–4) |
-| Unknown global messages (`GenericMessage`); composable validation (`validate_fit_file` / `FitFile.validate`) with WIRE + PROFILE (developer fields + ambiguous-subfield ERROR) + Activity FILE_TYPE; Builder `strict=True` wraps the same API | Partial | Full Profile field/enum/units rules; Workout/Course FILE_TYPE; PRESERVATION level |
-| Full PROFILE semantics (native required fields, enums, units beyond subfield scale/units); post-edit preservation; non-Activity FILE_TYPE rules | Not supported / incomplete | Phases 3–4 and remaining-gaps table below |
-| Unknown field ids on known messages (`UnknownField` + `raw_bytes` on decode; unedited preserve path) | Supported | Post-edit PRESERVATION rewrite (Stage 3 F) still uses projected re-encode |
+| **Preservation encode** (`to_bytes(preserve=True)`, default) for buffer-decoded files: unedited path bit-identical; **post-edit** path re-encodes dirty records and copies `source_bytes` for the rest | Supported | Canonical encode policies (Stage 3 G); compressed-header dirty rewrite may expand to normal headers |
+| Unknown global messages (`GenericMessage`); composable validation (`validate_fit_file` / `FitFile.validate`) with WIRE + PROFILE (developer fields + ambiguous-subfield ERROR) + Activity FILE_TYPE; opt-in **PRESERVATION** level; Builder `strict=True` wraps default levels only | Partial | Full Profile field/enum/units rules; Workout/Course FILE_TYPE |
+| Full PROFILE semantics (native required fields, enums, units beyond subfield scale/units); non-Activity FILE_TYPE rules | Not supported / incomplete | Phases 3–4 and remaining-gaps table below |
+| Unknown field ids on known messages (`UnknownField` + `raw_bytes` on decode; survive post-edit when not mutated) | Supported | Mutating an unknown field clears `raw_bytes` (PRESERVATION ERROR if that level is selected) |
 
 Until §11 Definition of Done is met, do not describe the library as fully
 protocol-conformant. Prefer “supports common Activity/Workout workflows” and
@@ -42,7 +42,7 @@ stable keys, later letters are stage placeholders until children are created.
 | Full component / accumulator coverage beyond `_KNOWN_COMPONENTS` | Phase 3 | **C** SHA-15 | **Done** main-field registry + nested + rollover; active-subfield components via D |
 | Subfield resolution (type / scale / units / components) | Phase 3 | **D** SHA-16 | **Done** runtime match + PROFILE ambiguity ERROR |
 | Unknown field ids on known messages (decode retain + raw bytes) | Phase 3 | **E** SHA-17 | **Done** on main path: `UnknownField` + `raw_bytes`; prerequisite for post-edit preserve |
-| Post-edit PRESERVATION (edited files, dirty records) | Phase 4 / PRESERVATION level | **F** (SHA-12 stage 3; child TBD) | Unedited preserve path already works |
+| Post-edit PRESERVATION (edited files, dirty records) | Phase 4 / PRESERVATION level | **F** SHA-18 | **Done**: per-record dirty + mixed encode; opt-in PRESERVATION findings |
 | Encode policies (canonical vs preserve, strict vs repair) | Phase 4 §6 | **G** (SHA-12 stage 3; child TBD) | |
 | Full PROFILE validation from bundled Profile.xlsx `21.205.0` | Phase 3 PROFILE | **H** (SHA-12 stage 4; child TBD) | Slice by message family / rule kind |
 | Workout FILE_TYPE rules | Phase 4 §7 | **I** (SHA-12 stage 4; child TBD) | Not in first batch |
@@ -515,15 +515,15 @@ every `add`. FILE_TYPE rules cover Activity and fail closed for other types.
 
 **Already on the wire / compatibility path** (see Current status): layered
 decode (`fit_tool/wire`), chained multi-segment load, header + file CRC,
-compressed-timestamp reconstruction into field 253, partial component
-expansion from a hand-maintained registry, and unedited preservation encode
-via `to_bytes(preserve=True)` when `wire_document` is intact.
+compressed-timestamp reconstruction into field 253, component/subfield runtime
+semantics (main-field registry + active subfield), unknown fields on known
+messages, and preservation encode via `to_bytes(preserve=True)` for unedited
+**and post-edit** files (per-record dirty tracking; mixed `source_bytes` /
+re-project).
 
 This still does **not** complete the conformance claim. Remaining work includes
-full Profile field/enum/units/**subfield** semantics, complete components and
-accumulators, unknown fields on known messages, post-edit PRESERVATION,
-canonical encode policies, and Workout/Course FILE_TYPE validators — see
-**Remaining gaps** and Phases 3–5 below.
+full Profile validation scopes (DOMAIN/FULL), canonical encode policies, and
+Workout/Course FILE_TYPE validators — see **Remaining gaps** and Phases 3–5.
 
 ## 7. File-type validators
 
@@ -706,9 +706,10 @@ subfields, and full PROFILE validation remain Multica D / H (stages 2 and 4).
 Exit: all produced standard files pass the selected Garmin and repository
 validators without repair.
 
-**Progress (partial):** unedited `preserve=True` path and Activity FILE_TYPE
-(with fail-closed other types) exist. Post-edit PRESERVATION, encode policies,
-and Workout/Course validators are Multica F–G / I–J (stages 3–4).
+**Progress (partial):** unedited and **post-edit** `preserve=True` paths exist
+(dirty records re-projected; untouched records keep `source_bytes`; opt-in
+`ConformanceLevel.PRESERVATION`). Activity FILE_TYPE (fail-closed other types)
+exists. Encode policies and Workout/Course validators remain Multica G / I–J.
 
 ### Phase 5: API migration and performance
 

--- a/fit_tool/compatibility.py
+++ b/fit_tool/compatibility.py
@@ -93,7 +93,7 @@ def project_definition_record(raw: RawDefinitionRecord) -> Record:
     """Project a wire definition record to a compatibility Record."""
     header = record_header_from_raw(raw.header)
     message = definition_from_raw(raw)
-    return Record(header, message)
+    return Record(header, message, source_bytes=raw.source_bytes, dirty=raw.dirty)
 
 
 def project_data_record(
@@ -142,7 +142,17 @@ def project_data_record(
     else:
         expand_message_components(message)
 
-    return Record(header, message)
+    # Bind mutation hooks after component expansion so decode-time
+    # set_encoded_value(..., check_validity=False) does not mark dirty, and
+    # subsequent API edits do.
+    record = Record(
+        header,
+        message,
+        source_bytes=raw.source_bytes,
+        dirty=raw.dirty,
+    )
+    record.bind_mutation_hooks()
+    return record
 
 
 def _apply_resolved_timestamp(message: DataMessage, timestamp: int) -> None:

--- a/fit_tool/data_message.py
+++ b/fit_tool/data_message.py
@@ -213,7 +213,8 @@ class DataMessage(Message):
                     sub_field = field.get_valid_sub_field(self.fields)
                     row.extend(field.to_row(sub_field=sub_field))
                 else:
-                    raise FitEncodingError(f'Field for id: {field_definition.field_id} is not valid.')
+                    # Cleared field still listed on definition — CSV gets empty cells.
+                    row.extend([''] * max(1, field_definition.size // max(field.base_type.size, 1)))
 
             for field_definition in self.definition_message.developer_field_definitions:
                 field = developer_fields_by_id.get(
@@ -228,7 +229,7 @@ class DataMessage(Message):
                     sub_field = field.get_valid_sub_field(self.fields)
                     row.extend(field.to_row(sub_field=sub_field))
                 else:
-                    raise FitEncodingError(f'Developer Field for id: {field_definition.field_id} is not valid.')
+                    row.extend([''] * max(1, field_definition.size // max(field.base_type.size, 1)))
 
         else:
             for field in self.fields:
@@ -261,7 +262,15 @@ class DataMessage(Message):
                 if field.is_valid():
                     bytes_buffer.extend(field.to_bytes(endian=self.endian))
                 else:
-                    raise FitEncodingError(f'Field for id: {field_definition.field_id} is not valid.')
+                    # Cleared fields (e.g. property set to None → Field.clear()) stay
+                    # listed on the definition until it is rewritten. Emit invalid
+                    # bytes of the definition size so encode still succeeds.
+                    bytes_buffer.extend(
+                        field.invalid_bytes_for_definition_size(
+                            field_definition.size,
+                            endian=self.endian,
+                        )
+                    )
 
             for field_definition in self.definition_message.developer_field_definitions:
                 field = developer_fields_by_id.get(
@@ -275,7 +284,12 @@ class DataMessage(Message):
                 if field.is_valid():
                     bytes_buffer.extend(field.to_bytes(endian=self.endian))
                 else:
-                    raise FitEncodingError(f'Developer Field for id: {field_definition.field_id} is not valid.')
+                    bytes_buffer.extend(
+                        field.invalid_bytes_for_definition_size(
+                            field_definition.size,
+                            endian=self.endian,
+                        )
+                    )
 
         else:
             for field in self.fields:

--- a/fit_tool/field.py
+++ b/fit_tool/field.py
@@ -255,6 +255,13 @@ class Field:
                     )
                 self.size = new_size
 
+        # API mutations (check_validity=True) notify the owning Record for
+        # post-edit PRESERVATION dirty tracking. Decode uses check_validity=False.
+        if check_validity:
+            dirty_host = getattr(self, '_dirty_host', None)
+            if dirty_host is not None:
+                dirty_host()
+
     def encode_value(self, value, sub_field: SubField = None):
         if isinstance(value, str):
             return value

--- a/fit_tool/field.py
+++ b/fit_tool/field.py
@@ -163,6 +163,12 @@ class Field:
     def clear(self):
         self.size = 0
         self.encoded_values = []
+        # Generated property setters assign None via clear() rather than
+        # set_encoded_value(); still mark the owning Record dirty so
+        # preserve=True re-encodes instead of replaying stale source_bytes.
+        dirty_host = getattr(self, '_dirty_host', None)
+        if dirty_host is not None:
+            dirty_host()
 
     def is_valid(self) -> bool:
         return self.size != 0
@@ -413,6 +419,32 @@ class Field:
         bytes_buffer = bytes_buffer.ljust(self.size, b'\0')
 
         return bytes_buffer
+
+    def invalid_bytes_for_definition_size(
+            self,
+            size: int,
+            endian: Endian = Endian.LITTLE,
+    ) -> bytes:
+        """Emit protocol-invalid payload matching *size* (cleared field on wire).
+
+        Used when the field was cleared in memory (``size == 0``) but the active
+        definition still lists the field id — keeps definition and data aligned
+        after post-edit ``None`` assignment without rewriting the definition.
+        """
+        if size <= 0:
+            return b''
+        if self.base_type == BaseType.STRING:
+            return b'\x00' * size
+        element = max(self.base_type.size, 1)
+        count = size // element
+        rem = size % element
+        chunks = [
+            self.encoded_value_to_bytes(self.base_type.invalid_raw_value(), endian=endian)
+            for _ in range(count)
+        ]
+        if rem:
+            chunks.append(b'\x00' * rem)
+        return b''.join(chunks)
 
     def resolve_sub_field(self, fields: list) -> SubFieldResolution:
         """Resolve active subfield(s) from sibling field values (Profile order).

--- a/fit_tool/fit_file.py
+++ b/fit_tool/fit_file.py
@@ -13,7 +13,7 @@ from fit_tool.fit_file_header import FitFileHeader
 from fit_tool.record import Record
 from fit_tool.utils.crc import crc16
 from fit_tool.utils.logging import logger
-from fit_tool.wire.encoder import encode_document
+from fit_tool.wire.encoder import encode_document, encode_document_mixed
 from fit_tool.wire.model import FitDocument
 
 if TYPE_CHECKING:
@@ -26,8 +26,15 @@ class FitFile:
     Decode uses the unified :class:`~fit_tool.decoder.FitDecoder` state machine
     (wire layer + projection) shared with streaming APIs. When the source is an
     in-memory buffer, the raw :class:`~fit_tool.wire.model.FitDocument` is retained
-    so :meth:`to_bytes` can re-emit the original bytes until the file is edited
+    so :meth:`to_bytes` can re-emit the original bytes for **unedited** records
     (preservation mode).
+
+    **Post-edit PRESERVATION:** mutating fields on projected messages marks the
+    owning :class:`~fit_tool.record.Record` dirty (via field mutation hooks).
+    :meth:`to_bytes` with ``preserve=True`` (default) then re-encodes only dirty
+    records and copies ``source_bytes`` for the rest. Structural edits
+    (:meth:`add_record`, :meth:`remove_record`, :meth:`mark_dirty`, CRC override)
+    drop the wire document and fully re-project on encode.
     """
 
     def __init__(
@@ -46,7 +53,13 @@ class FitFile:
 
     @property
     def wire_document(self) -> FitDocument | None:
-        """Raw multi-segment wire model when decoded from a buffer and not edited."""
+        """Raw multi-segment wire model when decoded from a buffer.
+
+        Present after buffer decode until a **structural** edit clears it
+        (:meth:`mark_dirty`, add/remove record, CRC override). Per-record field
+        edits keep this document so untouched records can be re-emitted from
+        ``source_bytes``.
+        """
         return self._wire_document
 
     @property
@@ -60,7 +73,12 @@ class FitFile:
         self._wire_document = None
 
     def mark_dirty(self) -> None:
-        """Mark the current checksum / wire snapshot as stale after an in-memory edit."""
+        """Mark the file structurally dirty (full re-encode on next ``to_bytes``).
+
+        Clears the retained wire document. Prefer editing fields in place so
+        only the affected :class:`~fit_tool.record.Record` is marked dirty and
+        post-edit PRESERVATION can keep other records' ``source_bytes``.
+        """
         self._crc = None
         self._crc_overridden = False
         self._wire_document = None
@@ -72,6 +90,10 @@ class FitFile:
     def remove_record(self, record: Record) -> None:
         self.records.remove(record)
         self.mark_dirty()
+
+    def has_dirty_records(self) -> bool:
+        """Return True when any projected record was edited in place."""
+        return any(record.dirty for record in self.records)
 
     @classmethod
     def from_file(cls, path: str, *, allow_trailing_bytes: bool = False) -> FitFile:
@@ -142,13 +164,74 @@ class FitFile:
     def to_bytes(self, check_crc: bool = True, *, preserve: bool = True) -> bytes:
         """Serialize this file.
 
-        When ``preserve`` is true and a wire document is still available (decoded
-        from a buffer and never edited), the original segment bytes are re-emitted
-        so chained files and unknown layouts round-trip bit-identically.
+        When ``preserve`` is true and a wire document is still available:
+
+        * **No dirty records** — re-emit original segment bytes bit-identically
+          (chained files, unknown layouts, compressed headers).
+        * **Some dirty records** — copy ``source_bytes`` for untouched records
+          and re-project dirty ones; recompute header size and file CRC only for
+          segments that contain edits (post-edit PRESERVATION).
+
+        Set ``preserve=False`` (or call :meth:`mark_dirty`) to force a full
+        projected re-encode of every record.
         """
         if preserve and self._wire_document is not None:
+            if self.has_dirty_records():
+                return self._to_bytes_preserve_edits()
             return encode_document(self._wire_document, recompute_crc=False)
 
+        return self._to_bytes_projected(check_crc=check_crc)
+
+    def _to_bytes_preserve_edits(self) -> bytes:
+        """Mixed preserve: untouched wire bytes + re-encoded dirty records."""
+        document = self._wire_document
+        assert document is not None
+
+        wire_count = sum(len(segment.records) for segment in document.segments)
+        if wire_count != len(self.records):
+            # Structural mismatch — fall back to full projected encode.
+            logger.warning(
+                'Record count (%s) does not match wire document (%s); '
+                'falling back to full re-encode.',
+                len(self.records),
+                wire_count,
+            )
+            self.mark_dirty()
+            return self._to_bytes_projected(check_crc=True)
+
+        projected_iter = iter(self.records)
+        segment_record_bytes: list[list[bytes]] = []
+        segment_recompute: list[bool] = []
+
+        try:
+            for segment in document.segments:
+                rec_bytes: list[bytes] = []
+                dirty_in_segment = False
+                for raw in segment.records:
+                    projected = next(projected_iter)
+                    if projected.dirty:
+                        dirty_in_segment = True
+                        rec_bytes.append(projected.to_bytes())
+                    elif projected.source_bytes is not None:
+                        rec_bytes.append(projected.source_bytes)
+                    elif raw.source_bytes:
+                        rec_bytes.append(raw.source_bytes)
+                    else:
+                        rec_bytes.append(projected.to_bytes())
+                        dirty_in_segment = True
+                segment_record_bytes.append(rec_bytes)
+                segment_recompute.append(dirty_in_segment)
+        except (IndexError, struct.error, UnicodeError, ValueError) as exc:
+            raise FitEncodingError(f'Could not encode FIT records: {exc}') from exc
+
+        result = encode_document_mixed(document, segment_record_bytes, segment_recompute)
+        # Stale file CRC after mixed encode; leave override semantics to caller.
+        self._crc = None
+        self._crc_overridden = False
+        return result
+
+    def _to_bytes_projected(self, *, check_crc: bool = True) -> bytes:
+        """Full projected re-encode (no wire document, or preserve=False)."""
         try:
             record_buffers = [record.to_bytes() for record in self.records]
         except (IndexError, struct.error, UnicodeError, ValueError) as exc:
@@ -234,8 +317,10 @@ class FitFile:
         """Validate this file at selected conformance levels.
 
         Independent of :class:`~fit_tool.fit_file_builder.FitFileBuilder`.
-        Defaults to all implemented levels (WIRE, PROFILE, FILE_TYPE). Use
-        ``levels={ConformanceLevel.WIRE}`` for structure-only checks after decode.
+        Defaults to WIRE + PROFILE + FILE_TYPE. Use
+        ``levels={ConformanceLevel.WIRE}`` for structure-only checks after decode,
+        or include :attr:`~fit_tool.validation.ConformanceLevel.PRESERVATION`
+        for opt-in post-edit rewrite-loss findings.
 
         See :func:`~fit_tool.validation.validate_fit_file` for details.
         """

--- a/fit_tool/record.py
+++ b/fit_tool/record.py
@@ -101,10 +101,47 @@ class RecordHeader:
 
 
 class Record:
+    """One definition or data record in a FIT file.
 
-    def __init__(self, header: RecordHeader, message: Message):
+    When projected from the wire layer, :attr:`source_bytes` holds the original
+    on-wire bytes for that record. :attr:`dirty` is set when in-memory edits
+    invalidate those bytes so :meth:`~fit_tool.fit_file.FitFile.to_bytes` can
+    re-encode only edited records while copying untouched ``source_bytes``
+    (post-edit PRESERVATION).
+    """
+
+    def __init__(
+            self,
+            header: RecordHeader,
+            message: Message,
+            *,
+            source_bytes: bytes | None = None,
+            dirty: bool = False,
+    ):
         self.header = header
         self.message = message
+        self.source_bytes = source_bytes
+        self.dirty = dirty
+
+    def mark_dirty(self) -> None:
+        """Mark this record as edited (drop reliance on :attr:`source_bytes`)."""
+        self.dirty = True
+
+    def bind_mutation_hooks(self) -> None:
+        """Wire field setters so API mutations set :attr:`dirty`.
+
+        Decode paths use ``check_validity=False`` on field writes and do not
+        mark dirty. Authoring mutations (``check_validity=True``, the default)
+        call :meth:`mark_dirty`.
+        """
+        message = self.message
+        if not isinstance(message, DataMessage):
+            return
+        host = self.mark_dirty
+        for field in message.fields:
+            field._dirty_host = host  # noqa: SLF001 — intentional host binding
+        for field in message.developer_fields:
+            field._dirty_host = host  # noqa: SLF001
 
     @property
     def local_id(self) -> int:

--- a/fit_tool/tests/test_data_message.py
+++ b/fit_tool/tests/test_data_message.py
@@ -105,17 +105,19 @@ class TestDataMessage(unittest.TestCase):
         with self.assertRaises(ValueError):
             message.read_from_bytes(b'\x00')
 
-    def test_to_row_and_to_bytes_raise_for_invalid_regular_field(self):
+    def test_to_row_and_to_bytes_tolerate_cleared_regular_field(self):
+        """Cleared fields still listed on the definition encode as protocol-invalid."""
         definition = DefinitionMessage(field_definitions=[FieldDefinition(field_id=1, size=1, base_type=BaseType.UINT8)])
         message = DataMessage(
             name='sample',
             definition_message=definition,
             fields=[Field(field_id=1, name='sample_field', base_type=BaseType.UINT8, size=0)],
         )
-        with self.assertRaises(ValueError):
-            message.to_row()
-        with self.assertRaises(ValueError):
-            message.to_bytes()
+        row = message.to_row()
+        self.assertEqual(row[0], 'sample')
+        self.assertEqual(row[1], '')
+        out = message.to_bytes()
+        self.assertEqual(out, bytes([0xFF]))
 
     def test_to_row_and_to_bytes_raise_for_missing_developer_field(self):
         definition = DefinitionMessage(
@@ -127,7 +129,7 @@ class TestDataMessage(unittest.TestCase):
         with self.assertRaises(ValueError):
             message.to_bytes()
 
-    def test_to_row_and_to_bytes_raise_for_invalid_developer_field(self):
+    def test_to_row_and_to_bytes_tolerate_cleared_developer_field(self):
         definition = DefinitionMessage(
             developer_field_definitions=[DeveloperFieldDefinition(field_id=1, size=1, developer_data_index=0)]
         )
@@ -144,10 +146,11 @@ class TestDataMessage(unittest.TestCase):
                 )
             ],
         )
-        with self.assertRaises(ValueError):
-            message.to_row()
-        with self.assertRaises(ValueError):
-            message.to_bytes()
+        row = message.to_row()
+        self.assertEqual(row[0], 'sample')
+        self.assertEqual(row[1], '')
+        out = message.to_bytes()
+        self.assertEqual(out, bytes([0xFF]))
 
 
 class TestDataMessageCoverage(unittest.TestCase):

--- a/fit_tool/tests/test_post_edit_preservation.py
+++ b/fit_tool/tests/test_post_edit_preservation.py
@@ -1,0 +1,216 @@
+"""Post-edit PRESERVATION: dirty tracking + mixed re-encode (Stage 3 F / SHA-18)."""
+
+from __future__ import annotations
+
+import struct
+import unittest
+
+from fit_tool.field import UnknownField
+from fit_tool.fit_file import FitFile
+from fit_tool.profile.messages.record_message import RecordMessage
+from fit_tool.profile.messages.workout_step_message import WorkoutStepMessage
+from fit_tool.profile.profile_type import WorkoutStepDuration
+from fit_tool.tests.protocol_fixture_helpers import (
+    build_record_with_unknown_field,
+    build_workout_step_with_duration,
+    chain_segments,
+    wrap_records,
+)
+from fit_tool.validation import ConformanceLevel, Severity, validate_fit_file
+from fit_tool.wire.decoder import decode_bytes
+
+
+class TestPostEditPreservation(unittest.TestCase):
+    """Edit one field; unknown fields and other records survive."""
+
+    UNKNOWN_ID = 250
+    UNKNOWN_VALUE = 0xABCD
+
+    def test_field_edit_marks_record_dirty_keeps_wire_document(self):
+        raw = build_record_with_unknown_field(
+            unknown_field_id=self.UNKNOWN_ID,
+            unknown_value=self.UNKNOWN_VALUE,
+            heart_rate=120,
+        )
+        fit = FitFile.from_bytes(raw)
+        self.assertIsNotNone(fit.wire_document)
+        data = next(r for r in fit.records if not r.is_definition)
+        self.assertFalse(data.dirty)
+        self.assertIsNotNone(data.source_bytes)
+
+        assert isinstance(data.message, RecordMessage)
+        data.message.heart_rate = 99
+
+        self.assertTrue(data.dirty)
+        self.assertTrue(fit.has_dirty_records())
+        # Structural wire snapshot retained for mixed preserve.
+        self.assertIsNotNone(fit.wire_document)
+
+    def test_edit_one_field_unknown_field_bytes_survive(self):
+        raw = build_record_with_unknown_field(
+            unknown_field_id=self.UNKNOWN_ID,
+            unknown_value=self.UNKNOWN_VALUE,
+            heart_rate=120,
+        )
+        fit = FitFile.from_bytes(raw)
+        data = next(r for r in fit.records if not r.is_definition)
+        assert isinstance(data.message, RecordMessage)
+        data.message.heart_rate = 99
+
+        out = fit.to_bytes(preserve=True)
+        again = FitFile.from_bytes(out)
+        message = next(r.message for r in again.records if not r.is_definition)
+        assert isinstance(message, RecordMessage)
+        self.assertEqual(message.heart_rate, 99)
+        unknown = message.get_field(self.UNKNOWN_ID)
+        assert unknown is not None
+        self.assertIsInstance(unknown, UnknownField)
+        self.assertEqual(unknown.get_value(), self.UNKNOWN_VALUE)
+        self.assertEqual(unknown.raw_bytes, self.UNKNOWN_VALUE.to_bytes(2, 'little'))
+
+    def test_untouched_record_source_bytes_identical(self):
+        """Two data records: edit only the second; first stays bit-identical."""
+        # Build a single-segment file with two definition+data pairs by composing
+        # definition/data payloads (local ids 0 and 1).
+        from fit_tool.base_type import BaseType
+        from fit_tool.field_definition import FieldDefinition
+        from fit_tool.tests.protocol_fixture_helpers import definition_and_data
+
+        name_a = b'keep-me\x00'
+        payload_a = name_a + struct.pack('<B', 1) + struct.pack('<I', 1000)
+        name_b = b'edit-me\x00'
+        payload_b = name_b + struct.pack('<B', 1) + struct.pack('<I', 2000)
+        fields = [
+            FieldDefinition(field_id=0, size=len(name_a), base_type=BaseType.STRING),
+            FieldDefinition(field_id=1, size=1, base_type=BaseType.ENUM),
+            FieldDefinition(field_id=2, size=4, base_type=BaseType.UINT32),
+        ]
+        # Same field sizes for both (name lengths match).
+        self.assertEqual(len(name_a), len(name_b))
+        recs = definition_and_data(
+            global_id=27, field_definitions=fields, payload=payload_a, local_id=0,
+        ) + definition_and_data(
+            global_id=27, field_definitions=fields, payload=payload_b, local_id=1,
+        )
+        raw = wrap_records(recs)
+        fit = FitFile.from_bytes(raw)
+        self.assertEqual(len(fit.records), 4)  # 2 defs + 2 data
+
+        data_records = [r for r in fit.records if not r.is_definition]
+        self.assertEqual(len(data_records), 2)
+        first, second = data_records
+        first_source = first.source_bytes
+        assert first_source is not None
+
+        assert isinstance(second.message, WorkoutStepMessage)
+        second.message.workout_step_name = 'edited!'
+
+        self.assertFalse(first.dirty)
+        self.assertTrue(second.dirty)
+
+        out = fit.to_bytes(preserve=True)
+        document = decode_bytes(out)
+        segment = document.first_segment
+        assert segment is not None
+        # Wire records: def0, data0, def1, data1
+        untouched_data = segment.records[1]
+        self.assertEqual(untouched_data.source_bytes, first_source)
+
+        again = FitFile.from_bytes(out)
+        names = [
+            r.message.workout_step_name
+            for r in again.records
+            if not r.is_definition and isinstance(r.message, WorkoutStepMessage)
+        ]
+        self.assertEqual(names, ['keep-me', 'edited!'])
+
+    def test_structural_mark_dirty_still_drops_wire_document(self):
+        raw = build_record_with_unknown_field()
+        fit = FitFile.from_bytes(raw)
+        fit.mark_dirty()
+        self.assertIsNone(fit.wire_document)
+        rebuilt = fit.to_bytes()
+        FitFile.from_bytes(rebuilt)  # CRC-valid
+
+    def test_chained_edit_one_segment_record(self):
+        # Names length-matched so fixed definition size accepts the edit.
+        one = build_workout_step_with_duration(
+            duration_type=WorkoutStepDuration.DISTANCE.value,
+            duration_value_raw=5000,
+            name='seg-a',
+        )
+        two = build_workout_step_with_duration(
+            duration_type=WorkoutStepDuration.DISTANCE.value,
+            duration_value_raw=6000,
+            name='seg-b',
+        )
+        chained = chain_segments(one, two)
+        fit = FitFile.from_bytes(chained)
+        self.assertEqual(len(fit.wire_document.segments), 2)
+
+        # Edit data message in first segment only (records: d0, data0 | d0, data0).
+        first_data = fit.records[1]
+        assert isinstance(first_data.message, WorkoutStepMessage)
+        # Same byte length as 'seg-a\0' (6) so the definition size still fits.
+        first_data.message.workout_step_name = 'edit!'
+
+        out = fit.to_bytes(preserve=True)
+        document = decode_bytes(out)
+        self.assertEqual(len(document.segments), 2)
+        # Second segment fully untouched → bit-identical to original second segment.
+        self.assertEqual(
+            document.segments[1].header.source_bytes + b''.join(
+                r.source_bytes for r in document.segments[1].records
+            ) + struct.pack('<H', document.segments[1].stored_crc),
+            two,
+        )
+
+        again = FitFile.from_bytes(out)
+        names = [
+            r.message.workout_step_name
+            for r in again.records
+            if not r.is_definition and isinstance(r.message, WorkoutStepMessage)
+        ]
+        self.assertEqual(names, ['edit!', 'seg-b'])
+
+
+class TestPreservationConformanceLevel(unittest.TestCase):
+    def test_preservation_level_not_in_defaults(self):
+        raw = build_record_with_unknown_field()
+        fit = FitFile.from_bytes(raw)
+        report = validate_fit_file(fit)
+        self.assertFalse(
+            any(f.level is ConformanceLevel.PRESERVATION for f in report.findings)
+        )
+
+    def test_unknown_field_intact_has_no_preservation_error(self):
+        raw = build_record_with_unknown_field()
+        fit = FitFile.from_bytes(raw)
+        data = next(r for r in fit.records if not r.is_definition)
+        assert isinstance(data.message, RecordMessage)
+        data.message.heart_rate = 88
+        report = validate_fit_file(fit, levels={ConformanceLevel.PRESERVATION})
+        self.assertFalse(report.has_errors)
+
+    def test_cleared_raw_bytes_reports_preservation_error(self):
+        raw = build_record_with_unknown_field(
+            unknown_field_id=250,
+            unknown_value=0xABCD,
+        )
+        fit = FitFile.from_bytes(raw)
+        data = next(r for r in fit.records if not r.is_definition)
+        unknown = data.message.get_field(250)
+        assert isinstance(unknown, UnknownField)
+        # Mutating the unknown field clears raw_bytes (API path).
+        unknown.set_value(0, 0x1111)
+        self.assertIsNone(unknown.raw_bytes)
+
+        report = validate_fit_file(fit, levels={ConformanceLevel.PRESERVATION})
+        self.assertTrue(report.has_errors)
+        self.assertEqual(report.errors[0].level, ConformanceLevel.PRESERVATION)
+        self.assertEqual(report.errors[0].severity, Severity.ERROR)
+        self.assertIn('raw_bytes', report.errors[0].message)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/fit_tool/tests/test_post_edit_preservation.py
+++ b/fit_tool/tests/test_post_edit_preservation.py
@@ -46,6 +46,35 @@ class TestPostEditPreservation(unittest.TestCase):
         # Structural wire snapshot retained for mixed preserve.
         self.assertIsNotNone(fit.wire_document)
 
+    def test_clearing_field_via_none_marks_dirty_and_removes_value(self):
+        """Codex P1: generated setters use Field.clear() for None assignments."""
+        raw = build_record_with_unknown_field(
+            unknown_field_id=self.UNKNOWN_ID,
+            unknown_value=self.UNKNOWN_VALUE,
+            heart_rate=120,
+        )
+        fit = FitFile.from_bytes(raw)
+        data = next(r for r in fit.records if not r.is_definition)
+        assert isinstance(data.message, RecordMessage)
+        self.assertEqual(data.message.heart_rate, 120)
+
+        data.message.heart_rate = None  # type: ignore[assignment]
+
+        self.assertTrue(data.dirty)
+        self.assertTrue(fit.has_dirty_records())
+        self.assertIsNone(data.message.heart_rate)
+
+        out = fit.to_bytes(preserve=True)
+        again = FitFile.from_bytes(out)
+        message = next(r.message for r in again.records if not r.is_definition)
+        assert isinstance(message, RecordMessage)
+        # Cleared field must not reappear with the old wire value (120).
+        # Slot is re-emitted as protocol-invalid so the definition still matches.
+        self.assertNotEqual(message.heart_rate, 120)
+        unknown = message.get_field(self.UNKNOWN_ID)
+        assert unknown is not None
+        self.assertEqual(unknown.get_value(), self.UNKNOWN_VALUE)
+
     def test_edit_one_field_unknown_field_bytes_survive(self):
         raw = build_record_with_unknown_field(
             unknown_field_id=self.UNKNOWN_ID,

--- a/fit_tool/validation.py
+++ b/fit_tool/validation.py
@@ -1,4 +1,4 @@
-"""Composable FIT validation: wire, profile, and file-type levels.
+"""Composable FIT validation: wire, profile, file-type, and preservation levels.
 
 Validation is a first-class API independent of :class:`~fit_tool.fit_file_builder.FitFileBuilder`.
 Builder ``strict=True`` is a thin wrapper that runs the same checks and raises on errors.
@@ -11,10 +11,12 @@ Levels (aligned with ``docs/FIT_CONFORMANCE_DESIGN.md``):
   This is **not** full Garmin Profile validation (enums, units, required
   native fields per message, and broader subfield rule families remain deferred).
 * **FILE_TYPE** — ``file_id`` rules and Activity required messages/fields
+* **PRESERVATION** — opt-in checks for post-edit rewrite loss (e.g. unknown
+  field ``raw_bytes`` cleared). Not part of default / strict levels.
 
 File-type rules are implemented only for **Activity**. Other ``file_id.type``
 values fail closed at the FILE_TYPE level (intentional until more validators
-exist). PRESERVATION level is not implemented yet.
+exist).
 """
 
 from __future__ import annotations
@@ -29,6 +31,7 @@ from fit_tool.base_type import BaseType
 from fit_tool.data_message import DataMessage
 from fit_tool.definition_message import DefinitionMessage
 from fit_tool.exceptions import FitValidationError
+from fit_tool.field import UnknownField
 from fit_tool.message import Message
 from fit_tool.profile.profile_type import FileType, MesgNum
 from fit_tool.record import Record
@@ -52,6 +55,7 @@ class ConformanceLevel(Enum):
     WIRE = 'wire'
     PROFILE = 'profile'
     FILE_TYPE = 'file_type'
+    PRESERVATION = 'preservation'
 
 
 class Severity(Enum):
@@ -62,7 +66,7 @@ class Severity(Enum):
     INFO = 'info'
 
 
-# Levels available in this release (PRESERVATION deferred).
+# Default / Builder-strict levels. PRESERVATION is opt-in (post-edit loss checks).
 DEFAULT_LEVELS = frozenset({
     ConformanceLevel.WIRE,
     ConformanceLevel.PROFILE,
@@ -123,13 +127,17 @@ def _enum_value(value: Any) -> Any:
     return value.value if hasattr(value, 'value') else value
 
 
+# All levels recognized by :func:`validate_fit_file` (includes opt-in PRESERVATION).
+KNOWN_LEVELS = frozenset(ConformanceLevel)
+
+
 def _normalize_levels(levels: Iterable[ConformanceLevel] | None) -> frozenset:
     if levels is None:
         return DEFAULT_LEVELS
     normalized = frozenset(levels)
     if not normalized:
         raise FitValidationError('levels must contain at least one ConformanceLevel')
-    unknown = normalized - DEFAULT_LEVELS
+    unknown = normalized - KNOWN_LEVELS
     if unknown:
         names = ', '.join(sorted(level.value for level in unknown))
         raise FitValidationError(f'Unsupported conformance level(s): {names}')
@@ -529,6 +537,54 @@ def _collect_activity_field_findings(
             )
 
 
+def _collect_preservation_findings(
+    records: Sequence[Record],
+    findings: list[ValidationFinding],
+) -> None:
+    """Report post-edit rewrite risks (opt-in PRESERVATION level).
+
+    Findings fire when an unknown native field lost its captured wire slice
+    (``raw_bytes is None``) so a projected re-encode cannot guarantee the same
+    bytes. Untouched records that still have ``source_bytes`` are fine.
+    """
+    for record_index, record in enumerate(records):
+        if record.is_definition or not isinstance(record.message, DataMessage):
+            continue
+        message = record.message
+        for field in message.fields:
+            if not isinstance(field, UnknownField):
+                continue
+            if not field.is_valid():
+                continue
+            if field.raw_bytes is None:
+                findings.append(
+                    ValidationFinding(
+                        level=ConformanceLevel.PRESERVATION,
+                        severity=Severity.ERROR,
+                        message=(
+                            f'Unknown field id {field.field_id} on message '
+                            f'{message.name!r} (global {message.global_id}) lost '
+                            f'raw_bytes; post-edit rewrite cannot preserve the '
+                            f'original wire slice.'
+                        ),
+                        record_index=record_index,
+                    )
+                )
+            elif len(field.raw_bytes) != field.size:
+                findings.append(
+                    ValidationFinding(
+                        level=ConformanceLevel.PRESERVATION,
+                        severity=Severity.ERROR,
+                        message=(
+                            f'Unknown field id {field.field_id} on message '
+                            f'{message.name!r} has raw_bytes length '
+                            f'{len(field.raw_bytes)} != field size {field.size}.'
+                        ),
+                        record_index=record_index,
+                    )
+                )
+
+
 def validate_fit_file(
     source: FitFile | Sequence[Record],
     levels: Iterable[ConformanceLevel] | None = None,
@@ -542,9 +598,9 @@ def validate_fit_file(
     source:
         A :class:`FitFile` or a sequence of :class:`~fit_tool.record.Record`.
     levels:
-        Conformance levels to run. Defaults to all implemented levels
-        (WIRE, PROFILE, FILE_TYPE). Pass a subset for partial checks
-        (for example wire-only after decode).
+        Conformance levels to run. Defaults to WIRE + PROFILE + FILE_TYPE.
+        Pass ``{ConformanceLevel.PRESERVATION}`` (or include it) for opt-in
+        post-edit loss checks. PRESERVATION is **not** in the default set.
     raise_on_error:
         If true, raise :class:`FitValidationError` when any ERROR findings exist
         (first error message is used, matching historical Builder strict behavior).
@@ -571,6 +627,8 @@ def validate_fit_file(
         _collect_profile_findings(data_messages, findings, data_message_indices)
     if ConformanceLevel.FILE_TYPE in selected:
         _collect_file_type_findings(data_messages, findings, data_message_indices)
+    if ConformanceLevel.PRESERVATION in selected:
+        _collect_preservation_findings(records, findings)
 
     report = ValidationReport(findings)
     if raise_on_error:

--- a/fit_tool/wire/__init__.py
+++ b/fit_tool/wire/__init__.py
@@ -6,7 +6,13 @@ package must not import generated message classes.
 
 from fit_tool.wire.crc import crc16
 from fit_tool.wire.decoder import ByteSourceInput, WireDecoder, decode_bytes
-from fit_tool.wire.encoder import encode_document, encode_segment
+from fit_tool.wire.encoder import (
+    encode_document,
+    encode_document_mixed,
+    encode_segment,
+    encode_segment_mixed,
+    rewrite_header_source_bytes,
+)
 from fit_tool.wire.model import (
     FitDocument,
     FitSegment,
@@ -36,5 +42,8 @@ __all__ = [
     'crc16',
     'decode_bytes',
     'encode_document',
+    'encode_document_mixed',
     'encode_segment',
+    'encode_segment_mixed',
+    'rewrite_header_source_bytes',
 ]

--- a/fit_tool/wire/encoder.py
+++ b/fit_tool/wire/encoder.py
@@ -3,15 +3,20 @@
 When a :class:`~fit_tool.wire.model.FitDocument` is untouched, each segment is
 re-emitted from stored ``source_bytes`` and CRC fields so the output matches the
 input byte-for-byte (header, records, file CRC).
+
+Post-edit PRESERVATION mixes per-record ``source_bytes`` for untouched records
+with caller-supplied replacement bytes for dirty records
+(:func:`encode_segment_mixed` / :func:`encode_document_mixed`).
 """
 
 from __future__ import annotations
 
 import struct
+from collections.abc import Sequence
 
 from fit_tool.exceptions import FitEncodingError
 from fit_tool.wire.crc import crc16
-from fit_tool.wire.model import FitDocument, FitSegment
+from fit_tool.wire.model import FitDocument, FitSegment, RawFileHeader
 
 
 def encode_segment(segment: FitSegment, *, recompute_crc: bool = False) -> bytes:
@@ -43,3 +48,99 @@ def encode_document(document: FitDocument, *, recompute_crc: bool = False) -> by
         encode_segment(segment, recompute_crc=recompute_crc)
         for segment in document.segments
     )
+
+
+def rewrite_header_source_bytes(header: RawFileHeader, records_size: int) -> bytes:
+    """Rebuild header bytes with an updated ``records_size`` (and header CRC).
+
+    Keeps the original header length (12 or 14+). For headers larger than 14
+    bytes, intermediate extension bytes between the classic 12-byte prefix and
+    the trailing CRC are preserved.
+    """
+    source = header.source_bytes
+    if not source:
+        raise FitEncodingError('Cannot rewrite header without source_bytes.')
+
+    header_size = header.header_size
+    if len(source) < header_size:
+        raise FitEncodingError(
+            f'Header source_bytes length {len(source)} < declared size {header_size}.'
+        )
+
+    # Classic layout: size(1) + protocol(1) + profile(2) + records_size(4) + .FIT(4) [+ crc(2)]
+    prefix = bytearray(source[:header_size])
+    prefix[0] = header_size
+    prefix[1] = header.protocol_version & 0xFF
+    struct.pack_into('<H', prefix, 2, header.profile_version & 0xFFFF)
+    struct.pack_into('<I', prefix, 4, records_size & 0xFFFFFFFF)
+    prefix[8:12] = b'.FIT'
+
+    if header_size >= 14:
+        # Last two bytes = CRC of all preceding header bytes.
+        header_crc = crc16(bytes(prefix[: header_size - 2]))
+        struct.pack_into('<H', prefix, header_size - 2, header_crc)
+
+    return bytes(prefix)
+
+
+def encode_segment_mixed(
+        segment: FitSegment,
+        record_bytes: Sequence[bytes],
+        *,
+        recompute: bool = False,
+) -> bytes:
+    """Serialize a segment using per-record byte buffers.
+
+    *record_bytes* must align 1:1 with ``segment.records``. When *recompute* is
+    true (any record in the segment was edited), the header ``records_size`` and
+    file CRC are recalculated. Untouched segments keep the original header and
+    stored file CRC when *recompute* is false.
+    """
+    if len(record_bytes) != len(segment.records):
+        raise FitEncodingError(
+            f'Segment has {len(segment.records)} records but {len(record_bytes)} '
+            f'replacement buffers were supplied.'
+        )
+
+    records_blob = b''.join(record_bytes)
+
+    if recompute:
+        header_bytes = rewrite_header_source_bytes(segment.header, len(records_blob))
+        body = header_bytes + records_blob
+        file_crc = crc16(body)
+    else:
+        if not segment.header.source_bytes:
+            raise FitEncodingError('Cannot encode segment without header source_bytes.')
+        body = segment.header.source_bytes + records_blob
+        file_crc = segment.stored_crc
+
+    return body + struct.pack('<H', file_crc)
+
+
+def encode_document_mixed(
+        document: FitDocument,
+        segment_record_bytes: Sequence[Sequence[bytes]],
+        segment_recompute: Sequence[bool],
+) -> bytes:
+    """Serialize a document with per-segment / per-record replacement bytes."""
+    if not document.segments:
+        raise FitEncodingError('Cannot encode an empty FitDocument.')
+    if len(segment_record_bytes) != len(document.segments):
+        raise FitEncodingError(
+            f'Document has {len(document.segments)} segments but '
+            f'{len(segment_record_bytes)} segment buffers were supplied.'
+        )
+    if len(segment_recompute) != len(document.segments):
+        raise FitEncodingError(
+            f'Document has {len(document.segments)} segments but '
+            f'{len(segment_recompute)} recompute flags were supplied.'
+        )
+
+    parts = []
+    for segment, rec_bytes, recompute in zip(
+            document.segments,
+            segment_record_bytes,
+            segment_recompute,
+    ):
+        parts.append(encode_segment_mixed(segment, rec_bytes, recompute=recompute))
+    return b''.join(parts)

--- a/news/SHA-18.feature
+++ b/news/SHA-18.feature
@@ -1,0 +1,6 @@
+Post-edit **PRESERVATION**: per-record dirty tracking (field mutations mark
+`Record.dirty`) so `to_bytes(preserve=True)` re-encodes only edited records and
+copies `source_bytes` for the rest (unknown fields and other records survive).
+Opt-in `ConformanceLevel.PRESERVATION` reports loss when unknown-field
+`raw_bytes` were cleared. Structural `mark_dirty()` / add / remove still force
+a full projected re-encode.


### PR DESCRIPTION
## Summary

Implements Stage 3 **F** (post-edit PRESERVATION) from the protocol epic.

- **Dirty tracking**: field API mutations mark the owning `Record.dirty` (via `_dirty_host`); `source_bytes` retained from wire projection
- **Mixed encode**: `to_bytes(preserve=True)` copies untouched `source_bytes` and re-projects dirty records; segment header size + file CRC recomputed only for dirty segments
- **Structural edits** (`mark_dirty` / add / remove / CRC override) still drop `wire_document` for full re-encode
- **Opt-in** `ConformanceLevel.PRESERVATION` findings when unknown-field `raw_bytes` would be lost
- README capability matrix, design-doc status, Towncrier `news/SHA-18.feature`

## Acceptance

- [x] Documented API semantics for preserve after edit (FitFile docstring + README)
- [x] Golden round-trip tests (`test_post_edit_preservation.py`)
- [x] README capability matrix update
- [x] Towncrier

## Test plan

- [x] `uv run ruff check fit_tool`
- [x] `uv run pytest` (388 passed, 1 skipped)

Closes Multica SHA-18 / Stage 3 F.