### PR TITLE
SHA-19: encode policies PRESERVE vs CANONICAL

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ package already implements. Profile version in use: `21.205.0` (see
 
 | Status | Capabilities |
 | --- | --- |
-| **Supported** | Common Activity and Workout read/write via typed profile messages; `FitFileBuilder` encode path; **header CRC** (14-byte headers) and **file-level CRC** on load / stream exhaustion (`check_crc=True` default); developer fields for common declaration patterns; streaming iterators (`FitFile.iter_file` / `iter_stream`); CSV export (`to_csv` / `to_rows`); Course and similar message types when you construct them yourself; **chained multi-segment** FIT decode via `from_bytes` / `from_file` (all segments projected into `records`); **compressed timestamp** reconstruction into field 253; **subfield resolution** (ref-field match → type / scale / offset / units; multi-ref AND; first match wins); **component expansion** for all Profile main-field sources (generated registry) **and** components on the active subfield; nested expansion + accumulator rollover; **unknown field ids** on known messages as `UnknownField` (decoded values + `raw_bytes`); **preservation encode** (`to_bytes(preserve=True)`, default) for unedited files **and post-edit** (dirty records re-projected; untouched records keep `source_bytes`) |
+| **Supported** | Common Activity and Workout read/write via typed profile messages; `FitFileBuilder` encode path; **header CRC** (14-byte headers) and **file-level CRC** on load / stream exhaustion (`check_crc=True` default); developer fields for common declaration patterns; streaming iterators (`FitFile.iter_file` / `iter_stream`); CSV export (`to_csv` / `to_rows`); Course and similar message types when you construct them yourself; **chained multi-segment** FIT decode via `from_bytes` / `from_file` (all segments projected into `records`); **compressed timestamp** reconstruction into field 253; **subfield resolution** (ref-field match → type / scale / offset / units; multi-ref AND; first match wins); **component expansion** for all Profile main-field sources (generated registry) **and** components on the active subfield; nested expansion + accumulator rollover; **unknown field ids** on known messages as `UnknownField` (decoded values + `raw_bytes`); **encode modes** `EncodeMode.PRESERVE` (default; unedited bit-identical + post-edit dirty re-project) and `EncodeMode.CANONICAL` (full re-project, normalized sizes/CRCs; optional `strict=True` precheck) — see [Encode policies](#encode-policies) |
 | **Partial** | Unknown global messages via `GenericMessage` (readable; unedited preserve keeps wire bytes; post-edit re-encodes dirty records only); composable validation API (`validate_fit_file` / `FitFile.validate`) with WIRE + PROFILE + Activity FILE_TYPE levels — **PROFILE validation is CORE today** (developer-field subset + **ambiguous subfield** ERROR); opt-in **PRESERVATION** level reports unknown-field `raw_bytes` loss after edits; architecture decision **O1** keeps bundled `Profile.xlsx` as the full metadata source of truth with future DOMAIN/FULL scopes (FULL opt-in, not default strict) — see [`docs/FIT_CONFORMANCE_DESIGN.md`](docs/FIT_CONFORMANCE_DESIGN.md) §3.1; Builder `strict=True` is a thin wrapper over the same checks (WIRE+PROFILE+FILE_TYPE only) |
-| **Not supported / incomplete** | Full PROFILE semantics (native field requirements, enums, units beyond subfield scale/units); file-type rules for non-Activity types (FILE_TYPE level fails closed); canonical encode policies (Stage 3 G); bit-identical rewrite of compressed-timestamp dirty records (re-encode may expand to normal headers) |
+| **Not supported / incomplete** | Full PROFILE semantics (native field requirements, enums, units beyond subfield scale/units); file-type rules for non-Activity types (FILE_TYPE level fails closed); intentional `repair()` API (strict path never silent-repairs); bit-identical rewrite of compressed-timestamp dirty records when field 253 is not on the definition (strict raises; non-strict keeps compressed header) |
 
 If you need a construct listed as incomplete, prefer an official Garmin SDK or
 wait for the phased work in the design doc (including the **Remaining gaps**
@@ -139,6 +139,7 @@ from fit_tool import (
 | --- | --- |
 | `FitFile` | Load, inspect, stream, serialize, and validate FIT files |
 | `FitFileBuilder` | Build FIT files from messages |
+| `EncodeMode`, `EncodeOptions` | Explicit encode policies (PRESERVE vs CANONICAL) for `to_bytes` |
 | `validate_fit_file`, `ConformanceLevel`, `ValidationReport` | Composable validation (independent of Builder) |
 | `FitError` and subclasses | Typed errors for parse, CRC, encode, and validation failures |
 | `PROTOCOL_VERSION`, `SDK_VERSION`, `FIT_DATA_TYPE` | Bundled protocol/profile version metadata |
@@ -246,16 +247,50 @@ validate_fit_file(fit_file, levels={ConformanceLevel.WIRE})
 validate_fit_file(fit_file, levels={ConformanceLevel.PRESERVATION})
 ```
 
+### Encode policies
+
+`FitFile.to_bytes` supports two explicit modes (`EncodeMode`), with the legacy
+`preserve=` boolean as an alias. Defaults: **PRESERVE**, non-strict.
+
+```python
+from fit_tool import EncodeMode, FitFile
+
+fit = FitFile.from_bytes(raw_bytes)
+fit.to_bytes()                                   # PRESERVE (default)
+fit.to_bytes(mode=EncodeMode.PRESERVE)           # same
+fit.to_bytes(mode=EncodeMode.CANONICAL)          # full re-project
+fit.to_bytes(mode=EncodeMode.CANONICAL, strict=True)  # validate first
+fit.to_bytes(preserve=False)                     # alias → CANONICAL
+```
+
+| Concern | PRESERVE (default) | CANONICAL | + `strict=True` |
+| --- | --- | --- | --- |
+| Untouched records | copy `source_bytes` | re-project all | re-project all |
+| Dirty records | re-project | re-project | re-project |
+| Out-of-range values | reject at set (no clamp) | same | same + pre-encode validation |
+| Cleared field still on definition | protocol-invalid fill | same | same |
+| Scale / offset | `round((v+offset)*scale)` | same | same |
+| Expanded components | only definition fields on wire | same | same |
+| Compressed timestamp headers | keep if untouched; dirty may expand when field 253 is on the definition | expand when 253 on def; else keep compressed | expand when 253 on def; else **raise** |
+| CRC / sizes | recompute dirty segments only | recompute all | recompute; bad override raises |
+
+`strict=True` forces CANONICAL and runs WIRE + PROFILE + FILE_TYPE before encode.
+It never clamps invalid values or silently “fixes” bad caller data. Prefer
+`validate_fit_file` when you need a report without encoding.
+
+Full matrix and design notes:
+[`docs/FIT_CONFORMANCE_DESIGN.md`](docs/FIT_CONFORMANCE_DESIGN.md) §6.
+
 ### Post-edit preservation
 
 After `FitFile.from_bytes` / `from_file`, field mutations mark the owning
-`Record` dirty. `to_bytes(preserve=True)` (default) re-encodes only dirty
-records and copies original wire bytes for the rest (including unknown fields
-on untouched records). Structural edits (`add_record` / `remove_record` /
-`mark_dirty()`) drop the wire snapshot and fully re-project:
+`Record` dirty. PRESERVE mode re-encodes only dirty records and copies original
+wire bytes for the rest (including unknown fields on untouched records).
+Structural edits (`add_record` / `remove_record` / `mark_dirty()`) drop the wire
+snapshot and fully re-project:
 
 ```python
-from fit_tool import FitFile
+from fit_tool import EncodeMode, FitFile
 from fit_tool.profile.messages.record_message import RecordMessage
 
 fit = FitFile.from_bytes(raw_bytes)
@@ -265,7 +300,7 @@ for record in fit.records:
         break
 
 # Untouched records keep source_bytes; edited record is re-projected.
-out = fit.to_bytes(preserve=True)
+out = fit.to_bytes(mode=EncodeMode.PRESERVE)
 ```
 
 `FitFileBuilder` always checks wire limits on `add` (local message numbers, definition

--- a/docs/FIT_CONFORMANCE_DESIGN.md
+++ b/docs/FIT_CONFORMANCE_DESIGN.md
@@ -20,7 +20,8 @@ Baseline after wire-layer work (#44 / #45 and follow-ups on `main`):
 | **Component expansion** for all Profile **main-field** sources (generated registry, nested expansion, accumulators); also expands components declared on the **active subfield** | Supported (main fields + active-subfield components) | Remaining edge cases only |
 | **Subfield resolution** (ref-field match → type / scale / offset / units; first match wins; multi-ref AND) | Supported | Generated property accessors call `get_valid_sub_field` |
 | **Ambiguous subfields** (more than one match) | PROFILE ERROR (decode still uses first match) | Same policy |
-| **Preservation encode** (`to_bytes(preserve=True)`, default) for buffer-decoded files: unedited path bit-identical; **post-edit** path re-encodes dirty records and copies `source_bytes` for the rest | Supported | Canonical encode policies (Stage 3 G); compressed-header dirty rewrite may expand to normal headers |
+| **Preservation encode** (`to_bytes(mode=EncodeMode.PRESERVE)` / `preserve=True`, default) for buffer-decoded files: unedited path bit-identical; **post-edit** path re-encodes dirty records and copies `source_bytes` for the rest | Supported | Aligns with design §6.1 |
+| **Canonical encode** (`to_bytes(mode=EncodeMode.CANONICAL)` / `preserve=False`); optional `strict=True` precheck | Supported | Compressed-header expansion only when field 253 is on the definition; otherwise keep compressed (non-strict) or raise (strict) |
 | Unknown global messages (`GenericMessage`); composable validation (`validate_fit_file` / `FitFile.validate`) with WIRE + PROFILE (developer fields + ambiguous-subfield ERROR) + Activity FILE_TYPE; opt-in **PRESERVATION** level; Builder `strict=True` wraps default levels only | Partial | Full Profile field/enum/units rules; Workout/Course FILE_TYPE |
 | Full PROFILE semantics (native required fields, enums, units beyond subfield scale/units); non-Activity FILE_TYPE rules | Not supported / incomplete | Phases 3–4 and remaining-gaps table below |
 | Unknown field ids on known messages (`UnknownField` + `raw_bytes` on decode; survive post-edit when not mutated) | Supported | Mutating an unknown field clears `raw_bytes` (PRESERVATION ERROR if that level is selected) |
@@ -43,7 +44,7 @@ stable keys, later letters are stage placeholders until children are created.
 | Subfield resolution (type / scale / units / components) | Phase 3 | **D** SHA-16 | **Done** runtime match + PROFILE ambiguity ERROR |
 | Unknown field ids on known messages (decode retain + raw bytes) | Phase 3 | **E** SHA-17 | **Done** on main path: `UnknownField` + `raw_bytes`; prerequisite for post-edit preserve |
 | Post-edit PRESERVATION (edited files, dirty records) | Phase 4 / PRESERVATION level | **F** SHA-18 | **Done**: per-record dirty + mixed encode; opt-in PRESERVATION findings |
-| Encode policies (canonical vs preserve, strict vs repair) | Phase 4 §6 | **G** (SHA-12 stage 3; child TBD) | |
+| Encode policies (canonical vs preserve, strict vs repair) | Phase 4 §6 | **G** SHA-19 | **Done**: `EncodeMode` + policy matrix; no silent invalid clamp; `repair()` API still future |
 | Full PROFILE validation from bundled Profile.xlsx `21.205.0` | Phase 3 PROFILE | **H** (SHA-12 stage 4; child TBD) | Slice by message family / rule kind |
 | Workout FILE_TYPE rules | Phase 4 §7 | **I** (SHA-12 stage 4; child TBD) | Not in first batch |
 | Course FILE_TYPE rules | Phase 4 §7 | **J** (SHA-12 stage 4; child TBD) | Not in first batch |
@@ -465,39 +466,66 @@ discarded.
 
 ## 6. Encoder design
 
-The encoder has two explicit modes.
+The encoder has two explicit modes, exported as
+`fit_tool.EncodeMode` / `EncodeOptions` and accepted by
+`FitFile.to_bytes(mode=..., strict=...)`. The boolean `preserve=` kwarg remains
+as a compatibility alias (`True` → PRESERVE, `False` → CANONICAL).
 
 ### 6.1 Preservation mode
 
 ```python
-document.to_bytes(mode=EncodeMode.PRESERVE)
+from fit_tool import EncodeMode, FitFile
+
+fit.to_bytes(mode=EncodeMode.PRESERVE)  # default
+fit.to_bytes(preserve=True)             # alias
 ```
 
 - Untouched raw records are copied byte-for-byte.
-- Dirty records are rebuilt from their definition snapshot.
-- Unknown messages, fields, header extensions, and compressed headers survive.
+- Dirty records are rebuilt from their definition snapshot (encode policies apply).
+- Unknown messages, fields, header extensions, and compressed headers survive
+  when untouched.
 - Segment boundaries are retained.
 - CRCs and sizes are recalculated only for dirty segments.
 
 ### 6.2 Canonical mode
 
 ```python
-document.to_bytes(mode=EncodeMode.CANONICAL, strict=True)
+fit.to_bytes(mode=EncodeMode.CANONICAL)
+fit.to_bytes(mode=EncodeMode.CANONICAL, strict=True)
+fit.to_bytes(preserve=False)  # alias for non-strict canonical
 ```
 
-- Rebuild all definitions and data records.
-- Use normal headers by default; compressed timestamps are an explicit option.
-- Generate consistent header and file CRCs.
-- Emit the bundled Profile version.
-- Reject invalid values, sizes, local IDs, missing definitions, and unresolved
-  developer fields.
-- Run the selected conformance levels before returning bytes.
+- Rebuild all definitions and data records from the projected model.
+- Prefer normal record headers; expand compressed-timestamp headers when field
+  253 is present on the definition (otherwise keep compressed, or raise if
+  `strict=True`).
+- Generate consistent header and file CRCs (sizes always rewritten).
+- Reject out-of-range encoded values at set time (no clamp). Cleared fields
+  emit protocol-invalid fill so the definition stays aligned.
+- `strict=True` runs default conformance levels (WIRE + PROFILE + FILE_TYPE)
+  before returning bytes and forces CANONICAL.
 
-`strict=True` never silently repairs caller-supplied invariants. A separate
+`strict=True` never silently repairs caller-supplied invariants (no range
+clamping; mismatched overridden CRC raises when `check_crc=True`). A separate
 `repair()` API may intentionally fix sizes or CRCs and must return a report of
-every repair.
+every repair — **not implemented yet**.
 
-### 6.1 Compatibility-layer implementation status
+### 6.3 Encode policy matrix (implemented)
+
+| Concern | PRESERVE (default) | CANONICAL | CANONICAL + `strict=True` |
+| --- | --- | --- | --- |
+| Untouched records | `source_bytes` copy | full re-project | full re-project |
+| Dirty records | re-project | re-project | re-project |
+| Out-of-range field values | rejected at set (no clamp) | same | same + pre-encode validation |
+| Cleared field (`None`) still on definition | protocol-invalid fill | same | same |
+| Scale / offset | `round((v+offset)*scale)` | same | same |
+| Expanded component destinations | off-wire unless listed on definition | same | same |
+| Compressed timestamp (untouched) | keep wire bytes | expand to normal if def has 253; else keep compressed | expand if 253; else **raise** |
+| Compressed timestamp (dirty re-encode) | expand if def has 253; else keep compressed | same | expand if 253; else **raise** |
+| Header / file CRC | recompute dirty segments only | recompute all | recompute; wrong override raises |
+| Pre-encode validation | no | no | DEFAULT levels, raise on ERROR |
+
+### 6.4 Compatibility-layer implementation status
 
 Composable validation is available independently of the Builder:
 
@@ -522,8 +550,9 @@ messages, and preservation encode via `to_bytes(preserve=True)` for unedited
 re-project).
 
 This still does **not** complete the conformance claim. Remaining work includes
-full Profile validation scopes (DOMAIN/FULL), canonical encode policies, and
-Workout/Course FILE_TYPE validators — see **Remaining gaps** and Phases 3–5.
+full Profile validation scopes (DOMAIN/FULL) and Workout/Course FILE_TYPE
+validators — see **Remaining gaps** and Phases 3–5. Encode modes (G) are on the
+compatibility path; the long-term `FitDocument` encode surface remains future.
 
 ## 7. File-type validators
 
@@ -706,10 +735,10 @@ subfields, and full PROFILE validation remain Multica D / H (stages 2 and 4).
 Exit: all produced standard files pass the selected Garmin and repository
 validators without repair.
 
-**Progress (partial):** unedited and **post-edit** `preserve=True` paths exist
-(dirty records re-projected; untouched records keep `source_bytes`; opt-in
-`ConformanceLevel.PRESERVATION`). Activity FILE_TYPE (fail-closed other types)
-exists. Encode policies and Workout/Course validators remain Multica G / I–J.
+**Progress (partial):** unedited and **post-edit** PRESERVE paths exist; explicit
+`EncodeMode` / `strict` / policy matrix landed (G / SHA-19). Activity FILE_TYPE
+(fail-closed other types) exists. Workout/Course validators remain Multica I–J.
+`repair()` API is still future.
 
 ### Phase 5: API migration and performance
 

--- a/fit_tool/__init__.py
+++ b/fit_tool/__init__.py
@@ -18,6 +18,8 @@ FIT_DATA_TYPE = b'.FIT'
 
 from fit_tool.api import (  # noqa: E402
     ConformanceLevel,
+    EncodeMode,
+    EncodeOptions,
     FitCRCError,
     FitEncodingError,
     FitError,
@@ -46,6 +48,8 @@ __all__ = [
     'FitCRCError',
     'FitEncodingError',
     'FitValidationError',
+    'EncodeMode',
+    'EncodeOptions',
     'ConformanceLevel',
     'Severity',
     'ValidationFinding',

--- a/fit_tool/api.py
+++ b/fit_tool/api.py
@@ -16,6 +16,7 @@ Import them by module path, for example::
     from fit_tool.profile.profile_type import Sport, FileType
 """
 
+from fit_tool.encode import EncodeMode, EncodeOptions
 from fit_tool.exceptions import (
     FitCRCError,
     FitEncodingError,
@@ -45,6 +46,8 @@ __all__ = [
     'FitCRCError',
     'FitEncodingError',
     'FitValidationError',
+    'EncodeMode',
+    'EncodeOptions',
     'ConformanceLevel',
     'Severity',
     'ValidationFinding',

--- a/fit_tool/encode.py
+++ b/fit_tool/encode.py
@@ -1,0 +1,160 @@
+"""Encode modes and projected-record policies (Stage 3 G / SHA-19).
+
+Two explicit modes:
+
+* :attr:`EncodeMode.PRESERVE` (default) — re-emit wire ``source_bytes`` for
+  untouched records; re-project dirty records (post-edit PRESERVATION / F).
+* :attr:`EncodeMode.CANONICAL` — full projected re-encode of every record with
+  normalized headers, sizes, and CRCs.
+
+``strict=True`` forces the canonical path, runs default conformance levels
+before returning bytes, and never silently repairs invalid caller-supplied
+field data (no range clamping; wrong overridden CRC raises when ``check_crc``).
+"""
+
+from __future__ import annotations
+
+import struct
+from dataclasses import dataclass
+from enum import Enum
+from typing import TYPE_CHECKING
+
+from fit_tool.data_message import DataMessage
+from fit_tool.definition_message import DefinitionMessage
+from fit_tool.exceptions import FitEncodingError
+from fit_tool.record import Record, RecordHeader
+
+if TYPE_CHECKING:
+    from fit_tool.fit_file import FitFile
+
+_TIMESTAMP_FIELD_ID = 253
+
+
+class EncodeMode(str, Enum):
+    """How :meth:`~fit_tool.fit_file.FitFile.to_bytes` rebuilds the FIT stream."""
+
+    PRESERVE = 'preserve'
+    CANONICAL = 'canonical'
+
+
+@dataclass(frozen=True)
+class EncodeOptions:
+    """Options for FIT serialization.
+
+    Defaults match historical ``to_bytes()`` behavior: preservation when a wire
+    document is available, non-strict (no pre-encode validation).
+    """
+
+    mode: EncodeMode = EncodeMode.PRESERVE
+    strict: bool = False
+    check_crc: bool = True
+
+    def __post_init__(self) -> None:
+        if self.strict and self.mode is EncodeMode.PRESERVE:
+            # Strict validation applies to the projected/canonical rebuild path.
+            # Callers who want preserve + validation should call validate() first.
+            object.__setattr__(self, 'mode', EncodeMode.CANONICAL)
+
+
+def resolve_encode_options(
+        *,
+        mode: EncodeMode | str | None = None,
+        preserve: bool | None = None,
+        strict: bool = False,
+        check_crc: bool = True,
+) -> EncodeOptions:
+    """Resolve legacy ``preserve=`` and new ``mode=`` into :class:`EncodeOptions`.
+
+    Precedence:
+
+    1. Explicit ``mode``
+    2. Explicit ``preserve`` (``True`` → PRESERVE, ``False`` → CANONICAL)
+    3. Default PRESERVE
+
+    ``strict=True`` forces CANONICAL (see :class:`EncodeOptions`).
+    """
+    if mode is not None:
+        resolved = EncodeMode(mode) if not isinstance(mode, EncodeMode) else mode
+    elif preserve is not None:
+        resolved = EncodeMode.PRESERVE if preserve else EncodeMode.CANONICAL
+    else:
+        resolved = EncodeMode.PRESERVE
+
+    return EncodeOptions(mode=resolved, strict=strict, check_crc=check_crc)
+
+
+def definition_includes_field(definition: DefinitionMessage | None, field_id: int) -> bool:
+    if definition is None:
+        return False
+    return any(fd.field_id == field_id for fd in definition.field_definitions)
+
+
+def expand_compressed_header(record: Record) -> RecordHeader:
+    """Return a normal data header for a compressed-timestamp data record."""
+    header = record.header
+    if not header.is_time_compressed:
+        return header
+    return RecordHeader(
+        is_time_compressed=False,
+        is_definition=False,
+        has_developer_fields=header.has_developer_fields,
+        local_id=header.local_id,
+        time_offset_seconds=0,
+    )
+
+
+def can_expand_compressed_to_normal(message: DataMessage) -> bool:
+    """True when field 253 is on the definition so a normal header can carry the ts."""
+    return definition_includes_field(message.definition_message, _TIMESTAMP_FIELD_ID)
+
+
+def encode_record_projected(
+        record: Record,
+        *,
+        options: EncodeOptions | None = None,
+) -> bytes:
+    """Serialize one projected record under encode policies.
+
+    Policies for **data** records:
+
+    * **Compressed timestamp headers** — when the active definition includes
+      field 253, expand to a normal header and write the reconstructed
+      timestamp. If 253 is absent: keep the compressed header (non-strict) or
+      raise in strict mode rather than silently drop the timestamp.
+    * **Expanded component destinations** — only fields listed on the active
+      definition are written (synthetic destinations stay off-wire unless the
+      definition already includes them).
+    * **Invalid / cleared values** — integer ``None`` encodes as the protocol
+      invalid raw value; floats use the all-ones invalid bit pattern. Out-of-range
+      values are rejected at set time, not clamped.
+    """
+    options = options or EncodeOptions()
+    header = record.header
+    message = record.message
+
+    if (
+        not header.is_definition
+        and header.is_time_compressed
+        and isinstance(message, DataMessage)
+        and (options.mode is EncodeMode.CANONICAL or record.dirty)
+    ):
+        if can_expand_compressed_to_normal(message):
+            header = expand_compressed_header(record)
+        elif options.strict:
+            raise FitEncodingError(
+                'Strict canonical encode cannot expand a compressed-timestamp '
+                'header without field 253 on the definition (timestamp would be lost).'
+            )
+        # else: keep compressed header (timestamp remains in the 5-bit offset).
+
+    try:
+        return header.to_bytes() + message.to_bytes()
+    except (IndexError, struct.error, UnicodeError, ValueError, TypeError) as exc:
+        raise FitEncodingError(f'Could not encode FIT record: {exc}') from exc
+
+
+def apply_strict_precheck(fit_file: FitFile) -> None:
+    """Run default conformance levels and raise on ERROR findings."""
+    from fit_tool.validation import DEFAULT_LEVELS, validate_fit_file
+
+    validate_fit_file(fit_file, levels=DEFAULT_LEVELS, raise_on_error=True)

--- a/fit_tool/fit_file.py
+++ b/fit_tool/fit_file.py
@@ -8,6 +8,13 @@ from collections.abc import Iterable, Iterator
 from typing import TYPE_CHECKING, BinaryIO
 
 from fit_tool.decoder import FitDecoder
+from fit_tool.encode import (
+    EncodeMode,
+    EncodeOptions,
+    apply_strict_precheck,
+    encode_record_projected,
+    resolve_encode_options,
+)
 from fit_tool.exceptions import FitCRCError, FitEncodingError
 from fit_tool.fit_file_header import FitFileHeader
 from fit_tool.record import Record
@@ -29,12 +36,21 @@ class FitFile:
     so :meth:`to_bytes` can re-emit the original bytes for **unedited** records
     (preservation mode).
 
+    **Encode modes** (Stage 3 G):
+
+    * :attr:`~fit_tool.encode.EncodeMode.PRESERVE` (default) — unedited
+      ``source_bytes`` + dirty re-project (post-edit PRESERVATION / F).
+    * :attr:`~fit_tool.encode.EncodeMode.CANONICAL` — full projected re-encode
+      with normalized sizes/CRCs; compressed dirty headers may expand to normal.
+
+    Pass ``mode=`` / ``strict=`` to :meth:`to_bytes`, or the legacy
+    ``preserve=True|False`` alias (``False`` maps to CANONICAL).
+
     **Post-edit PRESERVATION:** mutating fields on projected messages marks the
     owning :class:`~fit_tool.record.Record` dirty (via field mutation hooks).
-    :meth:`to_bytes` with ``preserve=True`` (default) then re-encodes only dirty
-    records and copies ``source_bytes`` for the rest. Structural edits
-    (:meth:`add_record`, :meth:`remove_record`, :meth:`mark_dirty`, CRC override)
-    drop the wire document and fully re-project on encode.
+    Preserve mode then re-encodes only dirty records and copies ``source_bytes``
+    for the rest. Structural edits (:meth:`add_record`, :meth:`remove_record`,
+    :meth:`mark_dirty`, CRC override) drop the wire document and fully re-project.
     """
 
     def __init__(
@@ -161,28 +177,65 @@ class FitFile:
             wire_document=decoder.wire_document,
         )
 
-    def to_bytes(self, check_crc: bool = True, *, preserve: bool = True) -> bytes:
+    def to_bytes(
+            self,
+            check_crc: bool = True,
+            *,
+            preserve: bool | None = None,
+            mode: EncodeMode | str | None = None,
+            strict: bool = False,
+            options: EncodeOptions | None = None,
+    ) -> bytes:
         """Serialize this file.
 
-        When ``preserve`` is true and a wire document is still available:
+        **Modes** (see :class:`~fit_tool.encode.EncodeMode`):
 
-        * **No dirty records** — re-emit original segment bytes bit-identically
-          (chained files, unknown layouts, compressed headers).
-        * **Some dirty records** — copy ``source_bytes`` for untouched records
-          and re-project dirty ones; recompute header size and file CRC only for
-          segments that contain edits (post-edit PRESERVATION).
+        * **PRESERVE** (default; ``preserve=True``) when a wire document is
+          available:
 
-        Set ``preserve=False`` (or call :meth:`mark_dirty`) to force a full
-        projected re-encode of every record.
+          - **No dirty records** — re-emit original segment bytes bit-identically
+            (chained files, unknown layouts, compressed headers).
+          - **Some dirty records** — copy ``source_bytes`` for untouched records
+            and re-project dirty ones; recompute header size and file CRC only for
+            segments that contain edits (post-edit PRESERVATION).
+
+        * **CANONICAL** (``mode=EncodeMode.CANONICAL`` or ``preserve=False``) —
+          full projected re-encode of every record; normalized sizes and CRCs.
+
+        ``strict=True`` forces CANONICAL, runs WIRE+PROFILE+FILE_TYPE validation
+        before encode, and raises rather than silently repairing invalid field
+        data or mismatched overridden CRCs (when ``check_crc`` is true).
+
+        Prefer ``mode=`` / ``strict=`` for new code; ``preserve=`` remains the
+        boolean compatibility alias.
         """
-        if preserve and self._wire_document is not None:
+        if options is None:
+            options = resolve_encode_options(
+                mode=mode,
+                preserve=preserve,
+                strict=strict,
+                check_crc=check_crc,
+            )
+        elif preserve is not None or mode is not None or strict or check_crc is not True:
+            # Explicit kwargs win over a partial options object when both given.
+            options = resolve_encode_options(
+                mode=mode if mode is not None else options.mode,
+                preserve=preserve,
+                strict=strict or options.strict,
+                check_crc=check_crc if check_crc is not True else options.check_crc,
+            )
+
+        if options.strict:
+            apply_strict_precheck(self)
+
+        if options.mode is EncodeMode.PRESERVE and self._wire_document is not None:
             if self.has_dirty_records():
-                return self._to_bytes_preserve_edits()
+                return self._to_bytes_preserve_edits(options=options)
             return encode_document(self._wire_document, recompute_crc=False)
 
-        return self._to_bytes_projected(check_crc=check_crc)
+        return self._to_bytes_projected(options=options)
 
-    def _to_bytes_preserve_edits(self) -> bytes:
+    def _to_bytes_preserve_edits(self, *, options: EncodeOptions) -> bytes:
         """Mixed preserve: untouched wire bytes + re-encoded dirty records."""
         document = self._wire_document
         assert document is not None
@@ -197,7 +250,13 @@ class FitFile:
                 wire_count,
             )
             self.mark_dirty()
-            return self._to_bytes_projected(check_crc=True)
+            return self._to_bytes_projected(
+                options=EncodeOptions(
+                    mode=EncodeMode.CANONICAL,
+                    strict=options.strict,
+                    check_crc=options.check_crc,
+                )
+            )
 
         projected_iter = iter(self.records)
         segment_record_bytes: list[list[bytes]] = []
@@ -211,16 +270,22 @@ class FitFile:
                     projected = next(projected_iter)
                     if projected.dirty:
                         dirty_in_segment = True
-                        rec_bytes.append(projected.to_bytes())
+                        rec_bytes.append(
+                            encode_record_projected(projected, options=options)
+                        )
                     elif projected.source_bytes is not None:
                         rec_bytes.append(projected.source_bytes)
                     elif raw.source_bytes:
                         rec_bytes.append(raw.source_bytes)
                     else:
-                        rec_bytes.append(projected.to_bytes())
+                        rec_bytes.append(
+                            encode_record_projected(projected, options=options)
+                        )
                         dirty_in_segment = True
                 segment_record_bytes.append(rec_bytes)
                 segment_recompute.append(dirty_in_segment)
+        except FitEncodingError:
+            raise
         except (IndexError, struct.error, UnicodeError, ValueError) as exc:
             raise FitEncodingError(f'Could not encode FIT records: {exc}') from exc
 
@@ -230,10 +295,15 @@ class FitFile:
         self._crc_overridden = False
         return result
 
-    def _to_bytes_projected(self, *, check_crc: bool = True) -> bytes:
-        """Full projected re-encode (no wire document, or preserve=False)."""
+    def _to_bytes_projected(self, *, options: EncodeOptions) -> bytes:
+        """Full projected re-encode (canonical path, or no wire document)."""
         try:
-            record_buffers = [record.to_bytes() for record in self.records]
+            record_buffers = [
+                encode_record_projected(record, options=options)
+                for record in self.records
+            ]
+        except FitEncodingError:
+            raise
         except (IndexError, struct.error, UnicodeError, ValueError) as exc:
             raise FitEncodingError(f'Could not encode FIT records: {exc}') from exc
 
@@ -261,7 +331,7 @@ class FitFile:
         elif self._crc != calculated_crc:
             if self._crc_overridden:
                 message = f'Calculated crc ({calculated_crc}) != defined crc ({self._crc})'
-                if check_crc:
+                if options.check_crc:
                     raise FitCRCError(message)
                 logger.warning(message)
             else:
@@ -304,9 +374,18 @@ class FitFile:
                 csv_writer.writerow(self._create_csv_header(max_columns))
                 shutil.copyfileobj(rows_file, csv_file)
 
-    def to_file(self, path: str, *, preserve: bool = True) -> None:
+    def to_file(
+            self,
+            path: str,
+            *,
+            preserve: bool | None = None,
+            mode: EncodeMode | str | None = None,
+            strict: bool = False,
+    ) -> None:
         with open(path, 'wb') as file_object:
-            file_object.write(self.to_bytes(preserve=preserve))
+            file_object.write(
+                self.to_bytes(preserve=preserve, mode=mode, strict=strict)
+            )
 
     def validate(
         self,

--- a/fit_tool/fit_file.py
+++ b/fit_tool/fit_file.py
@@ -26,6 +26,10 @@ from fit_tool.wire.model import FitDocument
 if TYPE_CHECKING:
     from fit_tool.validation import ConformanceLevel, ValidationReport
 
+# Sentinel so explicit ``check_crc=True`` can override ``options.check_crc=False``
+# (a bare default of True is indistinguishable from "caller omitted the kwarg").
+_CHECK_CRC_UNSET: object = object()
+
 
 class FitFile:
     """Public FIT file facade.
@@ -179,7 +183,7 @@ class FitFile:
 
     def to_bytes(
             self,
-            check_crc: bool = True,
+            check_crc: bool | object = _CHECK_CRC_UNSET,
             *,
             preserve: bool | None = None,
             mode: EncodeMode | str | None = None,
@@ -207,22 +211,34 @@ class FitFile:
         data or mismatched overridden CRCs (when ``check_crc`` is true).
 
         Prefer ``mode=`` / ``strict=`` for new code; ``preserve=`` remains the
-        boolean compatibility alias.
+        boolean compatibility alias. Explicit kwargs win over a partial
+        ``options=`` object (including ``check_crc=True`` vs
+        ``EncodeOptions(check_crc=False)``).
         """
+        check_crc_explicit = check_crc is not _CHECK_CRC_UNSET
+        check_crc_value = True if not check_crc_explicit else bool(check_crc)
+
         if options is None:
             options = resolve_encode_options(
                 mode=mode,
                 preserve=preserve,
                 strict=strict,
-                check_crc=check_crc,
+                check_crc=check_crc_value,
             )
-        elif preserve is not None or mode is not None or strict or check_crc is not True:
+        elif (
+            preserve is not None
+            or mode is not None
+            or strict
+            or check_crc_explicit
+        ):
             # Explicit kwargs win over a partial options object when both given.
             options = resolve_encode_options(
                 mode=mode if mode is not None else options.mode,
                 preserve=preserve,
                 strict=strict or options.strict,
-                check_crc=check_crc if check_crc is not True else options.check_crc,
+                check_crc=(
+                    check_crc_value if check_crc_explicit else options.check_crc
+                ),
             )
 
         if options.strict:

--- a/fit_tool/tests/test_encode_policies.py
+++ b/fit_tool/tests/test_encode_policies.py
@@ -137,6 +137,22 @@ class TestCanonicalModeInvariants(unittest.TestCase):
         out = fit.to_bytes(options=EncodeOptions(mode=EncodeMode.CANONICAL))
         FitFile.from_bytes(out)
 
+    def test_explicit_check_crc_true_overrides_options_false(self):
+        """Codex P2: explicit check_crc=True must win over EncodeOptions(check_crc=False)."""
+        from fit_tool.exceptions import FitCRCError
+
+        raw = build_record_with_unknown_field(heart_rate=42)
+        fit = FitFile.from_bytes(raw)
+        # Force mismatched overridden CRC on the projected path.
+        fit.crc = 0x1234
+        opts = EncodeOptions(mode=EncodeMode.CANONICAL, check_crc=False)
+        # options alone: log + emit invalid CRC (no raise).
+        out = fit.to_bytes(options=opts)
+        self.assertEqual(out[-2:], (0x1234).to_bytes(2, 'little'))
+        # Explicit kwarg True must raise despite options.check_crc=False.
+        with self.assertRaises(FitCRCError):
+            fit.to_bytes(options=opts, check_crc=True)
+
 
 class TestInvalidValuePolicy(unittest.TestCase):
     def test_out_of_range_rejected_at_set_not_clamped(self):

--- a/fit_tool/tests/test_encode_policies.py
+++ b/fit_tool/tests/test_encode_policies.py
@@ -1,0 +1,315 @@
+"""Encode policies: PRESERVE vs CANONICAL (Stage 3 G / SHA-19)."""
+
+from __future__ import annotations
+
+import struct
+import unittest
+
+from fit_tool.base_type import BaseType
+from fit_tool.encode import (
+    EncodeMode,
+    EncodeOptions,
+    can_expand_compressed_to_normal,
+    encode_record_projected,
+    resolve_encode_options,
+)
+from fit_tool.exceptions import FitEncodingError, FitValidationError
+from fit_tool.field import Field, UnknownField
+from fit_tool.field_definition import FieldDefinition
+from fit_tool.fit_file import FitFile
+from fit_tool.fit_file_builder import FitFileBuilder
+from fit_tool.profile.messages.record_message import RecordMessage
+from fit_tool.profile.messages.workout_step_message import WorkoutStepMessage
+from fit_tool.profile.profile_type import WorkoutStepDuration
+from fit_tool.record import Record, RecordHeader
+from fit_tool.tests.protocol_fixture_helpers import (
+    build_record_with_compressed_speed_distance,
+    build_record_with_unknown_field,
+    definition_and_data,
+    wrap_records,
+)
+from fit_tool.wire.decoder import decode_bytes
+
+
+class TestResolveEncodeOptions(unittest.TestCase):
+    def test_defaults_to_preserve(self):
+        opts = resolve_encode_options()
+        self.assertEqual(opts.mode, EncodeMode.PRESERVE)
+        self.assertFalse(opts.strict)
+
+    def test_preserve_false_is_canonical(self):
+        opts = resolve_encode_options(preserve=False)
+        self.assertEqual(opts.mode, EncodeMode.CANONICAL)
+
+    def test_mode_overrides_preserve(self):
+        opts = resolve_encode_options(mode=EncodeMode.CANONICAL, preserve=True)
+        self.assertEqual(opts.mode, EncodeMode.CANONICAL)
+
+    def test_strict_forces_canonical(self):
+        opts = resolve_encode_options(preserve=True, strict=True)
+        self.assertEqual(opts.mode, EncodeMode.CANONICAL)
+        self.assertTrue(opts.strict)
+
+    def test_mode_string(self):
+        opts = resolve_encode_options(mode='canonical')
+        self.assertEqual(opts.mode, EncodeMode.CANONICAL)
+
+
+class TestPreserveModeInvariants(unittest.TestCase):
+    def test_untouched_identity(self):
+        raw = build_record_with_unknown_field(heart_rate=100)
+        fit = FitFile.from_bytes(raw)
+        self.assertEqual(fit.to_bytes(mode=EncodeMode.PRESERVE), raw)
+        # Legacy alias
+        self.assertEqual(fit.to_bytes(preserve=True), raw)
+
+    def test_dirty_unknown_survives_preserve(self):
+        raw = build_record_with_unknown_field(
+            heart_rate=100, unknown_field_id=250, unknown_value=0xBEEF,
+        )
+        fit = FitFile.from_bytes(raw)
+        data = next(r for r in fit.records if not r.is_definition)
+        assert isinstance(data.message, RecordMessage)
+        data.message.heart_rate = 88
+
+        out = fit.to_bytes(mode=EncodeMode.PRESERVE)
+        again = FitFile.from_bytes(out)
+        message = next(r.message for r in again.records if not r.is_definition)
+        assert isinstance(message, RecordMessage)
+        self.assertEqual(message.heart_rate, 88)
+        unknown = message.get_field(250)
+        assert isinstance(unknown, UnknownField)
+        self.assertEqual(unknown.get_value(), 0xBEEF)
+
+
+class TestCanonicalModeInvariants(unittest.TestCase):
+    def test_canonical_full_reproject_valid(self):
+        mesg = WorkoutStepMessage(local_id=0)
+        mesg.workout_step_name = 'canon'
+        mesg.duration_type = WorkoutStepDuration.DISTANCE
+        builder = FitFileBuilder(auto_define=True)
+        builder.add(mesg)
+        original = builder.build().to_bytes()
+
+        fit = FitFile.from_bytes(original)
+        out = fit.to_bytes(mode=EncodeMode.CANONICAL)
+        # Must be valid FIT (CRC checks on load).
+        again = FitFile.from_bytes(out)
+        names = [
+            r.message.workout_step_name
+            for r in again.records
+            if not r.is_definition and isinstance(r.message, WorkoutStepMessage)
+        ]
+        self.assertIn('canon', names)
+
+    def test_preserve_false_alias(self):
+        raw = build_record_with_unknown_field(heart_rate=55)
+        fit = FitFile.from_bytes(raw)
+        a = fit.to_bytes(mode=EncodeMode.CANONICAL)
+        b = fit.to_bytes(preserve=False)
+        self.assertEqual(a, b)
+
+    def test_canonical_re_encodes_dirty_and_clean(self):
+        """Canonical does not keep source_bytes for clean records."""
+        raw = build_record_with_unknown_field(heart_rate=70)
+        fit = FitFile.from_bytes(raw)
+        # No dirty records, but CANONICAL still rebuilds.
+        out = fit.to_bytes(mode=EncodeMode.CANONICAL)
+        # May differ in layout but must round-trip heart rate.
+        again = FitFile.from_bytes(out)
+        message = next(r.message for r in again.records if not r.is_definition)
+        assert isinstance(message, RecordMessage)
+        self.assertEqual(message.heart_rate, 70)
+
+    def test_strict_true_alone_forces_canonical(self):
+        raw = build_record_with_unknown_field(heart_rate=40)
+        fit = FitFile.from_bytes(raw)
+        # strict=True without mode → canonical path; FILE_TYPE fails without file_id.
+        with self.assertRaises(FitValidationError):
+            fit.to_bytes(strict=True)
+        # Non-strict canonical still works (no precheck).
+        out = fit.to_bytes(mode=EncodeMode.CANONICAL, strict=False)
+        FitFile.from_bytes(out)
+
+    def test_options_object_canonical(self):
+        raw = build_record_with_unknown_field(heart_rate=41)
+        fit = FitFile.from_bytes(raw)
+        out = fit.to_bytes(options=EncodeOptions(mode=EncodeMode.CANONICAL))
+        FitFile.from_bytes(out)
+
+
+class TestInvalidValuePolicy(unittest.TestCase):
+    def test_out_of_range_rejected_at_set_not_clamped(self):
+        field = Field(
+            field_id=3, name='heart_rate', base_type=BaseType.UINT8, size=1, growable=False,
+        )
+        with self.assertRaises(FitEncodingError):
+            field.set_encoded_value(0, 300)  # > UINT8 max
+
+    def test_none_encodes_as_protocol_invalid(self):
+        field = Field(
+            field_id=3, name='heart_rate', base_type=BaseType.UINT8, size=1, growable=False,
+        )
+        field.set_value(0, None)
+        self.assertEqual(field.encoded_values[0], BaseType.UINT8.invalid_raw_value())
+        packed = field.to_bytes()
+        self.assertEqual(packed, bytes([0xFF]))
+
+    def test_cleared_field_on_definition_emits_invalid_fill(self):
+        raw = build_record_with_unknown_field(heart_rate=120)
+        fit = FitFile.from_bytes(raw)
+        data = next(r for r in fit.records if not r.is_definition)
+        assert isinstance(data.message, RecordMessage)
+        data.message.heart_rate = None  # type: ignore[assignment]
+
+        out = fit.to_bytes(mode=EncodeMode.PRESERVE)
+        again = FitFile.from_bytes(out)
+        message = next(r.message for r in again.records if not r.is_definition)
+        assert isinstance(message, RecordMessage)
+        self.assertNotEqual(message.heart_rate, 120)
+
+
+class TestExpandedComponentsOnEncode(unittest.TestCase):
+    def test_expanded_destinations_not_written_unless_on_definition(self):
+        """Packed field 8 expands speed/distance at decode; re-encode keeps def slots."""
+        raw = build_record_with_compressed_speed_distance(
+            speed_encoded_12bit=1000, distance_encoded_12bit=32,
+        )
+        fit = FitFile.from_bytes(raw)
+        data = next(r for r in fit.records if not r.is_definition)
+        message = data.message
+        assert isinstance(message, RecordMessage)
+        # Expanded destinations exist in memory after decode.
+        speed = message.get_field(6)
+        distance = message.get_field(5)
+        self.assertIsNotNone(speed)
+        self.assertIsNotNone(distance)
+        self.assertTrue(speed.is_expanded_field or speed.is_valid())
+
+        # Preserve unedited: bit-identical (packed source only on wire).
+        self.assertEqual(fit.to_bytes(mode=EncodeMode.PRESERVE), raw)
+
+        # Canonical: only definition fields (timestamp + field 8) appear on wire.
+        out = fit.to_bytes(mode=EncodeMode.CANONICAL)
+        document = decode_bytes(out)
+        segment = document.first_segment
+        assert segment is not None
+        data_raw = next(r for r in segment.records if not r.header.is_definition)
+        # Payload = 4 (ts) + 3 (packed field 8) when definition matches builder.
+        self.assertEqual(len(data_raw.payload), 7)
+
+
+class TestCompressedTimestampOnEncode(unittest.TestCase):
+    def _build_compressed_with_field_253(self) -> bytes:
+        """Definition includes 253; data uses compressed header (empty body for 253)."""
+        # Normal definition with only heart_rate (no 253) + compressed data is
+        # the hard case. Prefer definition WITH 253 so expansion is possible:
+        # For this test, craft def with 253+HR, then a normal data with ts+hr,
+        # then a compressed data that omits body timestamp is non-trivial.
+        # Use two records: full timestamp first, then compressed sibling.
+        fields = [
+            FieldDefinition(field_id=253, size=4, base_type=BaseType.UINT32),
+            FieldDefinition(field_id=3, size=1, base_type=BaseType.UINT8),
+        ]
+        # First: normal data with full timestamp
+        normal = definition_and_data(
+            global_id=20,
+            field_definitions=fields,
+            payload=struct.pack('<IB', 1000, 60),
+            local_id=0,
+        )
+        # Compressed header: local_id=0, offset=5 → byte 0x80 | (0<<5) | 5 = 0x85
+        # Payload still carries fields per definition (wire decoder does not strip
+        # 253 from payload). Use a second definition-less compressed record with
+        # payload matching definition size so projection works.
+        compressed_header = bytes([0x85])
+        compressed_payload = struct.pack('<IB', 0xFFFFFFFF, 70)  # invalid ts slot + HR
+        # Rebuild as: def+normal, then compressed data only
+        body = normal + compressed_header + compressed_payload
+        return wrap_records(body)
+
+    def test_preserve_keeps_compressed_header_bytes(self):
+        raw = self._build_compressed_with_field_253()
+        fit = FitFile.from_bytes(raw)
+        # Find a compressed projected record if any.
+        compressed = [r for r in fit.records if r.header.is_time_compressed]
+        if not compressed:
+            self.skipTest('fixture did not produce compressed projection')
+        out = fit.to_bytes(mode=EncodeMode.PRESERVE)
+        self.assertEqual(out, raw)
+
+    def test_canonical_expands_when_253_on_definition(self):
+        raw = self._build_compressed_with_field_253()
+        fit = FitFile.from_bytes(raw)
+        compressed = [r for r in fit.records if r.header.is_time_compressed]
+        if not compressed:
+            self.skipTest('fixture did not produce compressed projection')
+        self.assertTrue(can_expand_compressed_to_normal(compressed[0].message))
+
+        out = fit.to_bytes(mode=EncodeMode.CANONICAL)
+        again = FitFile.from_bytes(out)
+        # After canonical, compressed headers should be gone (expanded).
+        self.assertFalse(any(r.header.is_time_compressed for r in again.records))
+
+    def test_strict_refuses_expand_without_253(self):
+        """Definition without field 253 cannot expand compressed header in strict mode."""
+        from fit_tool.data_message import DataMessage
+        from fit_tool.definition_message import DefinitionMessage
+        from fit_tool.endian import Endian
+
+        definition = DefinitionMessage(
+            local_id=0,
+            global_id=20,
+            endian=Endian.LITTLE,
+            field_definitions=[
+                FieldDefinition(field_id=3, size=1, base_type=BaseType.UINT8),
+            ],
+        )
+        message = DataMessage(
+            local_id=0,
+            global_id=20,
+            definition_message=definition,
+            fields=[
+                Field(field_id=3, name='heart_rate', base_type=BaseType.UINT8, size=1),
+            ],
+        )
+        message.get_field(3).set_encoded_value(0, 70, check_validity=False)
+        header = RecordHeader(
+            is_time_compressed=True,
+            is_definition=False,
+            local_id=0,
+            time_offset_seconds=3,
+        )
+        record = Record(header, message, dirty=True)
+        options = EncodeOptions(mode=EncodeMode.CANONICAL, strict=True)
+        with self.assertRaises(FitEncodingError):
+            encode_record_projected(record, options=options)
+
+
+class TestPublicApiEncodeSymbols(unittest.TestCase):
+    def test_encode_mode_exported(self):
+        from fit_tool import EncodeMode, EncodeOptions
+
+        self.assertEqual(EncodeMode.PRESERVE.value, 'preserve')
+        self.assertEqual(EncodeMode.CANONICAL.value, 'canonical')
+        self.assertIsInstance(EncodeOptions(), EncodeOptions)
+
+
+class TestScaleNormalizationPolicy(unittest.TestCase):
+    def test_scale_rounds_on_encode(self):
+        """Canonical scale path uses round(); not silent clamp of out-of-range."""
+        field = Field(
+            field_id=0,
+            name='speed',
+            base_type=BaseType.UINT16,
+            scale=1000.0,
+            offset=0.0,
+            size=2,
+            growable=False,
+        )
+        field.set_value(0, 1.23456)  # → round(1234.56) = 1235
+        self.assertEqual(field.encoded_values[0], 1235)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/fit_tool/tests/test_fit_file.py
+++ b/fit_tool/tests/test_fit_file.py
@@ -297,17 +297,14 @@ class TestFitFileMutationAndStream(unittest.TestCase):
 
     def test_to_bytes_encoding_error(self):
         from fit_tool.exceptions import FitEncodingError
-        from fit_tool.record import Record
 
         fit = self._simple_fit()
-        # Force a message that fails to_bytes
-        bad = mock.Mock()
-        bad.to_bytes.side_effect = ValueError('boom')
-        fit.records = [Record.from_message(WorkoutStepMessage())]
-        # Replace message to_bytes on the last record message path via mock of record.to_bytes
-        with mock.patch.object(fit.records[0], 'to_bytes', side_effect=ValueError('boom')):
+        # Projected encode uses encode_record_projected → message.to_bytes.
+        with mock.patch.object(
+            fit.records[0].message, 'to_bytes', side_effect=ValueError('boom'),
+        ):
             with self.assertRaises(FitEncodingError):
-                fit.to_bytes()
+                fit.to_bytes(preserve=False)
 
     def test_builder_add_all(self):
         mesg = WorkoutStepMessage(local_id=0)

--- a/fit_tool/tests/test_public_api.py
+++ b/fit_tool/tests/test_public_api.py
@@ -12,6 +12,8 @@ class TestPublicApi(unittest.TestCase):
             PROTOCOL_VERSION,
             SDK_VERSION,
             ConformanceLevel,
+            EncodeMode,
+            EncodeOptions,
             FitCRCError,
             FitEncodingError,
             FitError,
@@ -44,6 +46,9 @@ class TestPublicApi(unittest.TestCase):
         self.assertEqual(Severity.ERROR.value, 'error')
         self.assertTrue(issubclass(ValidationFinding, object))
         self.assertTrue(callable(ValidationReport))
+        self.assertEqual(EncodeMode.PRESERVE.value, 'preserve')
+        self.assertEqual(EncodeMode.CANONICAL.value, 'canonical')
+        self.assertIsInstance(EncodeOptions(), EncodeOptions)
 
     def test_package_all_matches_api_surface(self) -> None:
         import fit_tool

--- a/news/SHA-19.feature
+++ b/news/SHA-19.feature
@@ -1,0 +1,4 @@
+Encode policies: explicit `EncodeMode.PRESERVE` / `EncodeMode.CANONICAL` on
+`FitFile.to_bytes` (legacy `preserve=` still works). Canonical rebuilds all
+records with normalized sizes/CRCs; `strict=True` validates first and never
+clamps invalid values. Policy matrix documented in README and design doc §6.


### PR DESCRIPTION
## Summary

Stage 3 **G** (SHA-19): explicit encode policies for `fit-tool`.

- **`EncodeMode.PRESERVE`** (default) — unedited `source_bytes` + dirty re-project (aligns with SHA-18 F)
- **`EncodeMode.CANONICAL`** — full projected re-encode; normalized sizes/CRCs
- **`strict=True`** — forces CANONICAL, runs WIRE+PROFILE+FILE_TYPE before encode; never clamps out-of-range values
- Legacy `preserve=True|False` still works as an alias
- Policy matrix in README + design doc §6
- Towncrier fragment `news/SHA-19.feature`

### Compressed timestamps
- Untouched preserve: bit-identical
- Dirty/canonical: expand to normal header when field 253 is on the definition; otherwise keep compressed (non-strict) or raise (strict)

### Expanded components
- Only definition-listed fields are written; synthetic destinations stay off-wire

## Test plan

- [x] `uv run pytest` — 410 passed, 1 skipped
- [x] `uv run ruff check` on touched modules
- [x] New `test_encode_policies.py` mode invariants
- [x] Public API exports `EncodeMode` / `EncodeOptions`

Closes Multica SHA-19.